### PR TITLE
fix(init): cross-region subdomain uniqueness

### DIFF
--- a/db/control-plane/080_user_app_index_subdomain_unique.sql
+++ b/db/control-plane/080_user_app_index_subdomain_unique.sql
@@ -1,0 +1,33 @@
+-- @scope: platform
+-- 080_user_app_index_subdomain_unique.sql
+-- Subdomains are a global namespace (every app gets <subdomain>.butterbase.app).
+-- Pre-cutover the uniqueness check happened per-region against the runtime
+-- apps table, which doesn't protect against cross-region collisions. This
+-- migration adds the DB-level guarantee at the only cross-region table we
+-- already have: user_app_index.
+--
+-- Pre-flight: surface any existing duplicates as a NOTICE before attempting
+-- the index. If duplicates exist, the CREATE UNIQUE INDEX will fail and an
+-- operator must reconcile by suffixing one of the duplicate subdomains.
+
+DO $$
+DECLARE
+  dup_count INT;
+BEGIN
+  SELECT COUNT(*)::INT INTO dup_count FROM (
+    SELECT subdomain FROM user_app_index
+     WHERE subdomain IS NOT NULL
+     GROUP BY subdomain HAVING COUNT(*) > 1
+  ) AS d;
+
+  IF dup_count > 0 THEN
+    RAISE NOTICE 'user_app_index has % subdomains held by more than one app; UNIQUE index creation will fail. Reconcile before re-running.', dup_count;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_app_index_subdomain_uniq
+  ON user_app_index (subdomain)
+  WHERE subdomain IS NOT NULL;
+
+COMMENT ON INDEX user_app_index_subdomain_uniq IS
+  'Cross-region subdomain uniqueness. Partial index because legacy rows may have NULL subdomain.';

--- a/db/control-plane/080_user_app_index_subdomain_unique.sql
+++ b/db/control-plane/080_user_app_index_subdomain_unique.sql
@@ -6,7 +6,7 @@
 -- migration adds the DB-level guarantee at the only cross-region table we
 -- already have: user_app_index.
 --
--- Pre-flight: surface any existing duplicates as a NOTICE before attempting
+-- Pre-flight: surface any existing duplicates as a WARNING before attempting
 -- the index. If duplicates exist, the CREATE UNIQUE INDEX will fail and an
 -- operator must reconcile by suffixing one of the duplicate subdomains.
 
@@ -21,7 +21,7 @@ BEGIN
   ) AS d;
 
   IF dup_count > 0 THEN
-    RAISE NOTICE 'user_app_index has % subdomains held by more than one app; UNIQUE index creation will fail. Reconcile before re-running.', dup_count;
+    RAISE WARNING 'user_app_index has % subdomains held by more than one app; UNIQUE index creation will fail. Reconcile before re-running.', dup_count;
   END IF;
 END $$;
 

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -163,8 +163,8 @@ export async function initRoutes(app: FastifyInstance) {
     let subdomain = requestedSubdomain ?? name.replace(/_/g, '-');
 
     // Check subdomain uniqueness — auto-suffix with a butter-themed word if taken
-    const existing = await app.runtimeDb(region).query(
-      `SELECT id FROM apps WHERE subdomain = $1`,
+    const existing = await app.controlDb.query(
+      `SELECT app_id FROM user_app_index WHERE subdomain = $1`,
       [subdomain]
     );
     if (existing.rows.length > 0) {
@@ -184,8 +184,8 @@ export async function initRoutes(app: FastifyInstance) {
       subdomain = `${subdomain}-${word}`;
 
       // If still taken (unlikely), add a short random number
-      const stillTaken = await app.runtimeDb(region).query(
-        `SELECT id FROM apps WHERE subdomain = $1`,
+      const stillTaken = await app.controlDb.query(
+        `SELECT app_id FROM user_app_index WHERE subdomain = $1`,
         [subdomain]
       );
       if (stillTaken.rows.length > 0) {


### PR DESCRIPTION
## Summary
- Adds partial UNIQUE index on `user_app_index.subdomain` (migration 080) so the DB enforces global subdomain uniqueness.
- Switches the pre-insert subdomain check in `init.ts` from the regional `apps` table to `user_app_index`. Two apps in different regions can no longer claim the same subdomain.
- Migration includes a DO-block NOTICE that surfaces existing duplicates so the operator knows to reconcile before the UNIQUE creation runs.

## Risks
- If existing duplicates exist in `user_app_index`, `CREATE UNIQUE INDEX` will fail. The pre-flight DO block surfaces this as a NOTICE so the operator can reconcile (suffix one collision) before re-running.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] Pre-deploy: `SELECT subdomain FROM user_app_index GROUP BY subdomain HAVING COUNT(*) > 1` against prod returns 0 rows.
- [ ] After deploy: create app in region A with subdomain "foo"; create app in region B with subdomain "foo"; expect 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)