### PR TITLE
feat(static-frontend-worker): Miniflare integration for tests + local dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17173,6 +17173,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "miniflare": "^4.20260426.0",
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"
       }

--- a/packages/static-frontend-worker/Dockerfile
+++ b/packages/static-frontend-worker/Dockerfile
@@ -1,0 +1,60 @@
+# Local dev container: serves the static frontend worker via Miniflare so devs
+# can reproduce SPA routing locally without redeploying to butterbase. Wired up
+# as the `miniflare-frontend` service in the wrapper's docker-compose.local.yml.
+#
+# Build context: wrapper repo root.
+#   docker build -f submodules/butterbase-oss/packages/static-frontend-worker/Dockerfile .
+#
+# Runtime env (see scripts/local-server.mjs for the full list):
+#   LOCAL_FRONTEND_ASSETS_DIR  path inside the container (mount your dist/ here)
+#   LOCAL_FRONTEND_PORT        default 8787
+#   LOCAL_FRONTEND_HTML_HANDLING  default auto-trailing-slash
+
+# ---------- Builder: compile the worker against the full workspace ----------
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY submodules/butterbase-oss/package.json submodules/butterbase-oss/tsconfig.base.json submodules/butterbase-oss/
+COPY submodules/butterbase-oss/packages/shared/package.json submodules/butterbase-oss/packages/shared/
+COPY submodules/butterbase-oss/packages/static-frontend-worker/package.json submodules/butterbase-oss/packages/static-frontend-worker/
+COPY submodules/butterbase-oss/services/mcp-server/package.json submodules/butterbase-oss/services/mcp-server/
+COPY submodules/butterbase-oss/services/control-api/package.json submodules/butterbase-oss/services/control-api/
+
+RUN npm ci
+
+COPY submodules/butterbase-oss/packages/static-frontend-worker/ submodules/butterbase-oss/packages/static-frontend-worker/
+
+# --force defeats stale tsbuildinfo from the host (.dockerignore strips dist
+# but not tsbuildinfo). Build also runs scripts/emit-source.mjs which writes
+# dist/worker-source.generated.js.
+RUN npm run build --workspace=@butterbase/static-frontend-worker
+
+# ---------- Runtime: minimal image with miniflare + the built worker ----------
+# We deliberately do NOT carry the wrapper's lockfile into this stage. The
+# wrapper lockfile pins a platform-specific workerd binary (whatever the
+# developer's host is), which is wrong for a linux/amd64|arm64 container.
+# Installing miniflare directly here lets npm pick the right platform variant
+# at install time.
+#
+# Runtime is debian-based, NOT alpine — Cloudflare's workerd binary is linked
+# against glibc and crashes with "symbol not found" relocations on musl.
+FROM node:22-slim
+WORKDIR /app
+
+# Match the devDep version from the package's package.json. Hardcoded here
+# instead of read-from-package because we don't carry the workspace into
+# this stage. Bump in lockstep with packages/static-frontend-worker/package.json.
+RUN npm init -y >/dev/null && \
+    npm install --omit=dev --no-package-lock miniflare@^4.20260426.0 2>&1 | tail -5
+
+COPY --from=builder /app/submodules/butterbase-oss/packages/static-frontend-worker/dist ./dist/
+COPY --from=builder /app/submodules/butterbase-oss/packages/static-frontend-worker/scripts ./scripts/
+COPY --from=builder /app/submodules/butterbase-oss/packages/static-frontend-worker/local-assets ./local-assets/
+
+ENV LOCAL_FRONTEND_HOST=0.0.0.0
+ENV LOCAL_FRONTEND_PORT=8787
+
+EXPOSE 8787
+
+CMD ["node", "./scripts/local-server.mjs"]

