### PR TITLE
fix(webhooks): Cloudflare hook routes via deployment index

### DIFF
--- a/services/control-api/src/routes/webhooks.ts
+++ b/services/control-api/src/routes/webhooks.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import * as CloudflarePages from '../services/cloudflare-pages.js';
 import { handleWebhook } from '../services/webhook-handler.js';
 import { config } from '../config.js';
+import { getRuntimeDbPool } from '../services/runtime-db.js';
 
 const cloudflareWebhookSchema = z.object({
   type: z.string(),
@@ -39,17 +40,30 @@ export async function registerWebhookRoutes(fastify: FastifyInstance) {
     try {
       const body = cloudflareWebhookSchema.parse(request.body);
 
-      // FIXME(batch-9.7): handleWebhook uses a single transaction spanning processed_webhook_events (platform)
-      // and app_deployments/apps (runtime). Split into two-phase commit or move idempotency to controlDb
-      // and runtime writes to runtimeDb in a separate step.
+      // Phase 1 (controlDb transaction inside handleWebhook): idempotency + resolve
+      // (app_id, region) for this Cloudflare deployment. Phase 2 (after commit) runs
+      // SELECT/UPDATE app_deployments + UPDATE apps on the resolved runtime DB in a
+      // single runtime transaction.
+      //
+      // If Phase 2 fails after Phase 1 commits, the event is marked processed on
+      // controlDb (idempotency) but the runtime state is stale. Cross-tier 2PC is
+      // intentionally not implemented; loud structured log + manual reconciliation
+      // is the recovery contract.
+      const route: { value: {
+        appId: string;
+        region: string;
+        status: 'READY' | 'ERROR' | 'CANCELED';
+        errorMessage: string | null;
+        url: string | undefined;
+      } | null } = { value: null };
+
       await handleWebhook(
         controlDb,
         'cloudflare',
         body.deployment_id,
         body.type,
         async (client) => {
-          // Map Cloudflare event type to our status
-          let status: string | null = null;
+          let status: 'READY' | 'ERROR' | 'CANCELED' | null = null;
           let errorMessage: string | null = null;
 
           switch (body.type) {
@@ -68,54 +82,110 @@ export async function registerWebhookRoutes(fastify: FastifyInstance) {
               return;
           }
 
-          if (!status) {
-            return;
-          }
-
-          // Find deployment by Cloudflare deployment ID
-          const deploymentResult = await client.query(
-            `SELECT id, app_id, status FROM app_deployments
-             WHERE cloudflare_deployment_id = $1`,
+          // Resolve routing — try the new index first, fall back to legacy controlDb
+          // app_deployments JOIN user_app_index for any in-flight pre-cutover deploys.
+          const idx = await client.query<{ app_id: string; region: string }>(
+            `SELECT app_id, region FROM cloudflare_deployment_index WHERE cloudflare_deployment_id = $1`,
             [body.deployment_id]
           );
 
-          if (deploymentResult.rows.length === 0) {
-            console.error(`[Webhook] Deployment not found for Cloudflare ID: ${body.deployment_id}`);
-            return;
-          }
-
-          const deployment = deploymentResult.rows[0];
-
-          // Update deployment record
-          await client.query(
-            `UPDATE app_deployments
-             SET status = $1,
-                 error_message = $2,
-                 deployment_url = COALESCE($3, deployment_url),
-                 completed_at = CASE WHEN $1 IN ('READY', 'ERROR', 'CANCELED') THEN now() ELSE completed_at END,
-                 updated_at = now()
-             WHERE id = $4`,
-            [status, errorMessage, body.url, deployment.id]
-          );
-
-          // Update apps table if deployment succeeded
-          if (status === 'READY' && body.url) {
-            await client.query(
-              `UPDATE apps
-               SET deployment_url = $1, last_deployed_at = now()
-               WHERE id = $2`,
-              [body.url, deployment.app_id]
+          let appId: string | null = null;
+          let region: string | null = null;
+          if (idx.rows.length > 0) {
+            appId = idx.rows[0].app_id;
+            region = idx.rows[0].region;
+          } else {
+            const fb = await client.query<{ app_id: string; region: string | null }>(
+              `SELECT ad.app_id, uai.region
+                 FROM app_deployments ad
+                 LEFT JOIN user_app_index uai ON uai.app_id = ad.app_id
+                WHERE ad.cloudflare_deployment_id = $1`,
+              [body.deployment_id]
             );
+            if (fb.rows.length === 0) {
+              console.error(
+                { cfDeploymentId: body.deployment_id, type: body.type },
+                '[Webhook] No routing entry in cloudflare_deployment_index or legacy app_deployments — dropping webhook'
+              );
+              return;
+            }
+            appId = fb.rows[0].app_id;
+            region = fb.rows[0].region ?? 'us-east-1';
           }
 
-          console.log(`[Webhook] Updated deployment ${deployment.id} to status ${status}`);
+          route.value = {
+            appId,
+            region,
+            status,
+            errorMessage,
+            url: body.url,
+          };
         }
       );
 
+      // Phase 2: single runtime transaction at the resolved region.
+      if (route.value) {
+        const r = route.value;
+        try {
+          const runtimePool = getRuntimeDbPool(config.runtimeDb, r.region);
+          const rtClient = await runtimePool.connect();
+          try {
+            await rtClient.query('BEGIN');
+
+            const dep = await rtClient.query<{ id: string; app_id: string }>(
+              `SELECT id, app_id FROM app_deployments WHERE cloudflare_deployment_id = $1`,
+              [body.deployment_id]
+            );
+
+            if (dep.rows.length === 0) {
+              await rtClient.query('ROLLBACK');
+              console.error(
+                { cfDeploymentId: body.deployment_id, region: r.region, appId: r.appId },
+                '[Webhook] Phase 2: runtime app_deployments row not found at resolved region'
+              );
+            } else {
+              await rtClient.query(
+                `UPDATE app_deployments
+                 SET status = $1,
+                     error_message = $2,
+                     deployment_url = COALESCE($3, deployment_url),
+                     completed_at = CASE WHEN $1 IN ('READY', 'ERROR', 'CANCELED') THEN now() ELSE completed_at END,
+                     updated_at = now()
+                 WHERE id = $4`,
+                [r.status, r.errorMessage, r.url, dep.rows[0].id]
+              );
+
+              if (r.status === 'READY' && r.url) {
+                await rtClient.query(
+                  `UPDATE apps SET deployment_url = $1, last_deployed_at = now() WHERE id = $2`,
+                  [r.url, dep.rows[0].app_id]
+                );
+              }
+
+              await rtClient.query('COMMIT');
+              console.log(`[Webhook] Updated deployment ${dep.rows[0].id} to status ${r.status}`);
+            }
+          } catch (txErr) {
+            await rtClient.query('ROLLBACK').catch(() => { /* swallow rollback failures */ });
+            throw txErr;
+          } finally {
+            rtClient.release();
+          }
+        } catch (err) {
+          console.error(
+            { err, appId: r.appId, region: r.region, cfDeploymentId: body.deployment_id, status: r.status, url: r.url },
+            '[Webhook] Phase 2 runtime transaction failed after Phase 1 commit — manual reconciliation needed'
+          );
+        }
+      }
+
       return reply.send({ received: true });
     } catch (error) {
-      console.error('[Webhook] Error processing Cloudflare webhook:', error);
-      return reply.status(500).send({ error: 'Failed to process webhook' });
+      console.error('[Webhook] Failed to process Cloudflare webhook:', error);
+      return reply.status(500).send({
+        error: 'Webhook processing failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
     }
   });
 }


### PR DESCRIPTION
## Summary
- Replaces closed PR #9 (which used a minimal-split approach that silently no-op'd post-cutover).
- Phase 1 (controlDb, inside `handleWebhook` transaction): idempotency + resolve `(app_id, region)` from `cloudflare_deployment_index`; fall back to legacy controlDb `app_deployments` JOIN `user_app_index` for pre-cutover in-flight deploys.
- Phase 2 (runtimeDb at the resolved region): single transaction wrapping the `app_deployments` UPDATE + the conditional `apps` UPDATE.
- Phase 2 failure after Phase 1 commit: structured `console.error` with `cfDeploymentId`, `appId`, `region`, `status`, `url`. Operator reconciles manually. Cross-tier 2PC intentionally not implemented.

## Depends on
- PR #11 (migration 079: cloudflare_deployment_index table + backfill).
- PR #12 (deployment.service.ts writes the index after the runtime UPDATE).

Merge order MUST be 11 → 12 → this PR. Otherwise this handler will fall back to the legacy controlDb `app_deployments` SELECT for every webhook — works, but uses the slow path.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After all three PRs deploy: trigger a new deployment.succeeded webhook; verify `app_deployments.status` and `apps.deployment_url` both update on the regional runtime DB.
- [ ] Simulate a webhook for a deployment with no index entry (e.g. delete the index row): verify the fallback path resolves via the legacy `app_deployments` + `user_app_index` JOIN.