### PR TITLE
fix(auth): eliminate signup-grant race

### DIFF
--- a/db/control-plane/081_platform_users_plan_id_backfill.sql
+++ b/db/control-plane/081_platform_users_plan_id_backfill.sql
@@ -1,0 +1,20 @@
+-- @scope: platform
+-- 081: Backfill platform_users.plan_id so the signup-grant path never sees NULL.
+--
+-- Context: the column default is 'playground', but historically a small window
+-- existed where a newly-inserted platform_users row could be observed with a
+-- NULL plan_id before provisionStripeCustomer assigned it. The JIT signup-grant
+-- IIFE in auth.ts re-SELECTed plan_id and fell back to 'free' (a plan that
+-- does not exist), silently no-op'ing the grant.
+--
+-- This migration is defensive: in current prod plan_id has a DB default of
+-- 'playground' applied at INSERT time, so no rows are expected to be NULL.
+-- The UPDATE is idempotent and safe to re-run.
+
+BEGIN;
+
+UPDATE platform_users
+SET plan_id = 'playground'
+WHERE plan_id IS NULL;
+
+COMMIT;

--- a/services/control-api/src/plugins/auth.ts
+++ b/services/control-api/src/plugins/auth.ts
@@ -151,17 +151,20 @@ const authPlugin: FastifyPluginAsync = async (fastify) => {
       }
 
       try {
-        // Upsert user into platform_users
+        // Upsert user into platform_users. We return plan_id from the INSERT
+        // itself (DB default 'playground') so the signup-grant path below does
+        // not race with provisionStripeCustomer to read it back.
         const result = await fastify.controlDb.query(
           `INSERT INTO platform_users (cognito_sub, email, email_verified)
            VALUES ($1, $2, $3)
            ON CONFLICT (cognito_sub)
            DO UPDATE SET email = $2, email_verified = $3, updated_at = now()
-           RETURNING id, stripe_customer_id`,
+           RETURNING id, stripe_customer_id, plan_id`,
           [claims.sub, claims.email, claims.email_verified]
         );
 
         const userId = result.rows[0].id;
+        const planId = result.rows[0].plan_id;
 
         // Auto-provision Stripe customer + Playground subscription for new users
         if (!result.rows[0].stripe_customer_id) {
@@ -174,15 +177,13 @@ const authPlugin: FastifyPluginAsync = async (fastify) => {
           // Fire-and-forget: errors logged but never block auth.
           (async () => {
             try {
-              const planRow = await fastify.controlDb.query<{ plan_id: string }>(
-                `SELECT plan_id FROM platform_users WHERE id = $1`,
-                [userId]
-              );
-              const planId = planRow.rows[0]?.plan_id ?? 'free';
               const { grantSignupCredits } = await import('../services/credit-grants-service.js');
               await grantSignupCredits(fastify.controlDb, { userId, planId });
             } catch (err) {
-              fastify.log.error({ err }, `Failed to grant signup credits to user ${userId}`);
+              fastify.log.error(
+                { err, userId, planId },
+                'signup-grant: failed to grant signup credits'
+              );
             }
           })();
         }


### PR DESCRIPTION
## Summary
- Signup-grant IIFE in auth.ts re-SELECTed plan_id immediately after the user INSERT, racing with the concurrent provisionStripeCustomer call that sets plan_id. When the SELECT won, plan_id was NULL → fallback to 'free' (a non-existent plan) → grantSignupCredits threw → catch swallowed → user silently never received their $1 playground signup credit.
- Fix returns plan_id directly from the INSERT (DB default 'playground') and passes it straight to grantSignupCredits. Race removed by construction.
- Migration 081 defensively backfills any historical NULL plan_id (0 rows in prod; idempotent).
- Grant failure log is now structured with userId/planId for triage.

## Test plan
- [x] `tsc -b` clean
- [x] Migration 081 applied to prod control DB — UPDATE 0 (as expected)
- [ ] CI: DB-gated integration tests (`auth-signup-grant.test.ts`, `credit-grants-service.test.ts`)