--- a/packages/static-frontend-worker/README.md
+++ b/packages/static-frontend-worker/README.md
@@ -1,0 +1,94 @@
+# @butterbase/static-frontend-worker
+
+Per-app static frontend worker source for the Butterbase WfP dispatch namespace.
+
+One copy of the compiled output of `src/worker.ts` is uploaded by `control-api` into the WfP dispatch namespace per customer app (script name = appId). The worker is bound to a Cloudflare Assets binding containing the user's uploaded zip contents and serves them with an in-worker SPA fallback (`/` resolves to home `index.html` under `html_handling: 'auto-trailing-slash'`).
+
+To modify worker behavior: edit `src/worker.ts`, rebuild, redeploy `control-api`.
+
+## Layout
+
+```
+src/
+  worker.ts                       # the worker (typed TS, compiles to dist/worker.js)
+  worker.test.ts                  # unit tests vs hand-mocked env.ASSETS
+  worker.miniflare.test.ts        # integration tests vs real workerd
+  index.ts                        # exports worker handler + WORKER_SOURCE constant
+  worker-source.generated.d.ts    # committed shim for the build-time generated module
+scripts/
+  emit-source.mjs                 # post-build: dist/worker.js → dist/worker-source.generated.js
+  local-server.mjs                # local Miniflare HTTP server (dev mode)
+local-assets/                     # sample SPA shipped for first-run of dev:serve
+Dockerfile                        # for the `miniflare-frontend` compose service
+```
+
+## Build
+
+```
+npm run build
+```
+
+Compiles `src/worker.ts` → `dist/worker.js`, then runs `emit-source.mjs` which writes `dist/worker-source.generated.js` exporting the compiled bytes as a string constant. `control-api`'s `cloudflare-wfp.ts` imports `WORKER_SOURCE` from this package and uploads it verbatim to CF on each deploy.
+
+`--force` is mandatory in the tsc invocation: the wrapper's `.dockerignore` strips `dist/` but not `tsconfig.tsbuildinfo`, so non-force builds inside docker skip emit.
+
+## Test
+
+```
+npm test
+```
+
+Two test files:
+
+1. **`worker.test.ts`** — Native Vitest against a hand-mocked `env.ASSETS`. Fast, deterministic, covers MIME defaults, error handling, the exact PR #33 307 cascade. ~10ms.
+
+2. **`worker.miniflare.test.ts`** — Boots the actual compiled worker against Miniflare 4 (real `workerd` runtime + real Assets binding configured the way prod is). Catches regressions where the hand-mock and real runtime diverge — e.g. if CF changes Assets binding semantics. ~350ms.
+
+Note: Miniflare's default routes assets BEFORE the user worker (the standalone Workers Static Assets behavior). In a WfP dispatch namespace, the user worker is the entry point and `env.ASSETS` is just a binding it calls. The test enables `routerConfig.invoke_user_worker_ahead_of_assets: true` to match prod.
+
+## Local dev — Mode 1: Miniflare HTTP server (host node)
+
+```
+npm run dev:serve
+```
+
+Boots Miniflare locally on `http://localhost:8787` serving `./local-assets/`. Customize via env vars:
+
+| Env | Default | Notes |
+|---|---|---|
+| `LOCAL_FRONTEND_ASSETS_DIR` | `./local-assets` | Path to the dist/ to serve |
+| `LOCAL_FRONTEND_PORT` | `8787` | Bind port |
+| `LOCAL_FRONTEND_HOST` | `0.0.0.0` | `127.0.0.1` for loopback-only |
+| `LOCAL_FRONTEND_HTML_HANDLING` | `auto-trailing-slash` | Mirror prod |
+
+Try:
+
+```
+curl -sI http://localhost:8787/                  # 200 + text/html (home)
+curl -sI http://localhost:8787/some/deep/route   # 200 + text/html (SPA fallback)
+curl -sI http://localhost:8787/about             # 200 + text/html (resolves /about.html)
+```
+
+## Local dev — Mode 2: docker-compose service
+
+`docker-compose.local.yml` ships a `miniflare-frontend` service:
+
+```
+docker compose -f docker-compose.local.yml up -d miniflare-frontend
+curl -sI http://localhost:8787/                  # same probes as above
+```
+
+To serve your own SPA's `dist/` instead of the sample assets:
+
+```
+docker compose -f docker-compose.local.yml run --rm \
+  -v "$(pwd)/path/to/your/dist:/app/local-assets" \
+  -p 8787:8787 \
+  miniflare-frontend
+```
+
+The container uses `node:22-slim` (debian, not alpine) because `workerd` is linked against glibc and crashes with `symbol not found` relocations on musl.
+
+## Production deployment
+
+This package's `WORKER_SOURCE` is uploaded to the WfP dispatch namespace as `worker.mjs` by `services/control-api/src/services/cloudflare-wfp.ts:deployUserWorker`. After upload, `services/control-api/src/services/deployment.service.ts:deployViaWfp` runs the SPA routing probe (PR #36) against the live URL and fails the deploy with `SPA_ROUTING_PROBE_FAILED` if the worker's fallback isn't resolving deep paths to 200 + text/html. Both layers together close the bug-via-user-complaint path.

