### PR TITLE
fix(webhooks): two-phase split for Cloudflare deployment hook

### DIFF
--- a/services/control-api/src/routes/webhooks.ts
+++ b/services/control-api/src/routes/webhooks.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import * as CloudflarePages from '../services/cloudflare-pages.js';
 import { handleWebhook } from '../services/webhook-handler.js';
+import { getRuntimeDbForApp } from '../services/region-resolver.js';
 import { config } from '../config.js';
 
 const cloudflareWebhookSchema = z.object({
@@ -39,9 +40,12 @@ export async function registerWebhookRoutes(fastify: FastifyInstance) {
     try {
       const body = cloudflareWebhookSchema.parse(request.body);
 
-      // FIXME(batch-9.7): handleWebhook uses a single transaction spanning processed_webhook_events (platform)
-      // and app_deployments/apps (runtime). Split into two-phase commit or move idempotency to controlDb
-      // and runtime writes to runtimeDb in a separate step.
+      // Cross-tier two-phase write: Phase 1 (controlDb) inside handleWebhook,
+      // Phase 2 (runtimeDb) below. If Phase 2 fails after Phase 1 commits,
+      // apps.deployment_url is stale until reconciled; cross-tier 2PC is not
+      // implemented here (single-tier transactions are the design contract).
+      let runtimeUpdate: { appId: string; url: string } | null = null;
+
       await handleWebhook(
         controlDb,
         'cloudflare',
@@ -98,19 +102,32 @@ export async function registerWebhookRoutes(fastify: FastifyInstance) {
             [status, errorMessage, body.url, deployment.id]
           );
 
-          // Update apps table if deployment succeeded
           if (status === 'READY' && body.url) {
-            await client.query(
-              `UPDATE apps
-               SET deployment_url = $1, last_deployed_at = now()
-               WHERE id = $2`,
-              [body.url, deployment.app_id]
-            );
+            // apps lives on runtime now; defer the UPDATE to Phase 2 (after controlDb commits).
+            runtimeUpdate = { appId: deployment.app_id, url: body.url };
           }
 
           console.log(`[Webhook] Updated deployment ${deployment.id} to status ${status}`);
         }
       );
+
+      const pendingRuntimeUpdate = runtimeUpdate as { appId: string; url: string } | null;
+      if (pendingRuntimeUpdate) {
+        try {
+          const runtimeDb = await getRuntimeDbForApp(controlDb, pendingRuntimeUpdate.appId);
+          await runtimeDb.query(
+            `UPDATE apps
+             SET deployment_url = $1, last_deployed_at = now()
+             WHERE id = $2`,
+            [pendingRuntimeUpdate.url, pendingRuntimeUpdate.appId]
+          );
+        } catch (err) {
+          console.error(
+            { err, appId: pendingRuntimeUpdate.appId, url: pendingRuntimeUpdate.url },
+            '[Webhook] Phase 2 apps UPDATE failed after controlDb commit — event marked processed but apps row stale; manual reconciliation may be needed'
+          );
+        }
+      }
 
       return reply.send({ received: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
- The `apps` table is dropped from controlDb. The Cloudflare webhook handler's inner `UPDATE apps SET deployment_url` ran inside a controlDb transaction and crashed every successful deploy notification.
- Split into Phase 1 (controlDb: idempotency + `app_deployments` SELECT/UPDATE) and Phase 2 (runtimeDb: `UPDATE apps`). Phase 2 runs after controlDb commits. If Phase 2 fails, the event is marked processed but `apps.deployment_url` is stale — logged loudly; cross-tier 2PC intentionally not implemented.

## Risks
- A Phase 2 failure leaves `apps.deployment_url` stale. Operationally: the controlDb `app_deployments` row still reflects READY, so the deployment record itself is correct; only the convenience column on `apps` is wrong. Recovery: re-run the deploy or manual UPDATE.
- The handler's reads/UPDATEs against `app_deployments` remain on controlDb in this PR. A sibling PR (Task 3, frontend-from-source) moves the `app_deployments` INSERT to runtime. The webhook's controlDb reads will need a follow-up migration once `app_deployments` is exclusively on runtime — tracked separately.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After deploy: trigger a Cloudflare deployment-succeeded webhook (or replay one) and confirm `apps.deployment_url` updates in the regional runtime DB.