### PR TITLE
fix(cf-wfp): SPA fallback fetches `/` instead of `/index.html`

### DIFF
--- a/services/control-api/src/services/cloudflare-wfp.test.ts
+++ b/services/control-api/src/services/cloudflare-wfp.test.ts
@@ -141,6 +141,111 @@ describe('deployUserWorker', () => {
   });
 });
 
+describe('STATIC_FALLBACK_WORKER_JS (SPA fallback behavior)', () => {
+  // Extract the inlined worker script via a deploy invocation. The script lives
+  // as a module-private template literal in cloudflare-wfp.ts, so we read it
+  // from the FormData that deployUserWorker uploads to CF.
+  async function extractStaticFallbackScript(): Promise<string> {
+    fetchMock
+      .mockResolvedValueOnce(okText({ jwt: 'session-jwt' }))
+      .mockResolvedValueOnce(okText({ id: 'script-id' }));
+    await deployUserWorker({
+      scriptName: 'app_extract',
+      files: new Map(),
+      envVars: {},
+    });
+    const deployForm = (fetchMock.mock.calls[1][1] as RequestInit).body as FormData;
+    return await (deployForm.get('worker.mjs') as File).text();
+  }
+
+  // Instantiate the worker handler from the module source. The script uses
+  // `export default { ... }`, which `new Function` cannot host directly — swap
+  // it for an `exports.default` assignment and evaluate.
+  function instantiate(script: string): { fetch: (req: Request, env: unknown) => Promise<Response> } {
+    const moduleCode = script.replace(/export\s+default\s*/m, 'exports.default = ');
+    const exports: { default?: { fetch: (req: Request, env: unknown) => Promise<Response> } } = {};
+    new Function('exports', moduleCode)(exports);
+    if (!exports.default) throw new Error('worker script did not assign exports.default');
+    return exports.default;
+  }
+
+  it('source does NOT fall back to `/index.html` (regression guard for the html_handling 307 trap)', async () => {
+    const script = await extractStaticFallbackScript();
+    // Tripwire: under `html_handling: 'auto-trailing-slash'`, fetching
+    // /index.html via the Assets binding 307s to /. A fallback that targets
+    // /index.html re-enters the trap. Future maintainers must not regress.
+    expect(script).not.toMatch(/url\.pathname\s*=\s*['"]\/index\.html['"]/);
+    expect(script).toMatch(/url\.pathname\s*=\s*['"]\/['"]/);
+  });
+
+  it('resolves a deep-path miss to the home document with status 200 (not a 307 to /)', async () => {
+    const script = await extractStaticFallbackScript();
+    const handler = instantiate(script);
+
+    const indexBody = '<!doctype html><html><body><div id="root"></div></body></html>';
+    const assetsCalls: string[] = [];
+    const env = {
+      ASSETS: {
+        fetch: async (req: Request): Promise<Response> => {
+          const path = new URL(req.url).pathname;
+          assetsCalls.push(path);
+          // Emulate real CF behavior under html_handling: 'auto-trailing-slash':
+          //   - `/` serves index.html with 200
+          //   - `/index.html` 307s to `/` (the bug this fallback must escape)
+          //   - extensionless misses (e.g. `/history`) 307 to `/`
+          if (path === '/') {
+            return new Response(indexBody, {
+              status: 200,
+              headers: { 'content-type': 'text/html' },
+            });
+          }
+          return new Response('', { status: 307, headers: { location: '/' } });
+        },
+      },
+    };
+
+    const res = await handler.fetch(
+      new Request('https://app.example.com/history'),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(indexBody);
+    // First hop hits /history (307), fallback hops to / (200). /index.html
+    // must NOT appear — that path is the broken one.
+    expect(assetsCalls).toEqual(['/history', '/']);
+    expect(assetsCalls).not.toContain('/index.html');
+  });
+
+  it('serves a real asset directly without entering the fallback path', async () => {
+    const script = await extractStaticFallbackScript();
+    const handler = instantiate(script);
+
+    const cssBody = 'body { color: red; }';
+    const assetsCalls: string[] = [];
+    const env = {
+      ASSETS: {
+        fetch: async (req: Request): Promise<Response> => {
+          assetsCalls.push(new URL(req.url).pathname);
+          return new Response(cssBody, {
+            status: 200,
+            headers: { 'content-type': 'text/css' },
+          });
+        },
+      },
+    };
+
+    const res = await handler.fetch(
+      new Request('https://app.example.com/assets/app.css'),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(cssBody);
+    expect(assetsCalls).toEqual(['/assets/app.css']);
+  });
+});
+
 describe('deployUserWorkerWithScript', () => {
   it('uploads worker.mjs with the provided script and appends each additionalModule as a separate form-part', async () => {
     fetchMock

--- a/services/control-api/src/services/cloudflare-wfp.ts
+++ b/services/control-api/src/services/cloudflare-wfp.ts
@@ -27,15 +27,23 @@ function hash32(buf: Buffer): string {
 }
 
 // SPA fallback handled explicitly in-worker: on a non-2xx from the assets
-// binding, rewrite the path to /index.html and retry. This is the CF-canonical
-// SPA pattern and is deterministic across CF runtime variants (we previously
-// tried `not_found_handling: 'single-page-application'` and it threw inside WfP).
+// binding, retry against `/` (which resolves to the home `index.html` under
+// `html_handling: 'auto-trailing-slash'`). This is the CF-canonical SPA
+// pattern and is deterministic across CF runtime variants (we previously
+// tried `not_found_handling: 'single-page-application'` and it threw inside
+// WfP).
 //
 // NOTE: We check `res.ok` (status 200-299) rather than `res.status !== 404`
 // because the Assets binding inside a WfP dispatch namespace may return 307
 // redirects for non-file paths (e.g. /people → 307 Location: /) instead of
-// 404. Catching all non-2xx responses ensures SPA deep-links always resolve to
-// index.html instead of producing unexpected redirects.
+// 404. Catching all non-2xx responses ensures SPA deep-links always resolve
+// to the home document instead of producing unexpected redirects.
+//
+// IMPORTANT: the fallback fetches `/`, NOT `/index.html`. Under
+// `html_handling: 'auto-trailing-slash'`, fetching `/index.html` itself
+// returns a 307 redirect to `/` — the same trap this fallback exists to
+// escape. Fetching `/` returns the home document with status 200 directly.
+// Do not change this back to `/index.html`.
 //
 // MIME workaround: the Assets binding inside a WfP dispatch namespace does not
 // reliably set Content-Type headers. Without a correct Content-Type, browsers
@@ -90,7 +98,7 @@ export default {
       const res = await env.ASSETS.fetch(request);
       if (res.ok) return withMime(request, res);
       const url = new URL(request.url);
-      url.pathname = '/index.html';
+      url.pathname = '/';
       const fallback = await env.ASSETS.fetch(new Request(url.toString(), request));
       return withMime(new Request(url.toString()), fallback);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Under `html_handling: 'auto-trailing-slash'`, the Assets binding 307s `/index.html` → `/`. The in-worker SPA fallback was fetching `/index.html` as its recovery target after a non-2xx response, re-entering the same 307 trap it was built to escape — every deep-path refresh returned 307 `Location: /` and the browser snapped back to home.
- One-character pathname change in `STATIC_FALLBACK_WORKER_JS`: fetch `/` instead of `/index.html`. Under `auto-trailing-slash`, `/` resolves to the home `index.html` with status 200 directly. First-hop behavior unchanged for every existing app.
- Comment block above the worker expanded with an IMPORTANT note so the next maintainer doesn't "helpfully" revert.

## Tests
Three new tests under `STATIC_FALLBACK_WORKER_JS (SPA fallback behavior)` in `cloudflare-wfp.test.ts`:
- **Source tripwire** — regex assertion that the worker script no longer references `/index.html` as the fallback target.
- **Behavior** — instantiates the worker against a mocked `env.ASSETS` that emulates the real CF 307 cascade (`/` → 200, `/index.html` → 307 to `/`, extensionless miss → 307 to `/`). Asserts a deep-path request resolves to 200 + index.html body and never touches `/index.html`.
- **Happy path** — confirms real-asset requests serve directly without entering the fallback branch.

Verified the tests trip when the fix is reverted: behavior test produces the exact `307` symptom users observed.

## Test plan
- [x] `npm test src/services/cloudflare-wfp.test.ts` — 16/16 passing
- [x] `npm run build` (tsc -b) — clean
- [x] Regression guards confirmed to fail when fix is reverted
- [ ] Existing apps need redeploy to pick up the fixed worker; backfill script will follow as a separate operation

## Context
Reported via `submit_suggestion 93b31508` on `cardiocare.butterbase.dev`. Affects every WfP-deployed SPA using `BrowserRouter`-style deep paths.