### PR TITLE
fix(admin-kv): rate-limit hotspots — JOIN user_app_index

### DIFF
--- a/services/control-api/src/routes/admin/kv-admin-stats.ts
+++ b/services/control-api/src/routes/admin/kv-admin-stats.ts
@@ -152,14 +152,14 @@ const kvAdminStatsRoutes: FastifyPluginAsync = async (fastify) => {
     );
 
     const rate = await ctrl.query(
-      `SELECT al.app_id, akc.region,
+      `SELECT al.app_id, uai.region,
               COUNT(*) FILTER (WHERE al.status_code = 429) AS rate_limited,
               COUNT(*) AS total_ops,
               MIN(al.at) FILTER (WHERE al.status_code = 429) AS first_seen
          FROM audit_logs al
-         JOIN app_kv_credentials akc ON akc.app_id = al.app_id
+         JOIN user_app_index uai ON uai.app_id = al.app_id
         WHERE al.path LIKE '/v1/%/kv/%' AND al.at > now() - interval '24 hours'
-        GROUP BY al.app_id, akc.region
+        GROUP BY al.app_id, uai.region
        HAVING COUNT(*) FILTER (WHERE al.status_code = 429)::float / NULLIF(COUNT(*), 0) >= 0.05`,
     );
 


### PR DESCRIPTION
## Summary
- The KV admin "rate-limit hotspots" query JOINed the dropped controlplane `apps` table. The storage-hotspots query just above this one already correctly used `user_app_index` — bringing this one in line.
- `user_app_index.region` carries the column the query needs; no SELECT/GROUP BY changes.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After deploy: hit the KV admin hotspots endpoint that registers this handler and confirm 200, no controlplane "relation does not exist" errors in logs.