### PR TITLE
fix(kv): treat -1 cap as unlimited in rate-limit + storage + value-size gates

### DIFF
--- a/services/control-api/src/plugins/kv-quota.ts
+++ b/services/control-api/src/plugins/kv-quota.ts
@@ -219,8 +219,9 @@ const kvQuotaPlugin: FastifyPluginAsync = async (fastify) => {
     }
 
     // ── (2) Value size cap (writes only) ──────────────────────────────────
+    // -1 means unlimited (enterprise / custom tiers).
     const isWrite = op.kind === 'write' || op.kind === 'atomic_write' || op.kind === 'mset';
-    if (isWrite) {
+    if (isWrite && limits.maxValueBytes >= 0) {
       const valBytes = sizeOfBody(body);
       if (valBytes > limits.maxValueBytes) {
         return reply.code(413).send({
@@ -247,7 +248,8 @@ const kvQuotaPlugin: FastifyPluginAsync = async (fastify) => {
     }
 
     // ── (4) Storage cap (writes only; reads pass even if over cap) ────────
-    if (isWrite) {
+    // -1 means unlimited (enterprise / custom tiers).
+    if (isWrite && limits.maxStorageBytes >= 0) {
       const used = await getStorageBytes(kvR, appId);
       const incoming = sizeOfBody(body);
       if (used + incoming > limits.maxStorageBytes) {

--- a/services/control-api/src/services/kv/rate-limit.ts
+++ b/services/control-api/src/services/kv/rate-limit.ts
@@ -6,6 +6,12 @@ export async function checkRateLimit(
   opsCost: number,
   maxOpsPerSec: number,
 ): Promise<{ allowed: true } | { allowed: false; retryAfterSec: number }> {
+  // -1 (and any negative value) means unlimited — used by enterprise / custom tiers
+  // that intentionally disable per-second caps. Skip both the Redis bucket bump and
+  // the comparison so the call is free.
+  if (maxOpsPerSec < 0) {
+    return { allowed: true };
+  }
   const bucket = Math.floor(Date.now() / 1000);
   const key = `{${appId}}:_meta:rate:${bucket}`;
   const current = await client.incrBy(key, opsCost);


### PR DESCRIPTION
Enterprise / custom tiers store -1 to mean 'no cap'. Comparisons `x > -1` were always true → every KV op was rate-limited / rejected. Skip the gates when the cap is < 0.