### PR TITLE
migration(079): cloudflare_deployment_index

### DIFF
--- a/db/control-plane/079_cloudflare_deployment_index.sql
+++ b/db/control-plane/079_cloudflare_deployment_index.sql
@@ -1,0 +1,37 @@
+-- @scope: platform
+-- 079_cloudflare_deployment_index.sql
+-- Routing table so the Cloudflare deployment webhook can resolve a
+-- cloudflare_deployment_id back to (app_id, region) without touching
+-- app_deployments. app_deployments was moved to per-region runtime DBs;
+-- the webhook arrives on controlDb and needs to learn the region to
+-- forward the rest of its work to the right runtime pool.
+--
+-- Writers (deployment.service.ts) will INSERT a row immediately after
+-- they learn the Cloudflare deployment_id from a successful deploy.
+-- The webhook handler will SELECT this row to resolve routing.
+--
+-- Backfill from any existing controlDb app_deployments rows that still
+-- carry a cloudflare_deployment_id, joining user_app_index for region.
+
+CREATE TABLE IF NOT EXISTS cloudflare_deployment_index (
+  cloudflare_deployment_id TEXT PRIMARY KEY,
+  app_id                   TEXT NOT NULL,
+  region                   TEXT NOT NULL,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloudflare_deployment_index_app_id
+  ON cloudflare_deployment_index (app_id);
+
+INSERT INTO cloudflare_deployment_index (cloudflare_deployment_id, app_id, region, created_at)
+SELECT ad.cloudflare_deployment_id,
+       ad.app_id,
+       COALESCE(uai.region, 'us-east-1') AS region,
+       ad.created_at
+  FROM app_deployments ad
+  LEFT JOIN user_app_index uai ON uai.app_id = ad.app_id
+ WHERE ad.cloudflare_deployment_id IS NOT NULL
+ON CONFLICT (cloudflare_deployment_id) DO NOTHING;
+
+COMMENT ON TABLE cloudflare_deployment_index IS
+  'controlDb routing table: cloudflare_deployment_id -> (app_id, region). Read by the Cloudflare webhook handler to forward to the regional runtime DB.';


### PR DESCRIPTION
## Summary
- Adds a small controlDb routing table \`cloudflare_deployment_index (cloudflare_deployment_id PK, app_id, region, created_at)\` plus a secondary index on \`app_id\`.
- Backfills from existing \`app_deployments\` rows on controlDb (those still carry \`cloudflare_deployment_id\` from before the runtime cutover). Joins \`user_app_index\` for region, defaults to \`us-east-1\` for any row whose UAI peer is missing.
- Idempotent (\`CREATE TABLE IF NOT EXISTS\` + \`ON CONFLICT DO NOTHING\`); reversible (drop the table).

## Why
- The Cloudflare deployment webhook receives \`cloudflare_deployment_id\` and needs to resolve which app and region it belongs to. \`app_deployments\` moved to per-region runtime DBs, so the webhook can't query a single controlDb table for this anymore.
- Two follow-up PRs (writer + reader) sit on top of this migration.

## Risk
- New table is unread by current code. Landing this PR alone is a no-op functionally; safe to deploy ahead of the writer/reader PRs.

## Test plan
- [ ] Migration applies cleanly on a fresh controlDb.
- [ ] Migration applies cleanly on the existing prod controlDb (backfill should populate exactly the count of existing app_deployments rows with non-null cloudflare_deployment_id).
- [ ] Re-applying is a no-op (idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)