--- a/packages/static-frontend-worker/local-assets/about.html
+++ b/packages/static-frontend-worker/local-assets/about.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>About — Butterbase Local Frontend</title>
+  </head>
+  <body>
+    <h1>About</h1>
+    <p>This file demonstrates that <code>/about</code> with <code>html_handling: 'auto-trailing-slash'</code> resolves directly to <code>/about.html</code> (status 200) without entering the SPA fallback.</p>
+  </body>
+</html>

--- a/packages/static-frontend-worker/local-assets/index.html
+++ b/packages/static-frontend-worker/local-assets/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Butterbase Local Frontend (Miniflare)</title>
+    <style>
+      body { font-family: -apple-system, system-ui, sans-serif; max-width: 720px; margin: 4rem auto; padding: 0 1rem; color: #1a1a1a; }
+      h1 { font-size: 1.5rem; }
+      code { background: #f3f3f3; padding: 0.1rem 0.4rem; border-radius: 4px; }
+      pre { background: #f3f3f3; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+      .ok { color: #0a7c3a; font-weight: 600; }
+    </style>
+  </head>
+  <body>
+    <h1>Butterbase static frontend (local Miniflare)</h1>
+    <div id="root">
+      <p>
+        This page is served by the <code>@butterbase/static-frontend-worker</code>
+        package running inside Miniflare locally — the same <code>workerd</code>
+        runtime that serves <code>*.butterbase.dev</code> in production.
+      </p>
+      <p>
+        Drop your SPA's <code>dist/</code> contents into the directory mounted at
+        <code>LOCAL_FRONTEND_ASSETS_DIR</code> and the worker will serve them with
+        the same SPA fallback semantics prod uses.
+      </p>
+      <p class="ok">Path served: <code id="path"></code></p>
+      <p>Try a deep path that doesn't exist — the SPA fallback should return this page with status 200:</p>
+      <pre>curl -sI http://localhost:8787/some/deep/route</pre>
+    </div>
+    <script>
+      document.getElementById('path').textContent = window.location.pathname;
+    </script>
+  </body>
+</html>

--- a/packages/static-frontend-worker/package.json
+++ b/packages/static-frontend-worker/package.json
@@ -18,14 +18,18 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "local-assets",
+    "scripts/local-server.mjs"
   ],
   "scripts": {
     "build": "tsc -b --force && node ./scripts/emit-source.mjs",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "dev:serve": "node ./scripts/local-server.mjs"
   },
   "devDependencies": {
+    "miniflare": "^4.20260426.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4"
   }

--- a/packages/static-frontend-worker/scripts/local-server.mjs
+++ b/packages/static-frontend-worker/scripts/local-server.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Boots the static frontend worker locally via Miniflare (the same workerd
+// runtime CF runs in prod). Serves a configurable assets directory with the
+// same html_handling and binding setup the deployed worker uses, so devs can
+// reproduce SPA routing issues without redeploying.
+//
+// Usage (from package root):
+//   npm run dev:serve
+//
+// Env:
+//   LOCAL_FRONTEND_ASSETS_DIR  Path to the dist/ to serve.
+//                              Default: ./local-assets (a sample SPA shipped
+//                              with this package).
+//   LOCAL_FRONTEND_PORT        Port to bind. Default: 8787.
+//   LOCAL_FRONTEND_HOST        Host to bind. Default: 0.0.0.0 (so docker port
+//                              forwarding works; use 127.0.0.1 for native
+//                              loopback-only).
+//   LOCAL_FRONTEND_HTML_HANDLING  auto-trailing-slash (default), drop-trailing-slash,
+//                                 force-trailing-slash, or none.
+import { Miniflare } from 'miniflare';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(here, '..');
+
+const workerJsPath = join(packageRoot, 'dist', 'worker.js');
+if (!existsSync(workerJsPath)) {
+  console.error(
+    `[local-server] dist/worker.js not found at ${workerJsPath}. Run \`npm run build\` first.`,
+  );
+  process.exit(1);
+}
+const workerSource = readFileSync(workerJsPath, 'utf8');
+
+const assetsDir = resolve(
+  process.env.LOCAL_FRONTEND_ASSETS_DIR || join(packageRoot, 'local-assets'),
+);
+if (!existsSync(assetsDir)) {
+  console.error(`[local-server] Assets directory does not exist: ${assetsDir}`);
+  process.exit(1);
+}
+
+const port = Number.parseInt(process.env.LOCAL_FRONTEND_PORT || '8787', 10);
+const host = process.env.LOCAL_FRONTEND_HOST || '0.0.0.0';
+const htmlHandling =
+  /** @type {"auto-trailing-slash" | "drop-trailing-slash" | "force-trailing-slash" | "none"} */ (
+    process.env.LOCAL_FRONTEND_HTML_HANDLING || 'auto-trailing-slash'
+  );
+
+const mf = new Miniflare({
+  modules: true,
+  script: workerSource,
+  host,
+  port,
+  assets: {
+    directory: assetsDir,
+    binding: 'ASSETS',
+    assetConfig: {
+      html_handling: htmlHandling,
+    },
+    // Match prod: in a WfP dispatch namespace the user worker is the entry
+    // point and env.ASSETS is just a binding. Miniflare's default routes
+    // assets ahead of the user worker, which would bypass our SPA fallback.
+    routerConfig: {
+      has_user_worker: true,
+      invoke_user_worker_ahead_of_assets: true,
+    },
+  },
+});
+
+// Trigger initialization so the server is bound before we log readiness.
+await mf.ready;
+
+console.log(`[local-server] static-frontend-worker ready`);
+console.log(`[local-server]   listening:    http://${host}:${port}`);
+console.log(`[local-server]   assets dir:   ${assetsDir}`);
+console.log(`[local-server]   html_handling: ${htmlHandling}`);
+console.log(`[local-server] try:`);
+console.log(`[local-server]   curl -sI http://localhost:${port}/                  # 200 + text/html`);
+console.log(`[local-server]   curl -sI http://localhost:${port}/some/deep/route   # 200 (SPA fallback)`);
+console.log(`[local-server]   curl -sI http://localhost:${port}/about             # 200 (resolves /about.html)`);
+
+const shutdown = async (signal) => {
+  console.log(`[local-server] received ${signal}, shutting down…`);
+  await mf.dispose();
+  process.exit(0);
+};
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/packages/static-frontend-worker/src/worker.miniflare.test.ts
+++ b/packages/static-frontend-worker/src/worker.miniflare.test.ts
@@ -1,0 +1,158 @@
+// Integration tests for the static frontend worker against a real workerd
+// runtime via Miniflare. Complements src/worker.test.ts (which exercises the
+// handler against a hand-mocked env.ASSETS) by running the actual deployed
+// worker bundle with a real Assets binding configured the same way prod is
+// configured (html_handling: 'auto-trailing-slash').
+//
+// These tests catch a class of regression the hand-mock cannot: behaviors
+// that depend on the real Assets binding's response semantics — most
+// importantly the 307-from-Assets-on-extensionless-miss that PR #33's
+// fallback exists to escape. If CF ever changes that behavior (e.g. to 404
+// instead of 307), this test will surface the change concretely; the unit
+// tests would still pass because they mock the old behavior.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Miniflare } from 'miniflare';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(here, '..');
+const workerJsPath = join(packageRoot, 'dist', 'worker.js');
+
+const INDEX_BODY = '<!doctype html><html><body><div id="root"></div></body></html>';
+const ABOUT_BODY = '<!doctype html><h1>About</h1>';
+const CSS_BODY = 'body{color:red}';
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+let mf: Miniflare;
+let baseUrl: URL;
+let assetsDir: string;
+
+beforeAll(async () => {
+  const workerSource = readFileSync(workerJsPath, 'utf8');
+
+  assetsDir = mkdtempSync(join(tmpdir(), 'bb-mf-assets-'));
+  writeFileSync(join(assetsDir, 'index.html'), INDEX_BODY);
+  writeFileSync(join(assetsDir, 'about.html'), ABOUT_BODY);
+  mkdirSync(join(assetsDir, 'assets'), { recursive: true });
+  writeFileSync(join(assetsDir, 'assets', 'app.css'), CSS_BODY);
+  writeFileSync(join(assetsDir, 'logo.png'), PNG_BYTES);
+
+  mf = new Miniflare({
+    modules: true,
+    script: workerSource,
+    host: '127.0.0.1',
+    port: 0, // Let Miniflare pick a free port
+    assets: {
+      directory: assetsDir,
+      binding: 'ASSETS',
+      assetConfig: {
+        // Mirror production config — this is the setting that produces the
+        // 307-on-/index.html behavior PR #33's fallback was built to escape.
+        html_handling: 'auto-trailing-slash',
+      },
+      // In a WfP dispatch namespace the user worker is the entry point and
+      // env.ASSETS is just a binding it can choose to call. Miniflare's
+      // default routes assets ahead of the user worker (the standalone
+      // Workers Static Assets product behavior), which would mean our SPA
+      // fallback never runs because Assets returns 404 directly to the
+      // client. These two flags make the user worker the entry, matching
+      // prod.
+      routerConfig: {
+        has_user_worker: true,
+        invoke_user_worker_ahead_of_assets: true,
+      },
+    },
+  });
+  baseUrl = await mf.ready;
+}, 30_000);
+
+afterAll(async () => {
+  if (mf) await mf.dispose();
+  if (assetsDir) rmSync(assetsDir, { recursive: true, force: true });
+});
+
+async function get(path: string, init?: RequestInit): Promise<Response> {
+  return await mf.dispatchFetch(new URL(path, baseUrl).toString(), {
+    redirect: 'manual',
+    ...init,
+  });
+}
+
+describe('static-frontend-worker via Miniflare (real workerd)', () => {
+  describe('happy path', () => {
+    it('serves an existing asset directly with the expected status + body', async () => {
+      const res = await get('/assets/app.css');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(CSS_BODY);
+      expect(res.headers.get('content-type')).toMatch(/text\/css/);
+    });
+
+    it('serves the root path with the home index.html', async () => {
+      const res = await get('/');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_BODY);
+    });
+
+    it('resolves /about (extensionless) to /about.html via html_handling: auto-trailing-slash', async () => {
+      const res = await get('/about');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(ABOUT_BODY);
+    });
+
+    it('round-trips binary bytes (image/png) unchanged', async () => {
+      const res = await get('/logo.png');
+      expect(res.status).toBe(200);
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      expect(Array.from(bytes)).toEqual(Array.from(PNG_BYTES));
+    });
+  });
+
+  describe('SPA fallback against real CF semantics (PR #33 regression guard)', () => {
+    it('deep path that does not exist resolves to the home index.html with status 200', async () => {
+      // This is the canonical PR #33 case. Against the REAL Assets binding
+      // (not a hand-mock), /history with no matching file should: first
+      // attempt returns non-2xx, worker falls back to /, returns 200.
+      const res = await get('/history');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_BODY);
+    });
+
+    it('nested deep path also resolves to the home index.html', async () => {
+      const res = await get('/result/abc-123/details');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_BODY);
+    });
+
+    it('the worker NEVER returns a 307 redirect to /', async () => {
+      // The exact symptom the user reported. With redirect: manual the test
+      // observer would see the 307 if the bug was reintroduced. This is the
+      // strongest regression guard the package can carry: it runs the
+      // production worker bundle against the production Assets configuration.
+      for (const path of ['/history', '/profile', '/result/xyz', '/__missing']) {
+        const res = await get(path);
+        expect(res.status, `path=${path} should not be 307`).not.toBe(307);
+        expect(res.headers.get('location'), `path=${path} should have no Location header`).toBeNull();
+      }
+    });
+  });
+
+  describe('content-type defaults via worker withMime', () => {
+    it('serves CSS with text/css', async () => {
+      const res = await get('/assets/app.css');
+      expect(res.headers.get('content-type')).toMatch(/text\/css/);
+    });
+
+    it('serves PNG with image/png', async () => {
+      const res = await get('/logo.png');
+      expect(res.headers.get('content-type')).toMatch(/image\/png/);
+    });
+
+    it('serves the SPA fallback as text/html (even though the request was for an extensionless path)', async () => {
+      const res = await get('/history');
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds Miniflare-backed test coverage AND a local dev server to the static-frontend-worker package. Both use the same \`workerd\` runtime CF runs in production.

## Mode 1: integration tests vs real workerd
10 new tests in \`worker.miniflare.test.ts\`. Catches regressions where the hand-mocked \`env.ASSETS\` in \`worker.test.ts\` and the real workerd runtime diverge — e.g. if CF changes Assets binding semantics, or if a future worker change passes the hand-mock but fails the real runtime.

The explicit \"worker NEVER returns a 307 redirect to /\" assertion is now made against the real runtime, not a hand-mock — that's a meaningful step up in regression-detection confidence.

**Gotcha:** Miniflare's default routes assets ahead of the user worker (the standalone Workers Static Assets behavior). In a WfP dispatch namespace, the user worker is the entry point and \`env.ASSETS\` is just a binding it calls. The tests enable \`routerConfig.invoke_user_worker_ahead_of_assets: true\` to match prod — diagnosed by adding a logging wrapper worker; my SPA fallback was never running because Miniflare was serving assets directly.

## Mode 2: local HTTP server
\`npm run dev:serve\` boots Miniflare on \`http://localhost:8787\` serving a configurable assets dir. Lets devs reproduce SPA routing issues locally without redeploying.

Configurable via \`LOCAL_FRONTEND_ASSETS_DIR\`, \`LOCAL_FRONTEND_PORT\`, \`LOCAL_FRONTEND_HOST\`, \`LOCAL_FRONTEND_HTML_HANDLING\`.

## Mode 2 docker-compose service
New \`Dockerfile\` in this package. Wired into \`docker-compose.local.yml\` as \`miniflare-frontend\` (separate wrapper PR).

**Gotcha:** runtime is \`node:22-slim\` (debian), NOT alpine — Cloudflare's \`workerd\` binary is linked against glibc and crashes with \`symbol not found\` relocations on musl. Tested + documented.

The runtime stage also installs miniflare directly via \`npm init -y && npm install miniflare\` instead of inheriting the wrapper's lockfile — because the wrapper's lockfile pins the host's platform-specific workerd binary (e.g. \`@cloudflare/workerd-darwin-arm64\` for a Mac dev), which is wrong for a linux container.

## Test plan
- [x] \`npm test\` — 24/24 ✓ (14 unit + 10 Miniflare)
- [x] \`npm run dev:serve\` locally — \`curl /\`, \`/some/deep/route\`, \`/about\` all 200
- [x] \`docker compose up -d miniflare-frontend\` from wrapper — same probes pass against the containerized service
- [x] \`npm run build\` clean

## Out of scope
- No worker behavior change.
- No docker-compose entry yet (lands in the wrapper PR that bumps this submodule).