### PR TITLE
perf(ai-config): skip redundant region lookup

### DIFF
--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -48,8 +48,8 @@ async function readAutoRefillState(controlPool: pg.Pool, userId: string): Promis
   };
 }
 
-async function getAppDefaultModel(controlPool: pg.Pool, appId: string): Promise<string | null> {
-  const r = await controlPool.query<{ ai_config: { defaultModel?: string } | null }>(
+async function getAppDefaultModel(runtimePool: pg.Pool, appId: string): Promise<string | null> {
+  const r = await runtimePool.query<{ ai_config: { defaultModel?: string } | null }>(
     `SELECT ai_config FROM apps WHERE id = $1`,
     [appId]
   );
@@ -240,8 +240,11 @@ export async function aiConfigRoutes(app: FastifyInstance) {
 
       // ---- v2 path: multi-router gateway ----
       if (config.aiRouter.enabled) {
+        const region = await resolveAppHomeRegion(app.controlDb, appId);
+        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+
         const modelResolved = body.model
-          || (await getAppDefaultModel(app.controlDb, appId))
+          || (await getAppDefaultModel(runtimePool, appId))
           || config.aiRouter.platformDefaultModel;
 
         if (!modelResolved) {
@@ -251,9 +254,6 @@ export async function aiConfigRoutes(app: FastifyInstance) {
             message: 'No model specified and no default configured. Set apps.ai_config.defaultModel or pass a model in the request.',
           });
         }
-
-        const region = await resolveAppHomeRegion(app.controlDb, appId);
-        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
 
         const result = await routeChatCompletion(
           {
@@ -358,8 +358,11 @@ export async function aiConfigRoutes(app: FastifyInstance) {
 
       // ---- v2 path: multi-router gateway ----
       if (config.aiRouter.enabled) {
+        const region = await resolveAppHomeRegion(app.controlDb, appId);
+        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+
         const modelResolved = body.model
-          || (await getAppDefaultModel(app.controlDb, appId))
+          || (await getAppDefaultModel(runtimePool, appId))
           || config.aiRouter.platformDefaultModel;
 
         if (!modelResolved) {
@@ -369,9 +372,6 @@ export async function aiConfigRoutes(app: FastifyInstance) {
             message: 'No model specified and no default configured. Set apps.ai_config.defaultModel or pass a model in the request.',
           });
         }
-
-        const region = await resolveAppHomeRegion(app.controlDb, appId);
-        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
 
         const result = await routeEmbedding(
           {


### PR DESCRIPTION
## Summary
- Each v2-path chat completion or embedding resolved the app's home region twice: once inside `getAppDefaultModel`, once again via `resolveAppHomeRegion` + `getRuntimeDbForApp`. Two controlDb round-trips per request.
- Resolve the runtime pool once in the caller; pass it into `getAppDefaultModel`. One controlDb round-trip + one runtime round-trip per request.

Note: the existing `getAppDefaultModel` was also querying the control DB for `apps.ai_config`, whereas `apps` with `ai_config` lives on the runtime DB (confirmed by `openrouter-gateway.ts` pattern). This change also corrects that, making `getAppDefaultModel` query the runtime pool where `ai_config` actually resides.

## Test plan
- [ ] `pnpm --filter @butterbase/control-api build` green
- [ ] After deploy: hit `/v1/<app_id>/chat/completions` and `/v1/<app_id>/embeddings` with no `model` field, against an app whose `ai_config.defaultModel` is set; expect normal 200.