### PR TITLE
fix(ai-config): query runtime apps for default model

### DIFF
--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -49,7 +49,9 @@ async function readAutoRefillState(controlPool: pg.Pool, userId: string): Promis
 }
 
 async function getAppDefaultModel(controlPool: pg.Pool, appId: string): Promise<string | null> {
-  const r = await controlPool.query<{ ai_config: { defaultModel?: string } | null }>(
+  const region = await resolveAppHomeRegion(controlPool, appId);
+  const runtimeDb = getRuntimeDbPool(config.runtimeDb, region);
+  const r = await runtimeDb.query<{ ai_config: { defaultModel?: string } | null }>(
     `SELECT ai_config FROM apps WHERE id = $1`,
     [appId]
   );


### PR DESCRIPTION
## Summary
- `getAppDefaultModel` was querying `controlPool` against the dropped `apps` table, silently returning null on every request that relied on `apps.ai_config.defaultModel`.
- Resolve the app's home region first, then query the runtime pool. Matches the pattern already used by the 4 other ai-config call sites at lines 116/172/204/475.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After deploy: live smoke per `docs/superpowers/specs/2026-05-24-kv-launch-prod-smoke.md` — exercise an AI call that omits the `model` field against an app whose `ai_config.defaultModel` is set; expect non-NO_MODEL response.