### PR TITLE
fix(kv): point KV-path queries at user_app_index after migration 061

### DIFF
--- a/services/control-api/src/plugins/kv-quota.ts
+++ b/services/control-api/src/plugins/kv-quota.ts
@@ -137,11 +137,11 @@ async function resolveOwnerId(controlDb: Pool, appId: string): Promise<string | 
     // Fall through
   }
 
-  // Fallback: apps table on the control DB (works in test environments where
-  // the test harness inserts apps into the control DB pool directly)
+  // Fallback: user_app_index on the control DB (cross-region projection;
+  // the apps table itself was moved to per-region runtime DBs in Phase 2).
   try {
     const r = await controlDb.query<{ owner_id: string }>(
-      'SELECT owner_id FROM apps WHERE id = $1',
+      'SELECT user_id AS owner_id FROM user_app_index WHERE app_id = $1',
       [appId],
     );
     if (r.rows.length > 0 && r.rows[0].owner_id) {

--- a/services/control-api/src/routes/admin/kv-admin-stats.ts
+++ b/services/control-api/src/routes/admin/kv-admin-stats.ts
@@ -93,10 +93,10 @@ const kvAdminStatsRoutes: FastifyPluginAsync = async (fastify) => {
 
       if (metric === 'storage') {
         const r = await ctrl.query(
-          `SELECT s.app_id, a.owner_id, u.email AS owner_email, s.region, s.bytes_used, s.keys_total, s.snapshot_at
+          `SELECT s.app_id, uai.user_id AS owner_id, u.email AS owner_email, s.region, s.bytes_used, s.keys_total, s.snapshot_at
              FROM kv_app_usage_snapshot s
-             JOIN apps a ON a.id = s.app_id
-             JOIN platform_users u ON u.id = a.owner_id
+             JOIN user_app_index uai ON uai.app_id = s.app_id
+             JOIN platform_users u ON u.id = uai.user_id
             ORDER BY s.bytes_used DESC
             LIMIT $1`, [limit]);
         return { metric, apps: r.rows };
@@ -104,12 +104,12 @@ const kvAdminStatsRoutes: FastifyPluginAsync = async (fastify) => {
 
       if (metric === 'ops') {
         const r = await ctrl.query(
-          `SELECT m.app_id, a.owner_id, u.email AS owner_email, a.region, SUM(m.quantity)::bigint AS value
+          `SELECT m.app_id, uai.user_id AS owner_id, u.email AS owner_email, uai.region, SUM(m.quantity)::bigint AS value
              FROM usage_meters m
-             JOIN apps a ON a.id = m.app_id
-             JOIN platform_users u ON u.id = a.owner_id
+             JOIN user_app_index uai ON uai.app_id = m.app_id
+             JOIN platform_users u ON u.id = uai.user_id
             WHERE m.meter_type = 'kv_ops' AND m.period_start >= CURRENT_DATE
-            GROUP BY m.app_id, a.owner_id, u.email, a.region
+            GROUP BY m.app_id, uai.user_id, u.email, uai.region
             ORDER BY value DESC
             LIMIT $1`, [limit]);
         return { metric, apps: r.rows };
@@ -117,14 +117,14 @@ const kvAdminStatsRoutes: FastifyPluginAsync = async (fastify) => {
 
       // errors
       const r = await ctrl.query(
-        `SELECT al.app_id, a.owner_id, u.email AS owner_email, a.region, COUNT(*)::bigint AS value
+        `SELECT al.app_id, uai.user_id AS owner_id, u.email AS owner_email, uai.region, COUNT(*)::bigint AS value
            FROM audit_logs al
-           JOIN apps a ON a.id = al.app_id
-           JOIN platform_users u ON u.id = a.owner_id
+           JOIN user_app_index uai ON uai.app_id = al.app_id
+           JOIN platform_users u ON u.id = uai.user_id
           WHERE al.path LIKE '/v1/%/kv/%'
             AND al.status_code >= 400
             AND al.at > now() - interval '24 hours'
-          GROUP BY al.app_id, a.owner_id, u.email, a.region
+          GROUP BY al.app_id, uai.user_id, u.email, uai.region
           ORDER BY value DESC
           LIMIT $1`, [limit]);
       return { metric, apps: r.rows };
@@ -139,8 +139,8 @@ const kvAdminStatsRoutes: FastifyPluginAsync = async (fastify) => {
     const storage = await ctrl.query(
       `SELECT s.app_id, s.region, s.bytes_used, p.kv_max_storage_bytes AS max_storage_bytes, s.snapshot_at
          FROM kv_app_usage_snapshot s
-         JOIN apps a ON a.id = s.app_id
-         JOIN platform_users u ON u.id = a.owner_id
+         JOIN user_app_index uai ON uai.app_id = s.app_id
+         JOIN platform_users u ON u.id = uai.user_id
          LEFT JOIN plans p ON p.id = u.plan_id
         WHERE p.kv_max_storage_bytes IS NOT NULL
           AND s.bytes_used >= 0.9 * p.kv_max_storage_bytes`,

--- a/services/control-api/src/services/kv-credentials.ts
+++ b/services/control-api/src/services/kv-credentials.ts
@@ -64,14 +64,14 @@ export class KvCredentialsService {
       owns_app: boolean;
     }>(
       `SELECT
-         ak.user_id IS NOT NULL AS key_valid,
-         a.id IS NOT NULL      AS owns_app,
-         a.id                  AS app_id,
-         a.region              AS region,
+         ak.user_id IS NOT NULL  AS key_valid,
+         uai.app_id IS NOT NULL  AS owns_app,
+         uai.app_id              AS app_id,
+         uai.region              AS region,
          kv.redis_password
        FROM api_keys ak
-       LEFT JOIN apps a ON a.id = $2 AND a.owner_id = ak.user_id
-       LEFT JOIN app_kv_credentials kv ON kv.app_id = a.id
+       LEFT JOIN user_app_index uai ON uai.app_id = $2 AND uai.user_id = ak.user_id
+       LEFT JOIN app_kv_credentials kv ON kv.app_id = uai.app_id
        WHERE ak.key_hash = $1
          AND ak.revoked_at IS NULL
          AND (ak.expires_at IS NULL OR ak.expires_at > now())

--- a/services/control-api/src/services/kv/auth.ts
+++ b/services/control-api/src/services/kv/auth.ts
@@ -200,8 +200,8 @@ async function tryPlatformOwnerJwt(
   const r = await controlDb.query<{ region: string; redis_password: string }>(
     `SELECT akc.region, akc.redis_password
        FROM platform_users pu
-       JOIN apps a ON a.owner_id = pu.id AND a.id = $2
-       JOIN app_kv_credentials akc ON akc.app_id = a.id
+       JOIN user_app_index uai ON uai.user_id = pu.id AND uai.app_id = $2
+       JOIN app_kv_credentials akc ON akc.app_id = uai.app_id
       WHERE pu.cognito_sub = $1
       LIMIT 1`,
     [claims.sub, appId],

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -92,18 +92,13 @@ export async function insertAppRow(
     [appId, name, ownerId, dbName, region, config.deployment.defaultBackend]
   );
 
-  // Atomically register the app in the control-plane and provision KV credentials.
-  // Both writes are in a single controlDb transaction so they succeed or fail together.
-  // The control-plane apps row satisfies the FK required by app_kv_credentials.
+  // Provision KV credentials on the control-plane. The control-plane apps row
+  // (Phase 1 cutover) no longer exists; app_kv_credentials has no FK to it.
+  // Authoritative app row is the runtime DB INSERT above; cross-region projection
+  // is user_app_index, written by the init route after this helper returns.
   const client = await controlDb.connect();
   try {
     await client.query('BEGIN');
-    await client.query(
-      `INSERT INTO apps (id, name, owner_id, db_name, region)
-       VALUES ($1, $2, $3, $4, $5)
-       ON CONFLICT (id) DO NOTHING`,
-      [appId, name, ownerId, dbName, region],
-    );
     const kvSvc = new KvCredentialsService(client);
     await kvSvc.provision(appId, region);
     await client.query('COMMIT');


### PR DESCRIPTION
Migration 061 dropped the apps table from control-plane. KV code paths still queried it, causing 500s on every KV-bound request post-deploy.

Fixed 5 files / 6 queries:
- provisioner.ts insertAppRow — deleted the now-unnecessary controlDb INSERT into apps
- plugins/kv-quota.ts — owner lookup
- services/kv/auth.ts tryPlatformOwnerJwt — platform JWT app-ownership check
- services/kv-credentials.ts resolveDevApiKeyForApp — service-key + ownership check
- routes/admin/kv-admin-stats.ts — top-apps (3 metrics) + hotspots queries

All swap JOIN apps a → JOIN user_app_index uai (uai.user_id is the owner). user_app_index already exists as the cross-region projection of regional apps rows.

Out of scope for this hotfix (filed separately): ai-config.ts, cors.ts, app-config.ts, storage.ts, init.ts subdomain checks, admin.ts global-fanout queries, digest-notifier.ts.