### PR TITLE
feat(static-frontend-worker): _redirects E2E local + CF Pages precedence

### DIFF
--- a/packages/static-frontend-worker/scripts/local-server.mjs
+++ b/packages/static-frontend-worker/scripts/local-server.mjs
@@ -21,6 +21,7 @@ import { Miniflare } from 'miniflare';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { parseRedirects } from '../dist/redirects-parser.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(here, '..');
@@ -49,11 +50,31 @@ const htmlHandling =
     process.env.LOCAL_FRONTEND_HTML_HANDLING || 'auto-trailing-slash'
   );
 
+// Auto-parse `_redirects` from the assets dir if present. Mirrors what
+// control-api does at deploy time (see services/control-api/src/services/
+// deployment.service.ts:deployViaWfp) so the local dev experience matches
+// production.
+let redirectsRulesJson = '';
+const redirectsPath = join(assetsDir, '_redirects');
+if (existsSync(redirectsPath)) {
+  const text = readFileSync(redirectsPath, 'utf8');
+  const { rules, warnings } = parseRedirects(text);
+  for (const w of warnings) console.warn(`[local-server] _redirects: ${w}`);
+  if (rules.length > 0) {
+    redirectsRulesJson = JSON.stringify(rules);
+  }
+}
+
 const mf = new Miniflare({
   modules: true,
   script: workerSource,
   host,
   port,
+  // BB_REDIRECTS_RULES is a plain_text binding in prod; mirror that exactly so
+  // the worker reads it the same way locally.
+  bindings: redirectsRulesJson
+    ? { BB_REDIRECTS_RULES: redirectsRulesJson }
+    : {},
   assets: {
     directory: assetsDir,
     binding: 'ASSETS',
@@ -77,6 +98,12 @@ console.log(`[local-server] static-frontend-worker ready`);
 console.log(`[local-server]   listening:    http://${host}:${port}`);
 console.log(`[local-server]   assets dir:   ${assetsDir}`);
 console.log(`[local-server]   html_handling: ${htmlHandling}`);
+if (redirectsRulesJson) {
+  const ruleCount = JSON.parse(redirectsRulesJson).length;
+  console.log(`[local-server]   _redirects:   ${ruleCount} rule(s) loaded`);
+} else {
+  console.log(`[local-server]   _redirects:   (none)`);
+}
 console.log(`[local-server] try:`);
 console.log(`[local-server]   curl -sI http://localhost:${port}/                  # 200 + text/html`);
 console.log(`[local-server]   curl -sI http://localhost:${port}/some/deep/route   # 200 (SPA fallback)`);

--- a/packages/static-frontend-worker/src/worker.miniflare.test.ts
+++ b/packages/static-frontend-worker/src/worker.miniflare.test.ts
@@ -156,3 +156,105 @@ describe('static-frontend-worker via Miniflare (real workerd)', () => {
     });
   });
 });
