### PR TITLE
feat(deploy): probe SPA routing after WfP deploy

### DIFF
--- a/services/control-api/src/services/deployment.service.ts
+++ b/services/control-api/src/services/deployment.service.ts
@@ -12,6 +12,7 @@ import { getRuntimeDbPool } from './runtime-db.js';
 import { generateTemplatePage } from './template-page.js';
 import { decrypt } from './crypto.js';
 import { notifyDeploymentFailed } from './failure-notifications.service.js';
+import { probeSpaRouting } from './spa-routing-probe.js';
 
 export class DeploymentError extends Error {
   constructor(message: string, public readonly code?: string) {
@@ -574,6 +575,32 @@ async function deployViaWfp(ctx: PipelineCtx): Promise<DeployResult> {
   }
 
   const url = `https://${app.subdomain}.${config.subdomain.baseDomain}`;
+
+  // Step 5/5: Probe SPA routing on the live URL. Catches any future regression
+  // of the html_handling 307 trap (PR #33) at the deploy boundary instead of
+  // via user complaint. The probe hits a random deep path and asserts the
+  // worker's SPA fallback resolves it to 200 + text/html. Skipped only when
+  // explicitly disabled via env (e.g. for offline/staging environments where
+  // the URL isn't reachable from control-api).
+  if (process.env.SPA_ROUTING_PROBE_DISABLED !== 'true') {
+    console.log(`${tag} Step 5/5: Probing SPA routing at ${url}…`);
+    const probeStart = Date.now();
+    const result = await probeSpaRouting(url);
+    if (!result.ok) {
+      console.error(
+        `${tag} Step 5/5: SPA routing probe FAILED after ${Date.now() - probeStart}ms: ${result.reason}`,
+      );
+      throw new DeploymentError(
+        `SPA routing probe failed: ${result.reason}. The worker is uploaded but deep paths are not resolving to index.html. ` +
+          `This usually means the in-worker SPA fallback or html_handling config is broken. ` +
+          `Investigate before redeploying.`,
+        'SPA_ROUTING_PROBE_FAILED',
+      );
+    }
+    console.log(`${tag} Step 5/5: SPA routing probe OK in ${Date.now() - probeStart}ms`);
+  } else {
+    console.log(`${tag} Step 5/5: SPA routing probe skipped (SPA_ROUTING_PROBE_DISABLED=true)`);
+  }
 
   return {
     url,

--- a/services/control-api/src/services/spa-routing-probe.test.ts
+++ b/services/control-api/src/services/spa-routing-probe.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { probeSpaRouting } from './spa-routing-probe.js';
+
+function html200(body = '<!doctype html><div id="root"></div>'): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+function redirect(status: number, location: string): Response {
+  return new Response('', { status, headers: { location } });
+}
+
+const noSleep = async () => {};
+
+describe('probeSpaRouting', () => {
+  it('returns ok when the probe URL responds with 200 + text/html', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(html200());
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status).toBe(200);
+      expect(result.contentType).toMatch(/text\/html/);
+    }
+  });
+
+  it('fails on a 307 to / (the PR #33 regression symptom)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(redirect(307, '/'));
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0, // single attempt for this case
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(307);
+      expect(result.reason).toMatch(/expected status 200, got 307/);
+      expect(result.reason).toMatch(/Location: \//);
+    }
+  });
+
+  it('fails on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 404 }));
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(404);
+  });
+
+  it('fails on 200 with non-html content-type (e.g. served the wrong asset)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"foo": 1}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/expected content-type text\/html/);
+  });
+
+  it('fails on 200 with no content-type at all', async () => {
+    // Use a byte body so Node doesn't auto-set text/plain
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new TextEncoder().encode('whatever'), { status: 200 }),
+    );
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/expected content-type text\/html/);
+  });
+
+  it('treats network errors as probe failures (with reason)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED'));
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/network error: connect ECONNREFUSED/);
+  });
+
+  it('retries on transient failure and succeeds if a later attempt is healthy (WfP propagation race)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 })) // dispatcher hasn't seen new script yet
+      .mockResolvedValueOnce(new Response('', { status: 404 })) // still propagating
+      .mockResolvedValueOnce(html200()); // ok on 3rd try
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 2,
+    });
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports the LAST failure when all retries fail', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirect(307, '/'))
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response('', { status: 502 }));
+    const result = await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 2,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('appends a random probe path that cannot collide with real routes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(html200());
+    await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    const requestedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toMatch(/^https:\/\/app\.example\.com\/__bb_route_probe_[0-9a-f]{16}$/);
+  });
+
+  it('handles a deploymentUrl with a trailing slash without doubling it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(html200());
+    await probeSpaRouting('https://app.example.com/', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    const requestedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl).not.toMatch(/example\.com\/\//);
+    expect(requestedUrl).toMatch(/^https:\/\/app\.example\.com\/__bb_route_probe_[0-9a-f]{16}$/);
+  });
+
+  it('passes redirect: manual so a 307 is observable instead of being followed', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(html200());
+    await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: noSleep,
+      retries: 0,
+    });
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.redirect).toBe('manual');
+  });
+
+  it('observes the initial probeDelayMs before the first fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(html200());
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    await probeSpaRouting('https://app.example.com', {
+      fetchImpl: fetchMock,
+      sleep: sleepMock,
+      probeDelayMs: 750,
+      retries: 0,
+    });
+    // First sleep call must be the initial delay.
+    expect(sleepMock).toHaveBeenCalledWith(750);
+    expect(sleepMock.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/services/control-api/src/services/spa-routing-probe.ts
+++ b/services/control-api/src/services/spa-routing-probe.ts
@@ -1,0 +1,115 @@
+// Post-deploy SPA routing probe.
+//
+// After deployUserWorker uploads the per-app static frontend worker, we hit a
+// synthetic deep path on the live URL and assert the SPA fallback resolves to
+// 200 + text/html. Catches any future regression of the html_handling 307 trap
+// (PR #33) at the deploy boundary instead of via user complaint.
+//
+// The probe path is randomized so it cannot match any real route the user has
+// shipped. If the worker's fallback is working, this returns the home
+// document; if broken, it returns whatever the broken state produces
+// (typically 307 to /, or 404).
+//
+// Retries: WfP dispatcher takes ~100-500ms to register a new script after
+// upload. A small initial delay + 2 retries with backoff smooths over that
+// race; failures past the retry budget are real routing failures.
+
+import crypto from 'node:crypto';
+
+export interface ProbeOptions {
+  /** Initial delay before the first probe attempt. WfP dispatcher needs a beat to register the script. Default: 500ms. */
+  probeDelayMs?: number;
+  /** Number of retries on transient failure. Default: 2 (total 3 attempts). */
+  retries?: number;
+  /** Backoff between retries. Default: 500ms. */
+  retryDelayMs?: number;
+  /** Per-request timeout. Default: 5000ms. */
+  timeoutMs?: number;
+  /** Injectable for tests. Default: global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests. Default: setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type ProbeResult =
+  | { ok: true; status: number; contentType: string }
+  | { ok: false; reason: string; status?: number; contentType?: string | null };
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Probe the SPA fallback by GETing a synthetic deep path and verifying the
+ * worker resolves it to 200 + text/html (the index document). Returns a
+ * result; never throws. Callers decide whether a failure aborts the deploy.
+ */
+export async function probeSpaRouting(
+  deploymentUrl: string,
+  options: ProbeOptions = {},
+): Promise<ProbeResult> {
+  const probeDelayMs = options.probeDelayMs ?? 500;
+  const retries = options.retries ?? 2;
+  const retryDelayMs = options.retryDelayMs ?? 500;
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const probePath = `/__bb_route_probe_${crypto.randomBytes(8).toString('hex')}`;
+  const url = deploymentUrl.replace(/\/+$/, '') + probePath;
+
+  if (probeDelayMs > 0) await sleep(probeDelayMs);
+
+  let lastResult: ProbeResult = { ok: false, reason: 'no attempts made' };
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await sleep(retryDelayMs);
+    lastResult = await singleAttempt(fetchImpl, url, timeoutMs);
+    if (lastResult.ok) return lastResult;
+  }
+  return lastResult;
+}
+
+async function singleAttempt(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    // redirect: 'manual' so a 307 → / is observed as a 307, not silently
+    // followed (which would mask the exact bug this probe exists to detect).
+    const res = await fetchImpl(url, { redirect: 'manual', signal: ac.signal });
+    return evaluate(res);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: `network error: ${msg}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function evaluate(res: Response): ProbeResult {
+  const contentType = res.headers.get('content-type');
+
+  if (res.status !== 200) {
+    return {
+      ok: false,
+      reason: `expected status 200, got ${res.status}${
+        res.status >= 300 && res.status < 400
+          ? ` (Location: ${res.headers.get('location') ?? '<none>'})`
+          : ''
+      }`,
+      status: res.status,
+      contentType,
+    };
+  }
+  if (!contentType || !contentType.toLowerCase().includes('text/html')) {
+    return {
+      ok: false,
+      reason: `expected content-type text/html, got ${contentType ?? '<none>'}`,
+      status: res.status,
+      contentType,
+    };
+  }
+  return { ok: true, status: res.status, contentType };
+}


### PR DESCRIPTION
## Summary
After \`deployUserWorker\` uploads the per-app static frontend worker in \`deployViaWfp\`, hit a synthetic deep path on the live URL and assert the SPA fallback resolves to \`200 text/html\`. Catches future regressions of the html_handling 307 trap (PR #33) at the deploy boundary instead of via user complaint — which is how that bug actually shipped despite a comment block above the broken code documenting the failure mode.

## Behavior
- **On pass:** logs probe duration and transitions to READY (existing flow).
- **On fail:** throws \`DeploymentError(SPA_ROUTING_PROBE_FAILED)\` with observed status + content-type. Pipeline persists FAILED. **Worker is still uploaded** (rollback intentionally out of scope — too risky as an automated step). User investigates and redeploys.
- **Probe path** is randomized via \`crypto.randomBytes\` — \`/__bb_route_probe_<16-hex>\`. Cannot collide with real routes.
- **Probe options:** initial 500ms delay + 2 retries with 500ms backoff. Smooths over the WfP dispatcher's ~100-500ms propagation race. Healthy deploys pass on attempt 1 in well under a second.
- **\`redirect: 'manual'\`** so a 307 to / is observable as a 307 — silently following would mask the exact bug.
- **Disable switch:** \`SPA_ROUTING_PROBE_DISABLED=true\` for offline/staging environments.

## Tests
12 covering:
- Happy: 200 + text/html → ok
- PR #33 regression: 307 to / → fails with Location in reason
- 404 → fail
- 200 + application/json → fail
- 200 + no content-type → fail
- Network error → fail with reason
- Retry-then-succeed (WfP race) → ok on 3rd attempt
- All-retries-fail → reports last attempt
- Random path format (\`/__bb_route_probe_[0-9a-f]{16}\`)
- Trailing-slash URL normalization
- \`redirect: 'manual'\` contract
- Initial delay ordering (sleep before first fetch)

## Out of scope
- Miniflare-backed integration test (PR 3.5 follow-up; would replace the hand-mocked 307 in \`packages/static-frontend-worker\` with a real workerd run)
- Pages-backend probe (pages path is deprecated per current ops)
- Auto-rollback on probe failure

## Test plan
- [x] \`npm test -- src/services/spa-routing-probe.test.ts\` — 12/12 ✓
- [x] \`npm test -- src/services/cloudflare-wfp.test.ts\` — 13/13 ✓ (unchanged)
- [x] \`npm run build --workspace=@butterbase/control-api\` — clean
- [x] Pre-existing \`deployment.wfp.test.ts\` failures (DB fixture issue) unchanged vs main