### PR TITLE
feat(deploy): write cloudflare_deployment_index

### DIFF
--- a/services/control-api/src/services/deployment.service.ts
+++ b/services/control-api/src/services/deployment.service.ts
@@ -757,6 +757,24 @@ export async function deployArtifact(
       ]
     );
 
+    // Route-mapping write: webhook handlers consult cloudflare_deployment_index
+    // on controlDb to resolve (cloudflare_deployment_id -> app_id, region) without
+    // touching the per-region app_deployments. Best-effort: a failure here logs
+    // and does not fail the deploy; the webhook handler falls back gracefully.
+    if (result.cloudflareDeploymentId) {
+      try {
+        await db.query(
+          `INSERT INTO cloudflare_deployment_index (cloudflare_deployment_id, app_id, region)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (cloudflare_deployment_id) DO NOTHING`,
+          [result.cloudflareDeploymentId, appId, app.region]
+        );
+      } catch (err) {
+        console.error({ err, appId, cloudflareDeploymentId: result.cloudflareDeploymentId, region: app.region },
+          '[deployArtifact] cloudflare_deployment_index write failed — webhook routing may need fallback');
+      }
+    }
+
     // If terminal READY (WfP), also update apps.deployment_url + last_deployed_at,
     // and supersede any active Edge SSR deployments for the same app — they share
     // the same dispatch-namespace Worker script slot so a static WfP deploy replaces them.


### PR DESCRIPTION
## Summary
- After the deploy pipeline records a Cloudflare deployment ID against the per-region `app_deployments` row, also INSERT a routing row into the new controlDb `cloudflare_deployment_index`.
- Best-effort: a failure to write the index logs and continues. The webhook handler that reads this index (next PR) will have a fallback path for missing rows.
- Scoped to the WfP/Pages-via-pipeline path at `deployArtifact`. The template-deploy path (`deployTemplatePage`) is intentionally not instrumented — those rows are terminal (status='READY') at creation and don't need webhook routing.

## Depends on
- PR #11 (migration 079, creates the `cloudflare_deployment_index` table). This PR will fail at runtime if it lands first; merge order must be 079 → this PR.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After PR #11 + this PR deploy: run a frontend deploy and verify a row appears in `cloudflare_deployment_index`.
- [ ] Simulate index write failure (e.g. revoke INSERT privilege temporarily) and verify the deploy still succeeds with a console.error logged.