### PR TITLE
feat(hackathons): auto-resolve app_id from butterbase.dev URL on submit

### DIFF
--- a/db/control-plane/072_hackathon_submissions_drop_app_fk.sql
+++ b/db/control-plane/072_hackathon_submissions_drop_app_fk.sql
@@ -1,0 +1,12 @@
+-- 072_hackathon_submissions_drop_app_fk.sql
+--
+-- Post OSS-split the control-plane `apps` table only mirrors a subset of all
+-- apps; the cross-region authoritative catalog is `user_app_index`. The
+-- hackathon submit handler now auto-resolves app_id from a butterbase.dev URL
+-- via user_app_index, which can yield an app_id that exists in the catalog
+-- but not in the legacy `apps` mirror. The existing FK on
+-- hackathon_submissions.app_id → apps(id) would reject those rows, so drop it.
+-- We keep the column (TEXT, nullable) so existing readers continue to work.
+
+ALTER TABLE hackathon_submissions
+    DROP CONSTRAINT IF EXISTS hackathon_submissions_app_id_fkey;

--- a/services/control-api/src/routes/hackathons-mcp.ts
+++ b/services/control-api/src/routes/hackathons-mcp.ts
@@ -1,9 +1,26 @@
 import type { FastifyInstance } from 'fastify';
 import { resolveEligibility } from '../services/hackathons/eligibility.js';
 import { HACKATHON_OPEN_FOR_SUBMISSIONS_SQL_SUFFIX } from '../services/hackathons/open-for-submissions.js';
-import { validateSubmissionData, type FieldSchema } from '../services/hackathons/field-schema.js';
+import { validateSubmissionData, getUrlFieldKey, type FieldSchema } from '../services/hackathons/field-schema.js';
 import { verifyCode } from '../services/hackathons/codes.js';
 import { scoreSubmission } from '../services/hackathons/scoring.js';
+
+/**
+ * Extract the subdomain from a `<sub>.butterbase.dev` URL, or null if the URL
+ * isn't a (sub-of) butterbase.dev host. Used to auto-resolve app_id from the
+ * participant's deployed-project URL.
+ */
+function extractButterbaseSubdomain(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  let host: string;
+  try {
+    host = new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (host === 'butterbase.dev' || !host.endsWith('.butterbase.dev')) return null;
+  return host.slice(0, -'.butterbase.dev'.length) || null;
+}
 
 export async function hackathonsMcpRoutes(app: FastifyInstance) {
   /**
@@ -422,7 +439,26 @@ export async function hackathonsMcpRoutes(app: FastifyInstance) {
       });
     }
 
-    const appId = body.app_id ?? null;
+    // Resolve app_id: prefer an explicit body.app_id, otherwise try to derive
+    // it from the participant's deployed-project URL. We look up
+    // user_app_index (the cross-region authoritative app catalog) by the
+    // URL's subdomain, scoped to the requesting user — so a participant can
+    // only auto-bind to an app they own.
+    let appId: string | null = body.app_id ?? null;
+    if (!appId) {
+      const urlKey = getUrlFieldKey(h.field_schema) ?? 'demo_url';
+      const subdomain = extractButterbaseSubdomain(data[urlKey]);
+      if (subdomain) {
+        const { rows: appRows } = await app.controlDb.query<{ app_id: string }>(
+          `SELECT app_id FROM user_app_index
+            WHERE subdomain = $1 AND user_id = $2
+            ORDER BY created_at DESC
+            LIMIT 1`,
+          [subdomain, userId]
+        );
+        if (appRows[0]) appId = appRows[0].app_id;
+      }
+    }
 
     const { rows } = await app.controlDb.query<{
       id: string; version: number; created_at: string; updated_at: string; data: Record<string, unknown>; app_id: string | null;
@@ -440,17 +476,27 @@ export async function hackathonsMcpRoutes(app: FastifyInstance) {
 
     const submissionRow = rows[0];
 
-    // Fire-and-forget async scoring
-    setImmediate(() => {
-      scoreSubmission(app.controlDb, {
-        id: submissionRow.id,
-        hackathon_id: h.id,
-        participant_id: participantId,
-        user_id: userId,
-        data,
-        app_id: submissionRow.app_id,
-        field_schema: h.field_schema,
-      }, request.log).catch(() => {});
+    // Fire-and-forget async scoring. Features live in the per-region runtime
+    // DB (control plane only mirrors a subset post OSS-split), so route the
+    // feature-count query to the app's home region. Fall back to controlDb
+    // when there's no app_id — scoring still scores the URL criterion.
+    setImmediate(async () => {
+      try {
+        const pool = submissionRow.app_id
+          ? await app.runtimeDbForApp(submissionRow.app_id).catch(() => app.controlDb)
+          : app.controlDb;
+        await scoreSubmission(pool, {
+          id: submissionRow.id,
+          hackathon_id: h.id,
+          participant_id: participantId,
+          user_id: userId,
+          data,
+          app_id: submissionRow.app_id,
+          field_schema: h.field_schema,
+        }, request.log);
+      } catch (err) {
+        request.log.error({ err, submissionId: submissionRow.id }, '[hackathons] scoring dispatch failed');
+      }
     });
 
     const isInsert = submissionRow.version === 1;


### PR DESCRIPTION
## Summary

When a participant submits without an `app_id`, look up their app in `user_app_index` (the cross-region authoritative app catalog) by the subdomain of their deployed-project URL. Scoped to the requesting user — a participant can only auto-bind to an app they own.

Also routes the async feature-count query through `runtimeDbForApp` so scoring reads from the app's home region. Post OSS-split the feature tables (`app_functions`, `app_users`, `storage_objects`, …) live regionally; scoring against `controlDb` was missing data for any app not mirrored into the control plane.

Drops the FK `hackathon_submissions.app_id → apps(id)` — `user_app_index` is now the canonical reference and contains apps that aren't in the legacy `apps` mirror, so the FK would reject valid auto-resolved IDs.

## Motivation

uw0520 hackathon: 3 of 4 participants got `total_score = 0`. Root cause:
- They submitted without `app_id` (the field was optional and not obvious).
- Their apps exist only in regional runtime DBs, not in the control-plane `apps` mirror — so even passing `app_id` explicitly would have FK-rejected.
- Plus, `field_schema.is_url: true` was added to the hackathon AFTER submissions, so the URL-criterion fallback to `data.demo_url` always missed.

After this PR, resubmitting the same URL auto-binds the app and the runtime-DB-aware scorer awards both URL and feature points.

## Changes

- `services/control-api/src/routes/hackathons-mcp.ts`: `extractButterbaseSubdomain()` helper; auto-resolve `app_id` via `user_app_index` lookup scoped to `user_id`; dispatch `scoreSubmission` against `runtimeDbForApp(app_id)` with a `controlDb` fallback.
- `db/control-plane/072_hackathon_submissions_drop_app_fk.sql`: drop `hackathon_submissions_app_id_fkey`.

## Test plan

- [ ] `tsc -b` (passes locally)
- [ ] Apply migration `072_` in dev
- [ ] Manually resubmit one of the uw0520 entries via MCP `prep_and_submit_hackathon_entry`, confirm `hackathon_scores.total_score` updates with both criteria
- [ ] Verify the user-scoped guard rejects auto-resolution when the URL's subdomain belongs to a different user
- [ ] Existing scoring tests in `__tests__/hackathons-scoring.test.ts` need updating to seed feature data in the runtime DB instead of control DB (pre-existing breakage from OSS-split; not blocking this PR)