+
+// Second Miniflare instance with a BB_REDIRECTS_RULES binding configured.
+// Validates the END-TO-END rule application path against real workerd,
+// not the hand-mocked env.ASSETS in worker.test.ts.
+describe('static-frontend-worker rule application via Miniflare', () => {
+  let mfRules: Miniflare;
+  let baseUrlRules: URL;
+  let rulesAssetsDir: string;
+
+  const NEW_BODY = '<!doctype html><h1>NEW</h1>';
+  const V2_USERS_BODY = '<!doctype html><h1>V2 USERS</h1>';
+  const RULES = [
+    { from: '/old', to: '/new.html', status: 301 },
+    { from: '/api/*', to: '/v2/:splat', status: 200 },
+    { from: '/go-google', to: 'https://google.com', status: 302 },
+    { from: '/*', to: '/index.html', status: 200 },
+  ];
+
+  beforeAll(async () => {
+    const workerSource = readFileSync(workerJsPath, 'utf8');
+
+    rulesAssetsDir = mkdtempSync(join(tmpdir(), 'bb-mf-rules-'));
+    writeFileSync(join(rulesAssetsDir, 'index.html'), INDEX_BODY);
+    writeFileSync(join(rulesAssetsDir, 'new.html'), NEW_BODY);
+    mkdirSync(join(rulesAssetsDir, 'v2'), { recursive: true });
+    writeFileSync(join(rulesAssetsDir, 'v2', 'users.html'), V2_USERS_BODY);
+
+    mfRules = new Miniflare({
+      modules: true,
+      script: workerSource,
+      host: '127.0.0.1',
+      port: 0,
+      bindings: { BB_REDIRECTS_RULES: JSON.stringify(RULES) },
+      assets: {
+        directory: rulesAssetsDir,
+        binding: 'ASSETS',
+        assetConfig: { html_handling: 'auto-trailing-slash' },
+        routerConfig: {
+          has_user_worker: true,
+          invoke_user_worker_ahead_of_assets: true,
+        },
+      },
+    });
+    baseUrlRules = await mfRules.ready;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (mfRules) await mfRules.dispose();
+    if (rulesAssetsDir) rmSync(rulesAssetsDir, { recursive: true, force: true });
+  });
+
+  async function getRules(path: string): Promise<Response> {
+    return await mfRules.dispatchFetch(new URL(path, baseUrlRules).toString(), {
+      redirect: 'manual',
+    });
+  }
+
+  it('applies a 301 redirect: /old → 301 Location: /new.html', async () => {
+    const res = await getRules('/old');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe(
+      new URL('/new.html', baseUrlRules).toString(),
+    );
+  });
+
+  it('applies a 200 rewrite with :splat substitution: /api/users.html serves /v2/users.html content', async () => {
+    const res = await getRules('/api/users.html');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(V2_USERS_BODY);
+  });
+
+  it('applies a 302 redirect to an external URL: /go-google → 302 https://google.com', async () => {
+    const res = await getRules('/go-google');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://google.com');
+  });
+
+  it('catch-all SPA rule /* → /index.html serves home for unmatched deep paths', async () => {
+    const res = await getRules('/some/deep/route');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
+
+  it('catch-all SPA rule still routes the exact home path to index', async () => {
+    const res = await getRules('/');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
+
+  it('first match wins: /old → redirect (not the /* SPA rule)', async () => {
+    const res = await getRules('/old');
+    expect(res.status).toBe(301);
+    // If the SPA rule had won we would get 200 + INDEX_BODY.
+  });
+
+  it('first match wins: /api/users.html → rewrite (not the /* SPA rule)', async () => {
+    const res = await getRules('/api/users.html');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(V2_USERS_BODY);
+    // If the SPA rule had won we would get INDEX_BODY.
+  });
+});

--- a/packages/static-frontend-worker/src/worker.miniflare.test.ts
+++ b/packages/static-frontend-worker/src/worker.miniflare.test.ts
@@ -257,4 +257,24 @@ describe('static-frontend-worker rule application via Miniflare', () => {
     expect(await res.text()).toBe(V2_USERS_BODY);
     // If the SPA rule had won we would get INDEX_BODY.
   });
+
+  // CF Pages-compatible precedence: real assets win over 200 rewrites.
+  // /new.html exists as a real file. The /* SPA rule MUST NOT swallow it.
+  // Under html_handling: 'auto-trailing-slash', an existing .html file is
+  // 307-redirected to its canonical extensionless form (this is CF Pages's
+  // documented URL canonicalization). The worker forwards that 307 so the
+  // browser ends up at /new with the real file content.
+  it('real asset wins over /* SPA rewrite: /new.html → canonical 307 to /new', async () => {
+    const res = await getRules('/new.html');
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('/new');
+    // If the /* rule had won we would get a 200 with INDEX_BODY.
+  });
+
+  it('the canonical /new path serves the actual file (not the /* SPA fallback)', async () => {
+    const res = await getRules('/new');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(NEW_BODY);
+    // If the /* rule had won we would get INDEX_BODY.
+  });
 });

--- a/packages/static-frontend-worker/src/worker.test.ts
+++ b/packages/static-frontend-worker/src/worker.test.ts
@@ -265,7 +265,7 @@ describe('static-frontend-worker', () => {
   });
 
   describe('_redirects rule application (BB_REDIRECTS_RULES binding)', () => {
-    it('applies a 200 rewrite rule (serves target content under the original URL)', async () => {
+    it('applies a 200 rewrite rule on asset miss (serves target content under the original URL)', async () => {
       const indexBody = '<html>HOME</html>';
       const { env, calls } = makeAssetsEnv(
         { '/': () => htmlResponse(indexBody) },
@@ -278,9 +278,9 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(indexBody);
-      // The rewrite target /index.html is special-cased to fetch / instead
-      // (to escape the html_handling 307 trap). No call to /history.
-      expect(calls).toEqual(['/']);
+      // CF Pages-compatible precedence: asset lookup first (returns 404),
+      // then 200 rewrite applies. Rewrite target /index.html normalizes to /.
+      expect(calls).toEqual(['/history', '/']);
     });
 
     it('applies a 301 redirect rule (returns Location header, does NOT fetch target)', async () => {
@@ -299,31 +299,25 @@ describe('static-frontend-worker', () => {
       expect(calls).toEqual([]);
     });
 
-    it('first match wins (preserves rule order)', async () => {
-      const indexBody = '<html>HOME</html>';
-      const aboutBody = '<html>ABOUT</html>';
-      // Mock both /about (normalized) and /about.html (original) since the
-      // worker normalizes .html rewrite targets to escape the html_handling
-      // 307 trap. Either should serve, but the worker will fetch /about.
+    it('first match wins for 3xx rules (preserves rule order)', async () => {
+      // 3xx rules fire BEFORE asset lookup, so first-match-wins is observable
+      // even when an asset would match. With 200 rules, asset wins over rule,
+      // so testing rule ordering must use 3xx.
       const { env, calls } = makeAssetsEnv(
-        {
-          '/': () => htmlResponse(indexBody),
-          '/about': () => htmlResponse(aboutBody),
-        },
+        {},
         404,
         JSON.stringify([
-          { from: '/about', to: '/about.html', status: 200 },
-          { from: '/*', to: '/index.html', status: 200 },
+          { from: '/foo', to: '/specific', status: 301 },
+          { from: '/*', to: '/catchall', status: 301 },
         ]),
       );
       const res = await worker.fetch(
-        new Request('https://app.example.com/about'),
+        new Request('https://app.example.com/foo'),
         env,
       );
-      expect(res.status).toBe(200);
-      expect(await res.text()).toBe(aboutBody);
-      // Worker should have normalized /about.html → /about. No call to /index.html.
-      expect(calls).toEqual(['/about']);
+      expect(res.status).toBe(301);
+      expect(res.headers.get('location')).toBe('https://app.example.com/specific');
+      expect(calls).toEqual([]);
     });
 
     it('substitutes :splat in the rewrite target', async () => {
@@ -337,7 +331,8 @@ describe('static-frontend-worker', () => {
         env,
       );
       expect(res.status).toBe(200);
-      expect(calls).toEqual(['/v2/users/42']);
+      // Asset lookup for /api/users/42 first (misses), then rewrite to /v2/users/42.
+      expect(calls).toEqual(['/api/users/42', '/v2/users/42']);
     });
 
     it('substitutes :splat in the redirect target', async () => {
@@ -413,6 +408,63 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(indexBody);
+    });
+
+    describe('CF Pages-compatible precedence (assets vs rules)', () => {
+      it('3xx rule fires even when the requested path is a real asset (rule wins)', async () => {
+        const { env, calls } = makeAssetsEnv(
+          { '/old': () => htmlResponse('<html>existing file</html>') },
+          404,
+          JSON.stringify([{ from: '/old', to: '/new', status: 301 }]),
+        );
+        const res = await worker.fetch(
+          new Request('https://app.example.com/old'),
+          env,
+        );
+        expect(res.status).toBe(301);
+        expect(res.headers.get('location')).toBe('https://app.example.com/new');
+        // Asset must not be consulted — the 3xx rule preempts the lookup.
+        expect(calls).toEqual([]);
+      });
+
+      it('200 rewrite does NOT fire when the requested path is a real asset (asset wins)', async () => {
+        // Catch-all SPA rule would otherwise rewrite EVERY path to /index.html.
+        // With CF Pages precedence, real assets are served unchanged.
+        const assetBody = '<html>real file</html>';
+        const indexBody = '<html>HOME</html>';
+        const { env, calls } = makeAssetsEnv(
+          {
+            '/new.html': () => htmlResponse(assetBody),
+            '/': () => htmlResponse(indexBody),
+          },
+          404,
+          JSON.stringify([{ from: '/*', to: '/index.html', status: 200 }]),
+        );
+        const res = await worker.fetch(
+          new Request('https://app.example.com/new.html'),
+          env,
+        );
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(assetBody);
+        // Asset served directly. No rewrite applied.
+        expect(calls).toEqual(['/new.html']);
+      });
+
+      it('200 rewrite fires when the requested path is NOT a real asset (rule fallback)', async () => {
+        const indexBody = '<html>HOME</html>';
+        const { env, calls } = makeAssetsEnv(
+          { '/': () => htmlResponse(indexBody) },
+          404,
+          JSON.stringify([{ from: '/*', to: '/index.html', status: 200 }]),
+        );
+        const res = await worker.fetch(
+          new Request('https://app.example.com/missing'),
+          env,
+        );
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(indexBody);
+        expect(calls).toEqual(['/missing', '/']);
+      });
     });
 
     it('discards rule entries with wrong shape and serves with remaining valid rules', async () => {

--- a/packages/static-frontend-worker/src/worker.test.ts
+++ b/packages/static-frontend-worker/src/worker.test.ts
@@ -302,10 +302,13 @@ describe('static-frontend-worker', () => {
     it('first match wins (preserves rule order)', async () => {
       const indexBody = '<html>HOME</html>';
       const aboutBody = '<html>ABOUT</html>';
-      const { env } = makeAssetsEnv(
+      // Mock both /about (normalized) and /about.html (original) since the
+      // worker normalizes .html rewrite targets to escape the html_handling
+      // 307 trap. Either should serve, but the worker will fetch /about.
+      const { env, calls } = makeAssetsEnv(
         {
           '/': () => htmlResponse(indexBody),
-          '/about.html': () => htmlResponse(aboutBody),
+          '/about': () => htmlResponse(aboutBody),
         },
         404,
         JSON.stringify([
@@ -319,6 +322,8 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(aboutBody);
+      // Worker should have normalized /about.html → /about. No call to /index.html.
+      expect(calls).toEqual(['/about']);
     });
 
     it('substitutes :splat in the rewrite target', async () => {

--- a/packages/static-frontend-worker/src/worker.ts
+++ b/packages/static-frontend-worker/src/worker.ts
@@ -90,6 +90,26 @@ function loadRules(env: Env): RedirectRule[] {
   return cachedRules;
 }
 
+// Translate a rewrite target to the form Assets actually serves with 200 under
+// `html_handling: 'auto-trailing-slash'`. The Assets binding 307-redirects any
+// .html path to its canonical extensionless form; if a rewrite asks for
+// /foo.html and we forward Assets's 307, the rewrite is broken (client sees
+// the 307). Normalizing here means the worker fetches the form Assets returns
+// 200 for, and we serve that content under the original request URL.
+function normalizeRewriteTarget(target: string): string {
+  // Don't rewrite cross-origin targets (e.g. external URLs that snuck into a
+  // 200 rule — though those are nonsensical, defend in depth).
+  if (/^https?:\/\//i.test(target)) return target;
+  if (target.endsWith('/index.html')) {
+    // /foo/index.html → /foo/   ;   /index.html → /
+    return target.slice(0, -'index.html'.length);
+  }
+  if (target.endsWith('.html')) {
+    return target.slice(0, -'.html'.length);
+  }
+  return target;
+}
+
 function matchRule(path: string, rule: RedirectRule): string | null {
   if (rule.from.endsWith('/*')) {
     const prefix = rule.from.slice(0, -2);
@@ -187,11 +207,14 @@ const handler = {
             );
           }
           // 200 rewrite: fetch target from assets under the original URL.
-          // Special case: a rewrite to `/index.html` retargets to `/` because
-          // `html_handling: 'auto-trailing-slash'` returns a 307 → / for
-          // `/index.html` itself, which would defeat the rewrite. Fetching
-          // `/` serves the same content via the trailing-slash resolution.
-          const fetchPath = target === '/index.html' ? '/' : target;
+          // `html_handling: 'auto-trailing-slash'` canonicalizes any .html
+          // path away: `/foo.html` → 307 `/foo`, `/foo/index.html` → 307
+          // `/foo/`, `/index.html` → 307 `/`. Fetching the .html target
+          // literally would defeat the rewrite (the worker would return the
+          // 307 to the client). Strip .html / .../index.html so the resolved
+          // path round-trips through Assets's trailing-slash resolution and
+          // returns 200 with the file content.
+          const fetchPath = normalizeRewriteTarget(target);
           const fetchUrl = new URL(fetchPath, url);
           const rewritten = await env.ASSETS.fetch(
             new Request(fetchUrl.toString(), request),

--- a/packages/static-frontend-worker/src/worker.ts
+++ b/packages/static-frontend-worker/src/worker.ts
@@ -110,6 +110,39 @@ function normalizeRewriteTarget(target: string): string {
   return target;
 }
 
+// Decide whether an Assets binding response represents a "miss" (no file at
+// the requested path) vs a hit. Hits include both literal 2xx responses AND
+// canonical 3xx redirects that `html_handling: 'auto-trailing-slash'` issues
+// for existing .html / index.html files:
+//
+//   /foo.html        → 307 Location: /foo            (canonical, asset exists)
+//   /foo/index.html  → 307 Location: /foo/           (canonical, asset exists)
+//   /index.html      → 307 Location: /               (canonical, asset exists)
+//   /missing.html    → 404                            (true miss)
+//   /missing         → 307 Location: /   (WfP only)   (miss-fallback)
+//
+// We distinguish hit-vs-miss for 3xx responses by comparing the actual
+// Location header to the expected canonical form of the requested path. Any
+// 3xx whose Location does NOT match the canonical form is a miss-fallback
+// (the WfP dispatch-namespace quirk PR #33 worked around).
+function looksLikeAssetMiss(res: Response, requestPath: string): boolean {
+  if (res.status === 404) return true;
+  if (res.status >= 300 && res.status < 400) {
+    const loc = res.headers.get('location') ?? '';
+    let expectedCanonical: string | null = null;
+    if (requestPath.endsWith('/index.html')) {
+      expectedCanonical = requestPath.slice(0, -'index.html'.length);
+    } else if (requestPath.endsWith('.html')) {
+      expectedCanonical = requestPath.slice(0, -'.html'.length);
+    }
+    if (expectedCanonical !== null && loc === expectedCanonical) {
+      return false; // canonical redirect = asset exists
+    }
+    return true; // miss-fallback redirect
+  }
+  return false; // 2xx — asset hit
+}
+
 function matchRule(path: string, rule: RedirectRule): string | null {
   if (rule.from.endsWith('/*')) {
     const prefix = rule.from.slice(0, -2);
@@ -192,42 +225,53 @@ const handler = {
     try {
       const url = new URL(request.url);
       const rules = loadRules(env);
+      const match = rules.length > 0 ? findMatch(url.pathname, rules) : null;
 
-      // Apply _redirects rules BEFORE the asset lookup. First match wins.
-      // Status 200 = internal rewrite (fetch the target, return its content
-      // under the original URL). 3xx = client-visible redirect.
-      if (rules.length > 0) {
-        const match = findMatch(url.pathname, rules);
-        if (match) {
-          const target = match.resolvedTo;
-          if (match.rule.status >= 300 && match.rule.status < 400) {
-            return Response.redirect(
-              new URL(target, url).toString(),
-              match.rule.status,
-            );
-          }
-          // 200 rewrite: fetch target from assets under the original URL.
-          // `html_handling: 'auto-trailing-slash'` canonicalizes any .html
-          // path away: `/foo.html` → 307 `/foo`, `/foo/index.html` → 307
-          // `/foo/`, `/index.html` → 307 `/`. Fetching the .html target
-          // literally would defeat the rewrite (the worker would return the
-          // 307 to the client). Strip .html / .../index.html so the resolved
-          // path round-trips through Assets's trailing-slash resolution and
-          // returns 200 with the file content.
-          const fetchPath = normalizeRewriteTarget(target);
-          const fetchUrl = new URL(fetchPath, url);
-          const rewritten = await env.ASSETS.fetch(
-            new Request(fetchUrl.toString(), request),
-          );
-          return withMime(new Request(fetchUrl.toString()), rewritten);
-        }
+      // Cloudflare Pages-compatible precedence:
+      //   1. 3xx redirect rules ALWAYS win, even if the path is a real file.
+      //      (`/old /new 301` fires even when /old exists.)
+      //   2. Real assets win over 200 rewrites — try the asset binding next.
+      //      A 200 rewrite is a fallback that only fires on asset miss.
+      //   3. 200 rewrites apply only after the asset lookup misses.
+      //   4. No rule + asset miss → preserve PR #33 SPA fallback to `/`
+      //      (this is the default behavior for apps that don't ship a
+      //      _redirects file; keeping it ensures purely-additive semantics).
+
+      // (1) 3xx redirects: fire unconditionally.
+      if (match && match.rule.status >= 300 && match.rule.status < 400) {
+        return Response.redirect(
+          new URL(match.resolvedTo, url).toString(),
+          match.rule.status,
+        );
       }
 
-      // No matching rule (or no rules at all) → original behavior: direct
-      // asset lookup, with SPA fallback to `/` on non-2xx. This preserves the
-      // PR #33 fix for apps that don't ship a `_redirects` file.
+      // (2) Asset lookup. If the asset exists, serve it — real files win
+      // over 200 rewrites (matches Cloudflare Pages behavior). "Exists"
+      // includes canonical 3xx redirects that html_handling issues for
+      // existing .html / index.html files; those are forwarded so the
+      // browser sees the canonical URL (the documented CF Pages behavior).
       const res = await env.ASSETS.fetch(request);
-      if (res.ok) return withMime(request, res);
+      if (!looksLikeAssetMiss(res, url.pathname)) return withMime(request, res);
+
+      // (3) Asset miss + 200 rewrite matched → apply rewrite.
+      // `html_handling: 'auto-trailing-slash'` canonicalizes any .html path
+      // away: /foo.html → 307 /foo, /foo/index.html → 307 /foo/, /index.html
+      // → 307 /. Fetching the .html target literally would defeat the
+      // rewrite (the worker would forward the 307). normalizeRewriteTarget
+      // strips .html / index.html so the resolved path round-trips through
+      // Assets's trailing-slash resolution and returns 200.
+      if (match && match.rule.status === 200) {
+        const fetchPath = normalizeRewriteTarget(match.resolvedTo);
+        const fetchUrl = new URL(fetchPath, url);
+        const rewritten = await env.ASSETS.fetch(
+          new Request(fetchUrl.toString(), request),
+        );
+        return withMime(new Request(fetchUrl.toString()), rewritten);
+      }
+
+      // (4) No matching rule and asset miss → default SPA fallback to `/`.
+      // Preserves the PR #33 fix for apps that don't ship a `_redirects`
+      // file (and for apps that ship one without a catch-all).
       const fallbackUrl = new URL(request.url);
       fallbackUrl.pathname = '/';
       const fallback = await env.ASSETS.fetch(


### PR DESCRIPTION
## Summary
Two related changes from end-to-end testing of PR #38:

1. **`local-server.mjs` auto-parses `_redirects`** — so the local Miniflare dev container matches prod behavior. Drop a real SPA dist into the mounted dir and rules are honored locally with no manual env-var plumbing.
2. **Cloudflare Pages-compatible `_redirects` precedence** — assets now win over 200 rewrites, but 3xx redirects still win over assets. PR #38's "rules first" was simpler but incompatible with how every existing CF Pages user expects `_redirects` to behave.
3. **`.html` rewrite normalization broadened** — the worker handles `/foo.html` and `/foo/index.html` the same way it handled `/index.html` (escape the html_handling 307 trap on rewrite targets).

## CF Pages precedence (the key behavior shift)

| Scenario | Old | New |
|---|---|---|
| `/old /new 301` + `/old` exists as a file | 301 (rule wins) | 301 (rule wins) — unchanged |
| `/* /index.html 200` + `/new.html` exists as a file | HOME (catch-all swallowed it) | **307 to `/new` then NEW_BODY** (asset wins) |
| `/* /index.html 200` + `/random` does NOT exist | HOME (rewrite) | HOME (rewrite) — unchanged |
| No rules + missing path | SPA fallback to `/` | SPA fallback to `/` — unchanged |

Implemented via `looksLikeAssetMiss(res, path)` that distinguishes canonical 3xx redirects (asset exists, html_handling canonicalizing the URL) from WfP miss-fallback 3xx redirects (Assets binding fallback when the path doesn't exist). Documented inline.

## `local-server.mjs` changes

Auto-loads `_redirects` from the assets dir at startup, parses via `parseRedirects` (same code as control-api at deploy time), binds the rule table as `BB_REDIRECTS_RULES`. Startup log reports rule count:
\`\`\`
[local-server]   _redirects:   4 rule(s) loaded
\`\`\`

## End-to-end verification

Built a test fixture dist with:
\`\`\`
/_redirects:
  /old        /new.html              301
  /api/*      /v2/:splat             200
  /go-google  https://google.com     302
  /*          /index.html            200
\`\`\`

Mounted into `miniflare-frontend` via `docker run -v`. Curl results:

| Probe | Result |
|---|---|
| `/old` | 301 → /new.html ✓ |
| `/new.html` | **307 → /new (CF canonical, no longer swallowed)** ✓ |
| `/new` | 200 NEW PAGE ✓ |
| `/api/users.html` | 200 V2 USERS (rewrite via splat) ✓ |
| `/api/users` | 200 V2 USERS (rewrite + canonical) ✓ |
| `/go-google` | 302 → https://google.com ✓ |
| `/random/deep/route` | 200 HOME (SPA fallback) ✓ |
| `/` | 200 HOME ✓ |

7/7 — the critical `/new.html` case (the one that triggered this PR) now serves correctly.

## Tests
- `npm test`: **79/79** (31 worker unit + 29 parser + 19 Miniflare integration)
- Built and verified via `docker compose -f docker-compose.local.yml build miniflare-frontend` + run with test fixture

## Out of scope
- `html_handling: 'none'` switch (PR 5) — would eliminate the `looksLikeAssetMiss` heuristic entirely by removing the auto-canonicalization that requires it.
- The duplicate MIME map in worker.ts (dispatch-worker already re-applies Content-Type) — separate cleanup.