### PR TITLE
docs: fix 404 link to /api-reference/ai-api/#video-generation

### DIFF
--- a/services/docs/src/content/docs/core-concepts/ai-integration.md
+++ b/services/docs/src/content/docs/core-concepts/ai-integration.md
@@ -153,7 +153,7 @@ Authorization: Bearer {token}
 
 ## Video generation
 
-Video models work differently from chat: generation is **asynchronous** and can take 30 seconds to several minutes. You submit a job, poll until it's ready, and then download the rendered MP4. See [Video generation](../api-reference/ai-api.md#video-generation) in the API reference for the full flow.
+Video models work differently from chat: generation is **asynchronous** and can take 30 seconds to several minutes. You submit a job, poll until it's ready, and then download the rendered MP4. See [Video generation](/api-reference/ai-api/#video-generation) in the API reference for the full flow.
 
 Video is billed per call (not per token) — the actual cost appears as `charged_credits_usd` in the job's final poll response.
 


### PR DESCRIPTION
One-line link fix. `../api-reference/ai-api.md#video-generation` resolved to a 404 in Starlight (it doesn't rewrite the `.md` extension on relative links). Switched to the absolute `/api-reference/ai-api/#video-generation` pattern used everywhere else in the docs.