### PR TITLE
fix(edge-ssr): runtime INSERT for app_edge_ssr_deployments

### DIFF
--- a/services/control-api/src/routes/edge-ssr-from-source.ts
+++ b/services/control-api/src/routes/edge-ssr-from-source.ts
@@ -20,6 +20,9 @@ import * as R2 from '../services/r2.js';
 import * as BuildDriver from '../services/build-driver.service.js';
 import { loadAppEnvVars } from '../services/build-driver.service.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
+import { config } from '../config.js';
+import { resolveAppHomeRegion } from '../services/region-resolver.js';
+import { getRuntimeDbPool } from '../services/runtime-db.js';
 
 const createSchema = z.object({
   framework: z.enum(['nextjs-edge', 'remix-edge', 'other-edge']).default('nextjs-edge'),
@@ -72,9 +75,14 @@ export async function registerEdgeSsrFromSourceRoutes(fastify: FastifyInstance) 
 
     const buildId = crypto.randomUUID();
 
-    // Insert deployment row and capture the DB-generated id atomically via
-    // RETURNING, eliminating any race between concurrent from-source POSTs.
-    const depRow = await controlDb.query<{ id: string }>(
+    // app_edge_ssr_deployments lives in the runtime DB; resolve the app's
+    // home region and route the INSERT there. app_build_jobs stays on the
+    // control DB (platform-scope) — the build_jobs.deployment_id is a soft
+    // pointer, not an FK, so cross-tier is fine.
+    const region = await resolveAppHomeRegion(controlDb, appId);
+    const runtimeDb = getRuntimeDbPool(config.runtimeDb, region);
+
+    const depRow = await runtimeDb.query<{ id: string }>(
       `INSERT INTO app_edge_ssr_deployments (app_id, framework, status, deployed_by)
        VALUES ($1, $2, 'WAITING', $3)
        RETURNING id`,

--- a/services/control-api/src/routes/edge-ssr-from-source.ts
+++ b/services/control-api/src/routes/edge-ssr-from-source.ts
@@ -20,9 +20,7 @@ import * as R2 from '../services/r2.js';
 import * as BuildDriver from '../services/build-driver.service.js';
 import { loadAppEnvVars } from '../services/build-driver.service.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
-import { config } from '../config.js';
-import { resolveAppHomeRegion } from '../services/region-resolver.js';
-import { getRuntimeDbPool } from '../services/runtime-db.js';
+import { getRuntimeDbForApp } from '../services/region-resolver.js';
 
 const createSchema = z.object({
   framework: z.enum(['nextjs-edge', 'remix-edge', 'other-edge']).default('nextjs-edge'),
@@ -75,12 +73,8 @@ export async function registerEdgeSsrFromSourceRoutes(fastify: FastifyInstance) 
 
     const buildId = crypto.randomUUID();
 
-    // app_edge_ssr_deployments lives in the runtime DB; resolve the app's
-    // home region and route the INSERT there. app_build_jobs stays on the
-    // control DB (platform-scope) — the build_jobs.deployment_id is a soft
-    // pointer, not an FK, so cross-tier is fine.
-    const region = await resolveAppHomeRegion(controlDb, appId);
-    const runtimeDb = getRuntimeDbPool(config.runtimeDb, region);
+    // app_edge_ssr_deployments is runtime-tier (migration 061); route INSERT to the app's runtime DB.
+    const runtimeDb = await getRuntimeDbForApp(controlDb, appId);
 
     const depRow = await runtimeDb.query<{ id: string }>(
       `INSERT INTO app_edge_ssr_deployments (app_id, framework, status, deployed_by)


### PR DESCRIPTION
## Summary
- \`app_edge_ssr_deployments\` moved to runtime (\`db/runtime-plane/001\`); the controlDb copy was dropped by migration 061. The \`from-source\` create route still inserted into controlDb, returning "relation does not exist" for every edge-SSR deploy.
- Resolve the app's home region and route the deployment-row INSERT to the runtime pool. \`app_build_jobs\` (platform-scope) is unchanged; its \`deployment_id\` is a soft pointer, not an FK.

## Test plan
- [ ] \`pnpm --filter @butterbase/control-api build\` green
- [ ] After deploy: from-source edge-SSR deploy against a runtime app; expect 201 with \`deployment_id\`, then verify the row exists in the regional runtime DB (\`SELECT * FROM app_edge_ssr_deployments WHERE id = $1\`).