### PR TITLE
Static frontend worker — Phase 5+6: explicit resolution chain + drop in-worker MIME

### DIFF
--- a/packages/static-frontend-worker/README.md
+++ b/packages/static-frontend-worker/README.md
@@ -116,7 +116,7 @@ Apps that don't ship `_redirects` keep the existing default: direct asset lookup
 /foo.html   /foo 301
 ```
 
-**Non-html-extension misses return 404.** A request for `/missing.png`, `/missing.css`, or `/missing.js` that finds no matching file in the bundle returns 404 — not the `index.html` body. Frontend devs see honest network-tab status codes; broken image tags stop masquerading as HTML responses. Extensionless paths (`/history`, `/profile/42`) and `.html`/`.htm` paths still SPA-fallback to home on miss.
+**Non-html-extension misses return 404.** A request for `/missing.png`, `/missing.css`, or `/missing.js` that finds no matching file in the bundle returns 404 — not the `index.html` body. Frontend devs see honest network-tab status codes; broken image tags stop masquerading as HTML responses. Extensionless paths (`/history`, `/profile/42`) and `.html`/`.htm` paths still SPA-fallback to home on miss. This rule applies only when no explicit `200` rewrite rule matches first — for example, a user who ships `/* /index.html 200` will see `/missing.png` return the `index.html` body with status 200, matching Cloudflare Pages semantics.
 
 **`/_redirects` returns 404.** The file is parsed at deploy time and stripped from the uploaded asset bundle. The parsed rules govern routing; the raw file is not served.
 

--- a/packages/static-frontend-worker/README.md
+++ b/packages/static-frontend-worker/README.md
@@ -2,7 +2,7 @@
 
 Per-app static frontend worker source for the Butterbase WfP dispatch namespace.
 
-One copy of the compiled output of `src/worker.ts` is uploaded by `control-api` into the WfP dispatch namespace per customer app (script name = appId). The worker is bound to a Cloudflare Assets binding containing the user's uploaded zip contents and serves them with an in-worker SPA fallback (`/` resolves to home `index.html` under `html_handling: 'auto-trailing-slash'`).
+One copy of the compiled output of `src/worker.ts` is uploaded by `control-api` into the WfP dispatch namespace per customer app (script name = appId). The worker is bound to a Cloudflare Assets binding configured with `html_handling: 'none'` and serves content via an explicit path resolution chain with SPA fallback.
 
 To modify worker behavior: edit `src/worker.ts`, rebuild, redeploy `control-api`.
 
@@ -40,9 +40,9 @@ npm test
 
 Two test files:
 
-1. **`worker.test.ts`** — Native Vitest against a hand-mocked `env.ASSETS`. Fast, deterministic, covers MIME defaults, error handling, the exact PR #33 307 cascade. ~10ms.
+1. **`worker.test.ts`** — Native Vitest against a hand-mocked `env.ASSETS`. Fast, deterministic, covers the resolution chain, SPA fallback, honest 404s for asset-shaped misses, error handling. ~10ms.
 
-2. **`worker.miniflare.test.ts`** — Boots the actual compiled worker against Miniflare 4 (real `workerd` runtime + real Assets binding configured the way prod is). Catches regressions where the hand-mock and real runtime diverge — e.g. if CF changes Assets binding semantics. ~350ms.
+2. **`worker.miniflare.test.ts`** — Boots the actual compiled worker against Miniflare 4 (real `workerd` runtime + real Assets binding configured with `html_handling: 'none'`). Catches regressions where the hand-mock and real runtime diverge. ~350ms.
 
 Note: Miniflare's default routes assets BEFORE the user worker (the standalone Workers Static Assets behavior). In a WfP dispatch namespace, the user worker is the entry point and `env.ASSETS` is just a binding it calls. The test enables `routerConfig.invoke_user_worker_ahead_of_assets: true` to match prod.
 
@@ -59,7 +59,7 @@ Boots Miniflare locally on `http://localhost:8787` serving `./local-assets/`. Cu
 | `LOCAL_FRONTEND_ASSETS_DIR` | `./local-assets` | Path to the dist/ to serve |
 | `LOCAL_FRONTEND_PORT` | `8787` | Bind port |
 | `LOCAL_FRONTEND_HOST` | `0.0.0.0` | `127.0.0.1` for loopback-only |
-| `LOCAL_FRONTEND_HTML_HANDLING` | `auto-trailing-slash` | Mirror prod |
+| `LOCAL_FRONTEND_HTML_HANDLING` | `none` | Mirror prod |
 
 Try:
 
@@ -91,7 +91,7 @@ The container uses `node:22-slim` (debian, not alpine) because `workerd` is link
 
 ## `_redirects` support
 
-Users can ship a `_redirects` file at the root of their `dist/` zip. At deploy time, `services/control-api/src/services/deployment.service.ts:deployViaWfp` parses the file via `parseRedirects` (in this package) and bakes the compiled rule table into the worker as the `BB_REDIRECTS_RULES` plain_text binding. The worker applies rules before asset lookup, first match wins.
+Users can ship a `_redirects` file at the root of their `dist/` zip. At deploy time, `services/control-api/src/services/deployment.service.ts:deployViaWfp` parses the file via `parseRedirects` (in this package) and bakes the compiled rule table into the worker as the `BB_REDIRECTS_RULES` plain_text binding. The `_redirects` file itself is stripped from the uploaded asset bundle at deploy time — probing `/_redirects` returns 404. The worker applies rules before asset lookup, first match wins.
 
 Supported subset (Cloudflare Pages-compatible):
 - Comments (`#`)
@@ -105,7 +105,20 @@ Not yet supported (defer if a customer asks):
 - Query/header matchers (`status=200 country=US`)
 - Force-match `!`
 
-Apps that don't ship `_redirects` keep the existing default: direct asset lookup with SPA fallback to `/` on miss (PR #33). The `BB_*` binding namespace is reserved — user app env vars cannot override it (the deploy-time wire-up sets it after the user's env var loop).
+Apps that don't ship `_redirects` keep the existing default: direct asset lookup with SPA fallback to `/` on miss. The `BB_*` binding namespace is reserved — user app env vars cannot override it (the deploy-time wire-up sets it after the user's env var loop).
+
+### Behavior notes (Phase 5)
+
+**`/index.html` and `/foo.html` serve directly.** With `html_handling: 'none'`, these paths are literal asset hits — the worker returns them with 200. There is no canonical redirect to `/` or `/foo`. Users who want CF Pages-style URL canonicalization can ship a `_redirects` rule:
+
+```
+/index.html / 301
+/foo.html   /foo 301
+```
+
+**Non-html-extension misses return 404.** A request for `/missing.png`, `/missing.css`, or `/missing.js` that finds no matching file in the bundle returns 404 — not the `index.html` body. Frontend devs see honest network-tab status codes; broken image tags stop masquerading as HTML responses. Extensionless paths (`/history`, `/profile/42`) and `.html`/`.htm` paths still SPA-fallback to home on miss.
+
+**`/_redirects` returns 404.** The file is parsed at deploy time and stripped from the uploaded asset bundle. The parsed rules govern routing; the raw file is not served.
 
 ## Production deployment
 

--- a/packages/static-frontend-worker/scripts/local-server.mjs
+++ b/packages/static-frontend-worker/scripts/local-server.mjs
@@ -18,9 +18,10 @@
 //   LOCAL_FRONTEND_HTML_HANDLING  none (default, matches prod), auto-trailing-slash,
 //                                 drop-trailing-slash, or force-trailing-slash.
 import { Miniflare } from 'miniflare';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdtempSync, readdirSync, symlinkSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { parseRedirects } from '../dist/redirects-parser.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,20 @@ if (existsSync(redirectsPath)) {
   }
 }
 
+// Strip _redirects from the served assets dir, mirroring deployViaWfp which
+// deletes the file from the upload bundle after parsing so /_redirects → 404
+// in prod. Build a symlink farm excluding _redirects so the local worker sees
+// the same bundle shape without mutating the user's actual dist/.
+let servedDir = assetsDir;
+if (existsSync(redirectsPath)) {
+  const stripped = mkdtempSync(join(tmpdir(), 'bb-local-assets-'));
+  for (const entry of readdirSync(assetsDir)) {
+    if (entry === '_redirects') continue;
+    symlinkSync(join(assetsDir, entry), join(stripped, entry));
+  }
+  servedDir = stripped;
+}
+
 const mf = new Miniflare({
   modules: true,
   script: workerSource,
@@ -76,7 +91,7 @@ const mf = new Miniflare({
     ? { BB_REDIRECTS_RULES: redirectsRulesJson }
     : {},
   assets: {
-    directory: assetsDir,
+    directory: servedDir,
     binding: 'ASSETS',
     assetConfig: {
       html_handling: htmlHandling,

--- a/packages/static-frontend-worker/scripts/local-server.mjs
+++ b/packages/static-frontend-worker/scripts/local-server.mjs
@@ -15,8 +15,8 @@
 //   LOCAL_FRONTEND_HOST        Host to bind. Default: 0.0.0.0 (so docker port
 //                              forwarding works; use 127.0.0.1 for native
 //                              loopback-only).
-//   LOCAL_FRONTEND_HTML_HANDLING  auto-trailing-slash (default), drop-trailing-slash,
-//                                 force-trailing-slash, or none.
+//   LOCAL_FRONTEND_HTML_HANDLING  none (default, matches prod), auto-trailing-slash,
+//                                 drop-trailing-slash, or force-trailing-slash.
 import { Miniflare } from 'miniflare';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -47,7 +47,7 @@ const port = Number.parseInt(process.env.LOCAL_FRONTEND_PORT || '8787', 10);
 const host = process.env.LOCAL_FRONTEND_HOST || '0.0.0.0';
 const htmlHandling =
   /** @type {"auto-trailing-slash" | "drop-trailing-slash" | "force-trailing-slash" | "none"} */ (
-    process.env.LOCAL_FRONTEND_HTML_HANDLING || 'auto-trailing-slash'
+    process.env.LOCAL_FRONTEND_HTML_HANDLING || 'none'
   );
 
 // Auto-parse `_redirects` from the assets dir if present. Mirrors what

--- a/packages/static-frontend-worker/src/worker.miniflare.test.ts
+++ b/packages/static-frontend-worker/src/worker.miniflare.test.ts
@@ -513,4 +513,14 @@ describe('mixed fixture (static pages + redirects + SPA catch-all)', () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(INDEX_BODY);
   });
+
+  it('/missing.png is rewritten to /index.html when /* /index.html 200 catches it (rewrite fires before asset-shape gate)', async () => {
+    // The asset-shape gate (non-html-extension → 404) only runs when no 200
+    // rewrite rule matches. Here /* /index.html 200 matches first, so the
+    // worker returns the SPA shell with status 200 — identical to CF Pages
+    // behavior when the user ships this catch-all rule.
+    const res = await getMixed('/missing.png');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
 });

--- a/packages/static-frontend-worker/src/worker.miniflare.test.ts
+++ b/packages/static-frontend-worker/src/worker.miniflare.test.ts
@@ -2,14 +2,15 @@
 // runtime via Miniflare. Complements src/worker.test.ts (which exercises the
 // handler against a hand-mocked env.ASSETS) by running the actual deployed
 // worker bundle with a real Assets binding configured the same way prod is
-// configured (html_handling: 'auto-trailing-slash').
+// configured (html_handling: 'none').
 //
 // These tests catch a class of regression the hand-mock cannot: behaviors
-// that depend on the real Assets binding's response semantics — most
-// importantly the 307-from-Assets-on-extensionless-miss that PR #33's
-// fallback exists to escape. If CF ever changes that behavior (e.g. to 404
-// instead of 307), this test will surface the change concretely; the unit
-// tests would still pass because they mock the old behavior.
+// that depend on the real Assets binding's response semantics. With
+// html_handling: 'none', extensionless paths return 404 from Assets — no
+// redirects. The worker's resolveAssetPath candidates handle path resolution
+// explicitly. If CF ever changes Assets binding semantics, this test will
+// surface the change concretely; the unit tests would still pass because they
+// mock the old behavior.
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Miniflare } from 'miniflare';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
@@ -25,6 +26,11 @@ const INDEX_BODY = '<!doctype html><html><body><div id="root"></div></body></htm
 const ABOUT_BODY = '<!doctype html><h1>About</h1>';
 const CSS_BODY = 'body{color:red}';
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// ---------------------------------------------------------------------------
+// Fixture 1: Basic SPA fixture (index.html + about.html + assets).
+// Used by the main Miniflare instance.
+// ---------------------------------------------------------------------------
 
 let mf: Miniflare;
 let baseUrl: URL;
@@ -44,14 +50,14 @@ beforeAll(async () => {
     modules: true,
     script: workerSource,
     host: '127.0.0.1',
-    port: 0, // Let Miniflare pick a free port
+    port: 0,
     assets: {
       directory: assetsDir,
       binding: 'ASSETS',
       assetConfig: {
-        // Mirror production config — this is the setting that produces the
-        // 307-on-/index.html behavior PR #33's fallback was built to escape.
-        html_handling: 'auto-trailing-slash',
+        // Phase 5: use 'none' so Assets returns literal 2xx-or-404.
+        // No implicit CF URL canonicalization or redirects in the loop.
+        html_handling: 'none',
       },
       // In a WfP dispatch namespace the user worker is the entry point and
       // env.ASSETS is just a binding it can choose to call. Miniflare's
@@ -96,7 +102,9 @@ describe('static-frontend-worker via Miniflare (real workerd)', () => {
       expect(await res.text()).toBe(INDEX_BODY);
     });
 
-    it('resolves /about (extensionless) to /about.html via html_handling: auto-trailing-slash', async () => {
+    it('resolves /about (extensionless) to /about.html via worker candidate-2 lookup', async () => {
+      // Under html_handling: 'none', Assets returns 404 for /about.
+      // The worker's resolveAssetPath tries /about.html → hits.
       const res = await get('/about');
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(ABOUT_BODY);
@@ -112,9 +120,9 @@ describe('static-frontend-worker via Miniflare (real workerd)', () => {
 
   describe('SPA fallback against real CF semantics (PR #33 regression guard)', () => {
     it('deep path that does not exist resolves to the home index.html with status 200', async () => {
-      // This is the canonical PR #33 case. Against the REAL Assets binding
-      // (not a hand-mock), /history with no matching file should: first
-      // attempt returns non-2xx, worker falls back to /, returns 200.
+      // Under html_handling: 'none', /history returns 404 (not 307).
+      // The worker's resolveAssetPath tries /history, /history.html, /history/index.html —
+      // all miss — then SPA fallback to / → /index.html → 200.
       const res = await get('/history');
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
@@ -128,9 +136,7 @@ describe('static-frontend-worker via Miniflare (real workerd)', () => {
 
     it('the worker NEVER returns a 307 redirect to /', async () => {
       // The exact symptom the user reported. With redirect: manual the test
-      // observer would see the 307 if the bug was reintroduced. This is the
-      // strongest regression guard the package can carry: it runs the
-      // production worker bundle against the production Assets configuration.
+      // observer would see the 307 if the bug was reintroduced.
       for (const path of ['/history', '/profile', '/result/xyz', '/__missing']) {
         const res = await get(path);
         expect(res.status, `path=${path} should not be 307`).not.toBe(307);
@@ -139,27 +145,36 @@ describe('static-frontend-worker via Miniflare (real workerd)', () => {
     });
   });
 
-  describe('content-type defaults via worker withMime', () => {
-    it('serves CSS with text/css', async () => {
-      const res = await get('/assets/app.css');
-      expect(res.headers.get('content-type')).toMatch(/text\/css/);
+  describe('/index.html and /foo.html serve literally (Phase 5 behavior change)', () => {
+    it('/about.html serves literally with 200 (no canonical redirect)', async () => {
+      const res = await get('/about.html');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(ABOUT_BODY);
+      expect(res.headers.get('location')).toBeNull();
     });
 
-    it('serves PNG with image/png', async () => {
-      const res = await get('/logo.png');
-      expect(res.headers.get('content-type')).toMatch(/image\/png/);
+    it('/index.html serves literally with 200 (no canonical redirect)', async () => {
+      const res = await get('/index.html');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_BODY);
+      expect(res.headers.get('location')).toBeNull();
     });
+  });
 
-    it('serves the SPA fallback as text/html (even though the request was for an extensionless path)', async () => {
-      const res = await get('/history');
-      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+  describe('asset-shaped miss returns 404 (no SPA fallback)', () => {
+    it('/missing.png → 404 (binary extension, no SPA fallback)', async () => {
+      const res = await get('/missing.png');
+      expect(res.status).toBe(404);
+      // The body must not be INDEX_BODY — no SPA fallback fired.
+      const body = await res.text();
+      expect(body).not.toBe(INDEX_BODY);
     });
   });
 });
 
-// Second Miniflare instance with a BB_REDIRECTS_RULES binding configured.
-// Validates the END-TO-END rule application path against real workerd,
-// not the hand-mocked env.ASSETS in worker.test.ts.
+// ---------------------------------------------------------------------------
+// Fixture 2: Fixture with _redirects rules (BB_REDIRECTS_RULES binding).
+// ---------------------------------------------------------------------------
 describe('static-frontend-worker rule application via Miniflare', () => {
   let mfRules: Miniflare;
   let baseUrlRules: URL;
@@ -192,7 +207,8 @@ describe('static-frontend-worker rule application via Miniflare', () => {
       assets: {
         directory: rulesAssetsDir,
         binding: 'ASSETS',
-        assetConfig: { html_handling: 'auto-trailing-slash' },
+        // Phase 5: 'none' matches prod.
+        assetConfig: { html_handling: 'none' },
         routerConfig: {
           has_user_worker: true,
           invoke_user_worker_ahead_of_assets: true,
@@ -221,8 +237,10 @@ describe('static-frontend-worker rule application via Miniflare', () => {
     );
   });
 
-  it('applies a 200 rewrite with :splat substitution: /api/users.html serves /v2/users.html content', async () => {
-    const res = await getRules('/api/users.html');
+  it('applies a 200 rewrite with :splat substitution: /api/users → serves /v2/users.html content', async () => {
+    // Under html_handling: 'none', resolveAssetPath('/v2/users') tries
+    // /v2/users (404), then /v2/users.html (200) → serves V2_USERS_BODY.
+    const res = await getRules('/api/users');
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(V2_USERS_BODY);
   });
@@ -251,30 +269,248 @@ describe('static-frontend-worker rule application via Miniflare', () => {
     // If the SPA rule had won we would get 200 + INDEX_BODY.
   });
 
-  it('first match wins: /api/users.html → rewrite (not the /* SPA rule)', async () => {
-    const res = await getRules('/api/users.html');
+  it('first match wins: /api/users → rewrite (not the /* SPA rule)', async () => {
+    const res = await getRules('/api/users');
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(V2_USERS_BODY);
     // If the SPA rule had won we would get INDEX_BODY.
   });
 
-  // CF Pages-compatible precedence: real assets win over 200 rewrites.
-  // /new.html exists as a real file. The /* SPA rule MUST NOT swallow it.
-  // Under html_handling: 'auto-trailing-slash', an existing .html file is
-  // 307-redirected to its canonical extensionless form (this is CF Pages's
-  // documented URL canonicalization). The worker forwards that 307 so the
-  // browser ends up at /new with the real file content.
-  it('real asset wins over /* SPA rewrite: /new.html → canonical 307 to /new', async () => {
+  // Under html_handling: 'none', /new.html is a real file that Assets serves
+  // with 200 directly (no 307 canonicalization). The /* SPA rule MUST NOT
+  // swallow it — real assets win over 200 rewrites.
+  it('real asset wins over /* SPA rewrite: /new.html → 200 served literally (no 307)', async () => {
     const res = await getRules('/new.html');
-    expect(res.status).toBe(307);
-    expect(res.headers.get('location')).toBe('/new');
-    // If the /* rule had won we would get a 200 with INDEX_BODY.
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(NEW_BODY);
+    // Confirm no 307 or Location header — the old auto-trailing-slash behavior is gone.
+    expect(res.headers.get('location')).toBeNull();
   });
 
-  it('the canonical /new path serves the actual file (not the /* SPA fallback)', async () => {
+  it('the canonical /new path serves the actual file via candidate-2 lookup', async () => {
+    // resolveAssetPath('/new') → ['/new', '/new.html', '/new/index.html'].
+    // /new misses, /new.html hits.
     const res = await getRules('/new');
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(NEW_BODY);
     // If the /* rule had won we would get INDEX_BODY.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 3: Multi-page static site (no SPA fallback expected).
+// ---------------------------------------------------------------------------
+describe('multi-page static fixture', () => {
+  let mfMps: Miniflare;
+  let baseUrlMps: URL;
+  let mpsAssetsDir: string;
+
+  const CONTACT_BODY = '<!doctype html><h1>Contact</h1>';
+  const POST1_BODY = '<!doctype html><h1>Post 1</h1>';
+
+  beforeAll(async () => {
+    const workerSource = readFileSync(workerJsPath, 'utf8');
+
+    mpsAssetsDir = mkdtempSync(join(tmpdir(), 'bb-mf-mps-'));
+    writeFileSync(join(mpsAssetsDir, 'index.html'), INDEX_BODY);
+    writeFileSync(join(mpsAssetsDir, 'about.html'), ABOUT_BODY);
+    writeFileSync(join(mpsAssetsDir, 'contact.html'), CONTACT_BODY);
+    mkdirSync(join(mpsAssetsDir, 'blog'), { recursive: true });
+    writeFileSync(join(mpsAssetsDir, 'blog', 'post-1.html'), POST1_BODY);
+    // No _redirects shipped.
+
+    mfMps = new Miniflare({
+      modules: true,
+      script: workerSource,
+      host: '127.0.0.1',
+      port: 0,
+      assets: {
+        directory: mpsAssetsDir,
+        binding: 'ASSETS',
+        assetConfig: { html_handling: 'none' },
+        routerConfig: {
+          has_user_worker: true,
+          invoke_user_worker_ahead_of_assets: true,
+        },
+      },
+    });
+    baseUrlMps = await mfMps.ready;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (mfMps) await mfMps.dispose();
+    if (mpsAssetsDir) rmSync(mpsAssetsDir, { recursive: true, force: true });
+  });
+
+  async function getMps(path: string): Promise<Response> {
+    return await mfMps.dispatchFetch(new URL(path, baseUrlMps).toString(), {
+      redirect: 'manual',
+    });
+  }
+
+  it('/about → 200 with about body (candidate-2 .html lookup)', async () => {
+    const res = await getMps('/about');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(ABOUT_BODY);
+  });
+
+  it('/contact → 200 with contact body (candidate-2 .html lookup)', async () => {
+    const res = await getMps('/contact');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(CONTACT_BODY);
+  });
+
+  it('/blog/post-1 → 200 with post-1 body (candidate-2 .html lookup)', async () => {
+    const res = await getMps('/blog/post-1');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(POST1_BODY);
+  });
+
+  it('/missing.png → 404 (asset-shaped, no SPA fallback)', async () => {
+    const res = await getMps('/missing.png');
+    expect(res.status).toBe(404);
+    // Body must not be INDEX_BODY — no SPA fallback fired.
+    const body = await res.text();
+    expect(body).not.toBe(INDEX_BODY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 4: Pure SPA (index.html only, no _redirects).
+// ---------------------------------------------------------------------------
+describe('SPA fixture (index.html only)', () => {
+  let mfSpa: Miniflare;
+  let baseUrlSpa: URL;
+  let spaAssetsDir: string;
+
+  beforeAll(async () => {
+    const workerSource = readFileSync(workerJsPath, 'utf8');
+
+    spaAssetsDir = mkdtempSync(join(tmpdir(), 'bb-mf-spa-'));
+    writeFileSync(join(spaAssetsDir, 'index.html'), INDEX_BODY);
+    // No _redirects shipped.
+
+    mfSpa = new Miniflare({
+      modules: true,
+      script: workerSource,
+      host: '127.0.0.1',
+      port: 0,
+      assets: {
+        directory: spaAssetsDir,
+        binding: 'ASSETS',
+        assetConfig: { html_handling: 'none' },
+        routerConfig: {
+          has_user_worker: true,
+          invoke_user_worker_ahead_of_assets: true,
+        },
+      },
+    });
+    baseUrlSpa = await mfSpa.ready;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (mfSpa) await mfSpa.dispose();
+    if (spaAssetsDir) rmSync(spaAssetsDir, { recursive: true, force: true });
+  });
+
+  async function getSpa(path: string): Promise<Response> {
+    return await mfSpa.dispatchFetch(new URL(path, baseUrlSpa).toString(), {
+      redirect: 'manual',
+    });
+  }
+
+  it('/ → 200 home', async () => {
+    const res = await getSpa('/');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
+
+  it('/history → 200 home via SPA fallback', async () => {
+    const res = await getSpa('/history');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
+
+  it('/profile/42 → 200 home via SPA fallback', async () => {
+    const res = await getSpa('/profile/42');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
+  });
+
+  it('/missing.png → 404 (asset-shaped, no SPA fallback)', async () => {
+    const res = await getSpa('/missing.png');
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).not.toBe(INDEX_BODY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 5: Mixed fixture (/index.html, /old.html, _redirects with 301 + /*).
+// ---------------------------------------------------------------------------
+describe('mixed fixture (static pages + redirects + SPA catch-all)', () => {
+  let mfMixed: Miniflare;
+  let baseUrlMixed: URL;
+  let mixedAssetsDir: string;
+
+  const OLD_BODY = '<!doctype html><h1>Old Page</h1>';
+  const MIXED_RULES = [
+    { from: '/old', to: '/new', status: 301 },
+    { from: '/*', to: '/index.html', status: 200 },
+  ];
+
+  beforeAll(async () => {
+    const workerSource = readFileSync(workerJsPath, 'utf8');
+
+    mixedAssetsDir = mkdtempSync(join(tmpdir(), 'bb-mf-mixed-'));
+    writeFileSync(join(mixedAssetsDir, 'index.html'), INDEX_BODY);
+    writeFileSync(join(mixedAssetsDir, 'old.html'), OLD_BODY);
+
+    mfMixed = new Miniflare({
+      modules: true,
+      script: workerSource,
+      host: '127.0.0.1',
+      port: 0,
+      bindings: { BB_REDIRECTS_RULES: JSON.stringify(MIXED_RULES) },
+      assets: {
+        directory: mixedAssetsDir,
+        binding: 'ASSETS',
+        assetConfig: { html_handling: 'none' },
+        routerConfig: {
+          has_user_worker: true,
+          invoke_user_worker_ahead_of_assets: true,
+        },
+      },
+    });
+    baseUrlMixed = await mfMixed.ready;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (mfMixed) await mfMixed.dispose();
+    if (mixedAssetsDir) rmSync(mixedAssetsDir, { recursive: true, force: true });
+  });
+
+  async function getMixed(path: string): Promise<Response> {
+    return await mfMixed.dispatchFetch(new URL(path, baseUrlMixed).toString(), {
+      redirect: 'manual',
+    });
+  }
+
+  it('/old → 301 (3xx rule wins over everything)', async () => {
+    const res = await getMixed('/old');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toMatch(/\/new/);
+  });
+
+  it('/old.html → 200 served literally (real asset wins over /* SPA rewrite)', async () => {
+    const res = await getMixed('/old.html');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(OLD_BODY);
+  });
+
+  it('/missing → 200 home (/* SPA rewrite catches route-shaped miss)', async () => {
+    const res = await getMixed('/missing');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(INDEX_BODY);
   });
 });

--- a/packages/static-frontend-worker/src/worker.test.ts
+++ b/packages/static-frontend-worker/src/worker.test.ts
@@ -33,15 +33,6 @@ function htmlResponse(body: string, status = 200): Response {
   });
 }
 
-// Build a Response that DOES NOT have an inferred content-type. Node's
-// Response constructor auto-sets `text/plain;charset=UTF-8` for string
-// bodies, which doesn't match the CF runtime (where `new Response(body)`
-// leaves content-type unset). Using a byte body sidesteps that inference so
-// the worker's withMime fallback can be exercised faithfully.
-function bytesResponseNoContentType(body: string, status = 200): Response {
-  return new Response(new TextEncoder().encode(body), { status });
-}
-
 function redirectResponse(location: string, status = 307): Response {
   return new Response('', { status, headers: { location } });
 }
@@ -68,9 +59,10 @@ describe('static-frontend-worker', () => {
       expect(calls).toEqual(['/assets/app.css']);
     });
 
-    it('serves the root path directly with status 200', async () => {
+    it('serves the root path directly with status 200 via index.html candidate', async () => {
+      // / is a trailing-slash path — candidate 2 is /index.html.
       const { env, calls } = makeAssetsEnv({
-        '/': () => htmlResponse(INDEX_BODY),
+        '/index.html': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
         new Request('https://app.example.com/'),
@@ -78,20 +70,87 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
-      expect(calls).toEqual(['/']);
+      // Candidate 1 (/) misses, candidate 2 (/index.html) hits.
+      expect(calls).toEqual(['/', '/index.html']);
     });
   });
 
-  describe('SPA fallback (the PR #33 fix)', () => {
-    it('resolves a deep-path miss (307 → /) to the home document with status 200', async () => {
-      // Real CF behavior under `html_handling: 'auto-trailing-slash'`:
-      //   - extensionless misses 307 to `/`
-      //   - `/index.html` ALSO 307s to `/` (the trap)
-      //   - `/` serves index.html with 200
+  // Layer 1: unit tests against hand-mocked env.ASSETS — explicit resolution chain.
+  describe('resolveAssetPath candidates (Phase 5)', () => {
+    it('literal hit: /foo.js → 200 from candidate 1', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/foo.js': () =>
+          new Response('// js', { status: 200, headers: { 'content-type': 'application/javascript' } }),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/foo.js'), env);
+      expect(res.status).toBe(200);
+      expect(calls).toEqual(['/foo.js']);
+    });
+
+    it('trailing-slash index: /about/ → /about/index.html', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/about/index.html': () => htmlResponse('<h1>About</h1>'),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/about/'), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('<h1>About</h1>');
+      // Candidate 1 (/about/) misses, candidate 2 (/about/index.html) hits.
+      expect(calls).toEqual(['/about/', '/about/index.html']);
+    });
+
+    it('extensionless .html lookup: /about → /about.html hit (no /about/index.html consulted)', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/about.html': () => htmlResponse('<h1>About</h1>'),
+        '/about/index.html': () => htmlResponse('<h1>About Index</h1>'),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/about'), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('<h1>About</h1>');
+      // Candidate 1 (/about) misses, candidate 2 (/about.html) hits — stop.
+      expect(calls).toEqual(['/about', '/about.html']);
+      expect(calls).not.toContain('/about/index.html');
+    });
+
+    it('extensionless dir lookup: /about with no .html but with /about/index.html', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/about/index.html': () => htmlResponse('<h1>About Dir</h1>'),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/about'), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('<h1>About Dir</h1>');
+      // /about misses, /about.html misses, /about/index.html hits.
+      expect(calls).toEqual(['/about', '/about.html', '/about/index.html']);
+    });
+
+    it('/foo.html real file: serves literally (200), no redirect', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/foo.html': () => htmlResponse('<h1>Foo</h1>'),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/foo.html'), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('<h1>Foo</h1>');
+      // Literal hit — no extra candidates consulted, no redirect issued.
+      expect(calls).toEqual(['/foo.html']);
+      expect(res.headers.get('location')).toBeNull();
+    });
+
+    it('/index.html real file: serves literally (200), no redirect', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/index.html': () => htmlResponse(INDEX_BODY),
+      });
+      const res = await worker.fetch(new Request('https://app.example.com/index.html'), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_BODY);
+      expect(calls).toEqual(['/index.html']);
+      expect(res.headers.get('location')).toBeNull();
+    });
+  });
+
+  describe('SPA fallback (route-shaped miss)', () => {
+    it('all candidates miss for route-shaped path → SPA fallback to /', async () => {
       const { env, calls } = makeAssetsEnv({
         '/': () => htmlResponse(INDEX_BODY),
-        '/index.html': () => redirectResponse('/'),
-        '/history': () => redirectResponse('/'),
+        '/index.html': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
         new Request('https://app.example.com/history'),
@@ -99,102 +158,73 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
-      // Regression guard: the fallback must hit `/`, not `/index.html`.
-      expect(calls).toEqual(['/history', '/']);
-      expect(calls).not.toContain('/index.html');
+      // /history misses, /history.html misses, /history/index.html misses →
+      // SPA fallback to / which returns the home document.
+      expect(calls).toContain('/history');
+      expect(calls[calls.length - 1]).toBe('/');
     });
 
-    it('resolves a 404 miss to the home document', async () => {
+    it('all candidates miss for /missing.html → SPA fallback (.html is route-shaped)', async () => {
       const { env, calls } = makeAssetsEnv({
         '/': () => htmlResponse(INDEX_BODY),
+        '/index.html': () => htmlResponse(INDEX_BODY),
       });
-      // No /unknown route → default 404 from the mock
       const res = await worker.fetch(
-        new Request('https://app.example.com/unknown'),
+        new Request('https://app.example.com/missing.html'),
         env,
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
-      expect(calls).toEqual(['/unknown', '/']);
+      // /missing.html has a .html extension → route-shaped → SPA fallback.
+      expect(calls).toContain('/missing.html');
+      expect(calls[calls.length - 1]).toBe('/');
     });
 
     it('preserves the fallback response status when the home document is also missing', async () => {
-      // Pathological app with no index.html: both first hop and fallback miss.
       const { env, calls } = makeAssetsEnv({}, 404);
       const res = await worker.fetch(
         new Request('https://app.example.com/missing'),
         env,
       );
-      // Fallback returns whatever / returns. Both 404 → status 404.
+      // Fallback tries / then /index.html (the resolveAssetPath candidates for /).
+      // Both 404 → status 404.
       expect(res.status).toBe(404);
-      expect(calls).toEqual(['/missing', '/']);
+      // SPA fallback must have been attempted.
+      expect(calls).toContain('/');
     });
   });
 
-  describe('MIME defaults', () => {
-    it('applies text/css when the assets binding returns a .css file with no content-type', async () => {
-      const { env } = makeAssetsEnv({
-        '/styles.css': () => bytesResponseNoContentType('body{}'),
+  describe('asset-shaped miss returns honest 404 (no SPA fallback)', () => {
+    it('all candidates miss for /missing.png → 404, no SPA fallback', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
-        new Request('https://app.example.com/styles.css'),
+        new Request('https://app.example.com/missing.png'),
         env,
       );
-      expect(res.headers.get('content-type')).toBe('text/css');
+      expect(res.status).toBe(404);
+      // /missing.png only has 1 candidate (literal). SPA fallback must NOT fire.
+      expect(calls).toEqual(['/missing.png']);
+      expect(calls).not.toContain('/');
     });
 
-    it('applies application/javascript for .mjs', async () => {
-      const { env } = makeAssetsEnv({
-        '/app.mjs': () => bytesResponseNoContentType('export const x = 1;'),
+    it('all candidates miss for /missing.js → 404, no SPA fallback', async () => {
+      const { env, calls } = makeAssetsEnv({
+        '/': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
-        new Request('https://app.example.com/app.mjs'),
+        new Request('https://app.example.com/missing.js'),
         env,
       );
-      expect(res.headers.get('content-type')).toBe('application/javascript');
+      expect(res.status).toBe(404);
+      expect(calls).toEqual(['/missing.js']);
+      expect(calls).not.toContain('/');
     });
+  });
 
-    it('defaults to text/html for extensionless paths', async () => {
-      // Extensionless paths are served by the Assets binding from a .html
-      // file via html_handling. Mark them text/html so the browser renders
-      // them instead of triggering a download.
-      const { env } = makeAssetsEnv({
-        '/geo': () => bytesResponseNoContentType('<h1>geo</h1>'),
-      });
-      const res = await worker.fetch(
-        new Request('https://app.example.com/geo'),
-        env,
-      );
-      expect(res.headers.get('content-type')).toBe('text/html');
-    });
-
-    it('does NOT mis-detect the hostname dot as the extension for extensionless paths', async () => {
-      // Regression for the bug fixed in 0524fd9c: splitting the whole URL on
-      // '.' picks up 'ai' as the "extension" of 'butterbase.ai/geo' and
-      // falls through to application/octet-stream (triggering a download).
-      const { env } = makeAssetsEnv({
-        '/geo': () => bytesResponseNoContentType('<h1>geo</h1>'),
-      });
-      const res = await worker.fetch(
-        new Request('https://app.butterbase.ai/geo'),
-        env,
-      );
-      expect(res.headers.get('content-type')).toBe('text/html');
-      expect(res.headers.get('content-type')).not.toBe('application/octet-stream');
-    });
-
-    it('defaults to application/octet-stream for unknown extensions', async () => {
-      const { env } = makeAssetsEnv({
-        '/data.bin': () => bytesResponseNoContentType('binary'),
-      });
-      const res = await worker.fetch(
-        new Request('https://app.example.com/data.bin'),
-        env,
-      );
-      expect(res.headers.get('content-type')).toBe('application/octet-stream');
-    });
-
-    it('preserves a content-type the assets binding already set', async () => {
+  describe('MIME is NOT set inside the worker (Phase 6)', () => {
+    it('worker passes through whatever content-type Assets set (does not override)', async () => {
       const { env } = makeAssetsEnv({
         '/styles.css': () =>
           new Response('body{}', {
@@ -206,7 +236,43 @@ describe('static-frontend-worker', () => {
         new Request('https://app.example.com/styles.css'),
         env,
       );
+      // Worker must not modify the content-type that Assets already set.
       expect(res.headers.get('content-type')).toBe('text/css; charset=utf-8');
+    });
+
+    it('worker does NOT add a content-type when Assets returned none', async () => {
+      // Simulate Assets returning no content-type (as happens in WfP namespaces).
+      const { env } = makeAssetsEnv({
+        '/styles.css': () =>
+          new Response(new TextEncoder().encode('body{}'), { status: 200 }),
+      });
+      const res = await worker.fetch(
+        new Request('https://app.example.com/styles.css'),
+        env,
+      );
+      // The worker must not inject a MIME type — dispatch-worker owns that.
+      // content-type may be absent OR may be set by Node's fetch (text/plain
+      // is acceptable here as long as the worker itself didn't synthesize it).
+      // The critical assertion: it must NOT be 'text/css', 'application/javascript',
+      // 'image/png', or any worker-inferred value.
+      const ct = res.headers.get('content-type') ?? '';
+      expect(ct).not.toBe('text/css');
+      expect(ct).not.toBe('application/javascript');
+    });
+
+    it('SPA fallback response: worker passes content-type from Assets unchanged', async () => {
+      const { env } = makeAssetsEnv({
+        '/': () => htmlResponse(INDEX_BODY),
+        '/index.html': () => htmlResponse(INDEX_BODY),
+      });
+      const res = await worker.fetch(
+        new Request('https://app.example.com/history'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      // text/html was set by the mock (as Assets would set it); worker didn't add it.
+      // The point: whatever Assets returned, that's what came through.
+      expect(res.headers.get('content-type')).toBe('text/html');
     });
   });
 
@@ -267,8 +333,9 @@ describe('static-frontend-worker', () => {
   describe('_redirects rule application (BB_REDIRECTS_RULES binding)', () => {
     it('applies a 200 rewrite rule on asset miss (serves target content under the original URL)', async () => {
       const indexBody = '<html>HOME</html>';
+      // /index.html is the literal candidate for the rewrite target /index.html.
       const { env, calls } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody) },
+        { '/index.html': () => htmlResponse(indexBody) },
         404,
         JSON.stringify([{ from: '/*', to: '/index.html', status: 200 }]),
       );
@@ -278,9 +345,84 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(indexBody);
-      // CF Pages-compatible precedence: asset lookup first (returns 404),
-      // then 200 rewrite applies. Rewrite target /index.html normalizes to /.
-      expect(calls).toEqual(['/history', '/']);
+      // Asset lookup for /history (+ .html + /index.html) — all miss.
+      // Then 200 rewrite applies: resolveAssetPath('/index.html') → ['/index.html'].
+      // /index.html hits.
+      expect(calls).toContain('/history');
+      expect(calls).toContain('/index.html');
+    });
+
+    it('_redirects 200 rewrite: /api/* /v2/:splat — tries resolveAssetPath candidates in order', async () => {
+      const v2UsersBody = '<html>V2 USERS</html>';
+      // resolveAssetPath('/v2/users') = ['/v2/users', '/v2/users.html', '/v2/users/index.html']
+      const { env, calls } = makeAssetsEnv(
+        { '/v2/users': () => htmlResponse(v2UsersBody) },
+        404,
+        JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 200 }]),
+      );
+      const res = await worker.fetch(
+        new Request('https://app.example.com/api/users'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(v2UsersBody);
+      // Asset lookup for /api/users (+ .html + /index.html) — all miss.
+      // Rewrite to /v2/users — first candidate hits.
+      expect(calls).toContain('/api/users');
+      expect(calls).toContain('/v2/users');
+    });
+
+    it('_redirects 200 rewrite: target /v2/users.html serves via second candidate', async () => {
+      const v2UsersBody = '<html>V2 USERS</html>';
+      // When /v2/users misses but /v2/users.html exists, second candidate wins.
+      const { env, calls } = makeAssetsEnv(
+        { '/v2/users.html': () => htmlResponse(v2UsersBody) },
+        404,
+        JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 200 }]),
+      );
+      const res = await worker.fetch(
+        new Request('https://app.example.com/api/users'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(v2UsersBody);
+      expect(calls).toContain('/v2/users');
+      expect(calls).toContain('/v2/users.html');
+    });
+
+    it('_redirects 200 rewrite: target /v2/users/index.html serves via third candidate', async () => {
+      const v2UsersBody = '<html>V2 USERS DIR</html>';
+      // When /v2/users and /v2/users.html both miss, /v2/users/index.html wins.
+      const { env, calls } = makeAssetsEnv(
+        { '/v2/users/index.html': () => htmlResponse(v2UsersBody) },
+        404,
+        JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 200 }]),
+      );
+      const res = await worker.fetch(
+        new Request('https://app.example.com/api/users'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(v2UsersBody);
+      expect(calls).toContain('/v2/users');
+      expect(calls).toContain('/v2/users.html');
+      expect(calls).toContain('/v2/users/index.html');
+    });
+
+    it('_redirects 3xx rule fires regardless of asset existence (rule wins)', async () => {
+      const { env, calls } = makeAssetsEnv(
+        { '/old': () => htmlResponse('<html>existing file</html>') },
+        404,
+        JSON.stringify([{ from: '/old', to: '/new', status: 301 }]),
+      );
+      const res = await worker.fetch(
+        new Request('https://app.example.com/old'),
+        env,
+      );
+      expect(res.status).toBe(301);
+      expect(res.headers.get('location')).toBe('https://app.example.com/new');
+      // Asset must not be consulted — the 3xx rule preempts the lookup.
+      expect(calls).toEqual([]);
     });
 
     it('applies a 301 redirect rule (returns Location header, does NOT fetch target)', async () => {
@@ -300,9 +442,6 @@ describe('static-frontend-worker', () => {
     });
 
     it('first match wins for 3xx rules (preserves rule order)', async () => {
-      // 3xx rules fire BEFORE asset lookup, so first-match-wins is observable
-      // even when an asset would match. With 200 rules, asset wins over rule,
-      // so testing rule ordering must use 3xx.
       const { env, calls } = makeAssetsEnv(
         {},
         404,
@@ -332,7 +471,8 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       // Asset lookup for /api/users/42 first (misses), then rewrite to /v2/users/42.
-      expect(calls).toEqual(['/api/users/42', '/v2/users/42']);
+      expect(calls).toContain('/api/users/42');
+      expect(calls).toContain('/v2/users/42');
     });
 
     it('substitutes :splat in the redirect target', async () => {
@@ -362,10 +502,10 @@ describe('static-frontend-worker', () => {
       expect(res.status).toBe(status);
     });
 
-    it('falls through to default asset lookup + SPA fallback when no rule matches', async () => {
+    it('falls through to default SPA fallback when no rule matches', async () => {
       const indexBody = '<html>HOME</html>';
       const { env, calls } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody) },
+        { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
         404,
         JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 301 }]),
       );
@@ -375,15 +515,14 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(indexBody);
-      // First hop: /unrelated/deep/path → 404. Fallback: /. SPA fallback path
-      // is preserved for apps without a `/*` catch-all rule.
-      expect(calls).toEqual(['/unrelated/deep/path', '/']);
+      expect(calls).toContain('/unrelated/deep/path');
+      expect(calls[calls.length - 1]).toBe('/');
     });
 
     it('treats absent BB_REDIRECTS_RULES as no rules (existing behavior unchanged)', async () => {
       const indexBody = '<html>HOME</html>';
       const { env, calls } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody) },
+        { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
         404,
         // no rulesJson argument
       );
@@ -392,13 +531,13 @@ describe('static-frontend-worker', () => {
         env,
       );
       expect(res.status).toBe(200);
-      expect(calls).toEqual(['/history', '/']);
+      expect(calls[calls.length - 1]).toBe('/');
     });
 
     it('treats malformed BB_REDIRECTS_RULES JSON as no rules (does not break serving)', async () => {
       const indexBody = '<html>HOME</html>';
       const { env } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody) },
+        { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
         404,
         '{not valid json',
       );
@@ -428,8 +567,6 @@ describe('static-frontend-worker', () => {
       });
 
       it('200 rewrite does NOT fire when the requested path is a real asset (asset wins)', async () => {
-        // Catch-all SPA rule would otherwise rewrite EVERY path to /index.html.
-        // With CF Pages precedence, real assets are served unchanged.
         const assetBody = '<html>real file</html>';
         const indexBody = '<html>HOME</html>';
         const { env, calls } = makeAssetsEnv(
@@ -453,7 +590,7 @@ describe('static-frontend-worker', () => {
       it('200 rewrite fires when the requested path is NOT a real asset (rule fallback)', async () => {
         const indexBody = '<html>HOME</html>';
         const { env, calls } = makeAssetsEnv(
-          { '/': () => htmlResponse(indexBody) },
+          { '/index.html': () => htmlResponse(indexBody) },
           404,
           JSON.stringify([{ from: '/*', to: '/index.html', status: 200 }]),
         );
@@ -463,7 +600,38 @@ describe('static-frontend-worker', () => {
         );
         expect(res.status).toBe(200);
         expect(await res.text()).toBe(indexBody);
-        expect(calls).toEqual(['/missing', '/']);
+        expect(calls).toContain('/missing');
+        expect(calls).toContain('/index.html');
+      });
+
+      it('200 rewrite target miss → SPA fallback for route-shaped path', async () => {
+        // When the rewrite target also misses, route-shaped paths fall through to SPA.
+        const indexBody = '<html>HOME</html>';
+        const { env } = makeAssetsEnv(
+          { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
+          404,
+          JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 200 }]),
+        );
+        const res = await worker.fetch(
+          new Request('https://app.example.com/api/missing-route'),
+          env,
+        );
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(indexBody);
+      });
+
+      it('200 rewrite target miss → 404 for asset-shaped path', async () => {
+        // When the rewrite target also misses and the path is asset-shaped, return 404.
+        const { env } = makeAssetsEnv(
+          { '/': () => htmlResponse('<html>HOME</html>') },
+          404,
+          JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 200 }]),
+        );
+        const res = await worker.fetch(
+          new Request('https://app.example.com/api/missing.png'),
+          env,
+        );
+        expect(res.status).toBe(404);
       });
     });
 

--- a/packages/static-frontend-worker/src/worker.test.ts
+++ b/packages/static-frontend-worker/src/worker.test.ts
@@ -147,9 +147,10 @@ describe('static-frontend-worker', () => {
   });
 
   describe('SPA fallback (route-shaped miss)', () => {
-    it('all candidates miss for route-shaped path → SPA fallback to /', async () => {
+    it('all candidates miss for route-shaped path → SPA fallback to /index.html', async () => {
       const { env, calls } = makeAssetsEnv({
-        '/': () => htmlResponse(INDEX_BODY),
+        // No '/' mock: under html_handling: 'none', '/' always 404s in production.
+        // Only /index.html exists. The SPA fallback must land on /index.html.
         '/index.html': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
@@ -159,14 +160,15 @@ describe('static-frontend-worker', () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
       // /history misses, /history.html misses, /history/index.html misses →
-      // SPA fallback to / which returns the home document.
+      // SPA fallback fetches /index.html directly (not '/' first).
       expect(calls).toContain('/history');
-      expect(calls[calls.length - 1]).toBe('/');
+      expect(calls[calls.length - 1]).toBe('/index.html');
     });
 
     it('all candidates miss for /missing.html → SPA fallback (.html is route-shaped)', async () => {
       const { env, calls } = makeAssetsEnv({
-        '/': () => htmlResponse(INDEX_BODY),
+        // No '/' mock: under html_handling: 'none', '/' always 404s in production.
+        // Only /index.html exists. The SPA fallback must land on /index.html.
         '/index.html': () => htmlResponse(INDEX_BODY),
       });
       const res = await worker.fetch(
@@ -175,9 +177,9 @@ describe('static-frontend-worker', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_BODY);
-      // /missing.html has a .html extension → route-shaped → SPA fallback.
+      // /missing.html has a .html extension → route-shaped → SPA fallback fetches /index.html directly.
       expect(calls).toContain('/missing.html');
-      expect(calls[calls.length - 1]).toBe('/');
+      expect(calls[calls.length - 1]).toBe('/index.html');
     });
 
     it('preserves the fallback response status when the home document is also missing', async () => {
@@ -186,11 +188,10 @@ describe('static-frontend-worker', () => {
         new Request('https://app.example.com/missing'),
         env,
       );
-      // Fallback tries / then /index.html (the resolveAssetPath candidates for /).
-      // Both 404 → status 404.
+      // Fallback fetches /index.html directly; if that 404s too, propagate 404.
       expect(res.status).toBe(404);
-      // SPA fallback must have been attempted.
-      expect(calls).toContain('/');
+      // SPA fallback must have been attempted against /index.html.
+      expect(calls).toContain('/index.html');
     });
   });
 
@@ -505,7 +506,7 @@ describe('static-frontend-worker', () => {
     it('falls through to default SPA fallback when no rule matches', async () => {
       const indexBody = '<html>HOME</html>';
       const { env, calls } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
+        { '/index.html': () => htmlResponse(indexBody) },
         404,
         JSON.stringify([{ from: '/api/*', to: '/v2/:splat', status: 301 }]),
       );
@@ -516,13 +517,13 @@ describe('static-frontend-worker', () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(indexBody);
       expect(calls).toContain('/unrelated/deep/path');
-      expect(calls[calls.length - 1]).toBe('/');
+      expect(calls[calls.length - 1]).toBe('/index.html');
     });
 
     it('treats absent BB_REDIRECTS_RULES as no rules (existing behavior unchanged)', async () => {
       const indexBody = '<html>HOME</html>';
       const { env, calls } = makeAssetsEnv(
-        { '/': () => htmlResponse(indexBody), '/index.html': () => htmlResponse(indexBody) },
+        { '/index.html': () => htmlResponse(indexBody) },
         404,
         // no rulesJson argument
       );
@@ -531,7 +532,7 @@ describe('static-frontend-worker', () => {
         env,
       );
       expect(res.status).toBe(200);
-      expect(calls[calls.length - 1]).toBe('/');
+      expect(calls[calls.length - 1]).toBe('/index.html');
     });
 
     it('treats malformed BB_REDIRECTS_RULES JSON as no rules (does not break serving)', async () => {

--- a/packages/static-frontend-worker/src/worker.ts
+++ b/packages/static-frontend-worker/src/worker.ts
@@ -3,34 +3,21 @@
 // One copy of the compiled output of this file is uploaded into the WfP
 // dispatch namespace per customer app (script name = appId). The worker is
 // bound to a Cloudflare Assets binding containing the user's uploaded zip
-// contents and serves them with an in-worker SPA fallback.
+// contents and serves them with an explicit path resolution chain.
 //
-// SPA fallback: on a non-2xx from the Assets binding, retry against `/`
-// (which resolves to the home `index.html` under
-// `html_handling: 'auto-trailing-slash'`). This is the CF-canonical SPA
-// pattern and is deterministic across CF runtime variants (we previously
-// tried `not_found_handling: 'single-page-application'` and it threw inside
-// WfP).
+// Path resolution (html_handling: 'none'):
+//   The Assets binding returns literal file contents or 404 — no implicit CF
+//   URL canonicalization or redirects in the loop. The worker explicitly tries
+//   multiple path candidates in order:
+//     1. Literal path (/foo.js, /styles.css, /index.html, etc.)
+//     2. Trailing-slash directory index (/foo/ → /foo/index.html)
+//     3. Extensionless → /path.html then /path/index.html
+//   First 2xx wins. On all-miss, SPA fallback to / (which resolves via
+//   candidate 2 above) — unless the request was for a binary/asset extension,
+//   in which case an honest 404 is returned.
 //
-// We check `res.ok` (status 200-299) rather than `res.status !== 404`
-// because the Assets binding inside a WfP dispatch namespace may return 307
-// redirects for non-file paths (e.g. /people → 307 Location: /) instead of
-// 404. Catching all non-2xx responses ensures SPA deep-links always resolve
-// to the home document instead of producing unexpected redirects.
-//
-// IMPORTANT: the fallback fetches `/`, NOT `/index.html`. Under
-// `html_handling: 'auto-trailing-slash'`, fetching `/index.html` itself
-// returns a 307 redirect to `/` — the same trap this fallback exists to
-// escape. Fetching `/` returns the home document with status 200 directly.
-// Do not change this back to `/index.html`.
-//
-// MIME workaround: the Assets binding inside a WfP dispatch namespace does
-// not reliably set Content-Type headers. Without a correct Content-Type,
-// browsers block module scripts entirely ("strict MIME type checking"). We
-// detect the type from the URL extension and override the header when it is
-// missing. (The outer dispatch-worker also re-applies Content-Type at its
-// layer — this in-worker copy is defensive belt-and-braces; cleanup tracked
-// for a future PR.)
+// MIME: the outer dispatch-worker re-applies Content-Type on every response.
+// This worker returns raw Assets responses; there is no in-worker MIME map.
 
 export interface Env {
   ASSETS: { fetch(req: Request): Promise<Response> };
@@ -90,57 +77,37 @@ function loadRules(env: Env): RedirectRule[] {
   return cachedRules;
 }
 
-// Translate a rewrite target to the form Assets actually serves with 200 under
-// `html_handling: 'auto-trailing-slash'`. The Assets binding 307-redirects any
-// .html path to its canonical extensionless form; if a rewrite asks for
-// /foo.html and we forward Assets's 307, the rewrite is broken (client sees
-// the 307). Normalizing here means the worker fetches the form Assets returns
-// 200 for, and we serve that content under the original request URL.
-function normalizeRewriteTarget(target: string): string {
-  // Don't rewrite cross-origin targets (e.g. external URLs that snuck into a
-  // 200 rule — though those are nonsensical, defend in depth).
-  if (/^https?:\/\//i.test(target)) return target;
-  if (target.endsWith('/index.html')) {
-    // /foo/index.html → /foo/   ;   /index.html → /
-    return target.slice(0, -'index.html'.length);
+// Return the ordered list of asset paths to try for a given request path.
+// With html_handling: 'none', Assets returns literal contents or 404 — no
+// redirects. The worker tries these candidates in order; first 2xx wins.
+function resolveAssetPath(path: string): string[] {
+  const candidates: string[] = [];
+
+  // 1. Literal path (handles /foo.js, /styles.css, /index.html, etc.)
+  candidates.push(path);
+
+  // 2. Trailing-slash directory index (/foo/ → /foo/index.html)
+  if (path.endsWith('/')) {
+    candidates.push(path + 'index.html');
+    return candidates;
   }
-  if (target.endsWith('.html')) {
-    return target.slice(0, -'.html'.length);
+
+  // 3. Extensionless → try .html and /index.html
+  const filename = path.split('/').pop() || '';
+  if (!filename.includes('.')) {
+    candidates.push(path + '.html');
+    candidates.push(path + '/index.html');
   }
-  return target;
+
+  return candidates;
 }
 
-// Decide whether an Assets binding response represents a "miss" (no file at
-// the requested path) vs a hit. Hits include both literal 2xx responses AND
-// canonical 3xx redirects that `html_handling: 'auto-trailing-slash'` issues
-// for existing .html / index.html files:
-//
-//   /foo.html        → 307 Location: /foo            (canonical, asset exists)
-//   /foo/index.html  → 307 Location: /foo/           (canonical, asset exists)
-//   /index.html      → 307 Location: /               (canonical, asset exists)
-//   /missing.html    → 404                            (true miss)
-//   /missing         → 307 Location: /   (WfP only)   (miss-fallback)
-//
-// We distinguish hit-vs-miss for 3xx responses by comparing the actual
-// Location header to the expected canonical form of the requested path. Any
-// 3xx whose Location does NOT match the canonical form is a miss-fallback
-// (the WfP dispatch-namespace quirk PR #33 worked around).
-function looksLikeAssetMiss(res: Response, requestPath: string): boolean {
-  if (res.status === 404) return true;
-  if (res.status >= 300 && res.status < 400) {
-    const loc = res.headers.get('location') ?? '';
-    let expectedCanonical: string | null = null;
-    if (requestPath.endsWith('/index.html')) {
-      expectedCanonical = requestPath.slice(0, -'index.html'.length);
-    } else if (requestPath.endsWith('.html')) {
-      expectedCanonical = requestPath.slice(0, -'.html'.length);
-    }
-    if (expectedCanonical !== null && loc === expectedCanonical) {
-      return false; // canonical redirect = asset exists
-    }
-    return true; // miss-fallback redirect
-  }
-  return false; // 2xx — asset hit
+// Routes that look like "I'm a page" — fall back to SPA index on miss.
+// Routes that look like assets (.png/.js/etc.) get an honest 404.
+function isRouteLikeRequest(path: string): boolean {
+  const filename = path.split('/').pop() || '';
+  if (!filename.includes('.')) return true; // /history, /profile
+  return /\.(html?)$/i.test(filename); // /about.html
 }
 
 function matchRule(path: string, rule: RedirectRule): string | null {
@@ -173,53 +140,6 @@ function findMatch(
   return null;
 }
 
-const MIME: Record<string, string> = {
-  js: 'application/javascript',
-  mjs: 'application/javascript',
-  css: 'text/css',
-  html: 'text/html',
-  htm: 'text/html',
-  json: 'application/json',
-  svg: 'image/svg+xml',
-  png: 'image/png',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  ico: 'image/x-icon',
-  woff: 'font/woff',
-  woff2: 'font/woff2',
-  ttf: 'font/ttf',
-  otf: 'font/otf',
-  eot: 'application/vnd.ms-fontobject',
-  wasm: 'application/wasm',
-  xml: 'application/xml',
-  txt: 'text/plain',
-  map: 'application/json',
-};
-
-function withMime(req: Request, res: Response): Response {
-  if (res.headers.get('content-type')) return res;
-  // Extract extension from the last path segment only. Splitting the whole
-  // URL on '.' picks up the hostname (e.g. '.butterbase.ai/geo' → 'ai/geo')
-  // for extensionless paths. Extensionless paths are served by the Assets
-  // binding from a .html file via html_handling, so default them to
-  // text/html — octet-stream triggers a browser download instead of
-  // rendering.
-  const path = new URL(req.url).pathname;
-  const filename = path.split('/').pop() || '';
-  const dot = filename.lastIndexOf('.');
-  const ext = dot > -1 ? filename.slice(dot + 1).toLowerCase() : '';
-  const ct = MIME[ext] || (ext ? 'application/octet-stream' : 'text/html');
-  const h = new Headers(res.headers);
-  h.set('content-type', ct);
-  return new Response(res.body, {
-    status: res.status,
-    statusText: res.statusText,
-    headers: h,
-  });
-}
-
 const handler = {
   async fetch(request: Request, env: Env): Promise<Response> {
     try {
@@ -229,13 +149,10 @@ const handler = {
 
       // Cloudflare Pages-compatible precedence:
       //   1. 3xx redirect rules ALWAYS win, even if the path is a real file.
-      //      (`/old /new 301` fires even when /old exists.)
-      //   2. Real assets win over 200 rewrites — try the asset binding next.
-      //      A 200 rewrite is a fallback that only fires on asset miss.
+      //   2. Real assets win over 200 rewrites — try the asset binding first.
       //   3. 200 rewrites apply only after the asset lookup misses.
-      //   4. No rule + asset miss → preserve PR #33 SPA fallback to `/`
-      //      (this is the default behavior for apps that don't ship a
-      //      _redirects file; keeping it ensures purely-additive semantics).
+      //   4. No rule + asset miss → SPA fallback to `/` for route-shaped paths.
+      //   5. Asset-shaped paths (extension != .html/.htm) return honest 404.
 
       // (1) 3xx redirects: fire unconditionally.
       if (match && match.rule.status >= 300 && match.rule.status < 400) {
@@ -245,39 +162,54 @@ const handler = {
         );
       }
 
-      // (2) Asset lookup. If the asset exists, serve it — real files win
-      // over 200 rewrites (matches Cloudflare Pages behavior). "Exists"
-      // includes canonical 3xx redirects that html_handling issues for
-      // existing .html / index.html files; those are forwarded so the
-      // browser sees the canonical URL (the documented CF Pages behavior).
-      const res = await env.ASSETS.fetch(request);
-      if (!looksLikeAssetMiss(res, url.pathname)) return withMime(request, res);
-
-      // (3) Asset miss + 200 rewrite matched → apply rewrite.
-      // `html_handling: 'auto-trailing-slash'` canonicalizes any .html path
-      // away: /foo.html → 307 /foo, /foo/index.html → 307 /foo/, /index.html
-      // → 307 /. Fetching the .html target literally would defeat the
-      // rewrite (the worker would forward the 307). normalizeRewriteTarget
-      // strips .html / index.html so the resolved path round-trips through
-      // Assets's trailing-slash resolution and returns 200.
-      if (match && match.rule.status === 200) {
-        const fetchPath = normalizeRewriteTarget(match.resolvedTo);
-        const fetchUrl = new URL(fetchPath, url);
-        const rewritten = await env.ASSETS.fetch(
-          new Request(fetchUrl.toString(), request),
-        );
-        return withMime(new Request(fetchUrl.toString()), rewritten);
+      // (2) Asset lookup: try each candidate in order, first 2xx wins.
+      // Real files win over 200 rewrites (matches Cloudflare Pages behavior).
+      const candidates = resolveAssetPath(url.pathname);
+      let lastAssetRes: Response | null = null;
+      for (const candidate of candidates) {
+        const candidateUrl = new URL(request.url);
+        candidateUrl.pathname = candidate;
+        const res = await env.ASSETS.fetch(new Request(candidateUrl.toString(), request));
+        if (res.ok) return res;
+        lastAssetRes = res;
       }
 
-      // (4) No matching rule and asset miss → default SPA fallback to `/`.
-      // Preserves the PR #33 fix for apps that don't ship a `_redirects`
-      // file (and for apps that ship one without a catch-all).
-      const fallbackUrl = new URL(request.url);
-      fallbackUrl.pathname = '/';
-      const fallback = await env.ASSETS.fetch(
-        new Request(fallbackUrl.toString(), request),
-      );
-      return withMime(new Request(fallbackUrl.toString()), fallback);
+      // (3) Asset miss + 200 rewrite matched → try rewrite target candidates.
+      if (match && match.rule.status === 200) {
+        const targetCandidates = resolveAssetPath(match.resolvedTo);
+        for (const candidate of targetCandidates) {
+          const candidateUrl = new URL(request.url);
+          candidateUrl.pathname = candidate;
+          const rewritten = await env.ASSETS.fetch(
+            new Request(candidateUrl.toString(), request),
+          );
+          if (rewritten.ok) return rewritten;
+        }
+      }
+
+      // (4 & 5) All candidates missed. Route-shaped paths get SPA fallback;
+      // asset-shaped paths (binary extensions) return an honest 404.
+      if (isRouteLikeRequest(url.pathname)) {
+        // SPA fallback: resolve `/` via the same candidate chain, which tries
+        // `/` then `/index.html` (trailing-slash candidate 2). Under
+        // html_handling: 'none' the Assets binding returns 404 for `/` since
+        // only `/index.html` exists; the candidate chain handles that correctly.
+        const fallbackCandidates = resolveAssetPath('/');
+        for (const candidate of fallbackCandidates) {
+          const fallbackUrl = new URL(request.url);
+          fallbackUrl.pathname = candidate;
+          const fallback = await env.ASSETS.fetch(
+            new Request(fallbackUrl.toString(), request),
+          );
+          if (fallback.ok) return fallback;
+          lastAssetRes = fallback;
+        }
+        // If even / and /index.html miss, return the last response as-is.
+        return lastAssetRes ?? new Response('', { status: 404 });
+      }
+
+      // Asset-shaped miss: return the last 404 verbatim. No SPA fallback.
+      return lastAssetRes ?? new Response('', { status: 404 });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return new Response('worker error: ' + message, { status: 500 });

--- a/packages/static-frontend-worker/src/worker.ts
+++ b/packages/static-frontend-worker/src/worker.ts
@@ -190,21 +190,15 @@ const handler = {
       // (4 & 5) All candidates missed. Route-shaped paths get SPA fallback;
       // asset-shaped paths (binary extensions) return an honest 404.
       if (isRouteLikeRequest(url.pathname)) {
-        // SPA fallback: resolve `/` via the same candidate chain, which tries
-        // `/` then `/index.html` (trailing-slash candidate 2). Under
-        // html_handling: 'none' the Assets binding returns 404 for `/` since
-        // only `/index.html` exists; the candidate chain handles that correctly.
-        const fallbackCandidates = resolveAssetPath('/');
-        for (const candidate of fallbackCandidates) {
-          const fallbackUrl = new URL(request.url);
-          fallbackUrl.pathname = candidate;
-          const fallback = await env.ASSETS.fetch(
-            new Request(fallbackUrl.toString(), request),
-          );
-          if (fallback.ok) return fallback;
-          lastAssetRes = fallback;
-        }
-        // If even / and /index.html miss, return the last response as-is.
+        // SPA fallback: fetch /index.html directly. Under html_handling: 'none',
+        // '/' always 404s (no literal file named '/'); skipping it saves a
+        // guaranteed-miss round-trip on every SPA miss.
+        const spaUrl = new URL(request.url);
+        spaUrl.pathname = '/index.html';
+        const fallback = await env.ASSETS.fetch(new Request(spaUrl.toString(), request));
+        if (fallback.ok) return fallback;
+        lastAssetRes = fallback;
+        // If /index.html also misses, return the last response as-is.
         return lastAssetRes ?? new Response('', { status: 404 });
       }
 

--- a/services/control-api/src/services/__tests__/deployment.wfp.test.ts
+++ b/services/control-api/src/services/__tests__/deployment.wfp.test.ts
@@ -200,6 +200,37 @@ describe('runDeploymentPipeline (WfP branch)', () => {
     expect(allParamsFlat).toContain('READY');
   });
 
+  it('strips /_redirects from the fileMap before calling deployUserWorker', async () => {
+    const zipBuffer = makeZipBuffer({
+      'index.html': '<html>hi</html>',
+      '_redirects': '/old /new 301\n/* /index.html 200\n',
+    });
+    (R2.downloadObjectAsBuffer as ReturnType<typeof vi.fn>).mockResolvedValue(zipBuffer);
+
+    const db = makeDb({
+      name: 'My App',
+      subdomain: 'myapp',
+      cloudflare_project_name: null,
+      deployment_backend: 'wfp',
+    });
+
+    wireRuntimeDb(db);
+    await runDeploymentPipeline(
+      db as unknown as import('pg').Pool,
+      'app_abc',
+      'dep_redirects',
+      { r2_object_key: 'r2/key', framework: 'react-vite' }
+    );
+
+    expect(CloudflareWfp.deployUserWorker).toHaveBeenCalledTimes(1);
+    const call = (CloudflareWfp.deployUserWorker as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // _redirects must not appear in the uploaded bundle — it was parsed into
+    // BB_REDIRECTS_RULES and stripped so it doesn't leak routing config.
+    expect(call.files.has('/_redirects')).toBe(false);
+    // But the rest of the files should still be present.
+    expect(call.files.has('/index.html')).toBe(true);
+  });
+
   it('supersedes active app_edge_ssr_deployments rows when WfP static deploy reaches READY', async () => {
     const zipBuffer = makeZipBuffer({
       'index.html': '<html>hi</html>',

--- a/services/control-api/src/services/cloudflare-wfp.test.ts
+++ b/services/control-api/src/services/cloudflare-wfp.test.ts
@@ -101,7 +101,7 @@ describe('deployUserWorker', () => {
     const metadataBlob = (deployInit.body as FormData).get('metadata') as Blob;
     const metadataJson = JSON.parse(await metadataBlob.text());
     expect(metadataJson.main_module).toBe('worker.mjs');
-    expect(metadataJson.assets.config.html_handling).toBe('auto-trailing-slash');
+    expect(metadataJson.assets.config.html_handling).toBe('none');
     expect(metadataJson.assets.jwt).toBe('completion-jwt');
     expect(metadataJson.bindings).toEqual([
       { type: 'assets', name: 'ASSETS' },

--- a/services/control-api/src/services/cloudflare-wfp.ts
+++ b/services/control-api/src/services/cloudflare-wfp.ts
@@ -87,7 +87,7 @@ export async function deployUserWorkerWithScript(
     assets: {
       jwt: completionToken,
       config: {
-        html_handling: 'auto-trailing-slash',
+        html_handling: 'none',
       },
     },
     bindings: [

--- a/services/control-api/src/services/deployment.service.ts
+++ b/services/control-api/src/services/deployment.service.ts
@@ -577,6 +577,10 @@ async function deployViaWfp(ctx: PipelineCtx): Promise<DeployResult> {
     }
   }
 
+  // Strip _redirects from the upload — parsed rules are baked into BB_REDIRECTS_RULES,
+  // the served copy would be dead weight and would leak routing config.
+  fileMap.delete('/_redirects');
+
   console.log(`${tag} Step 3/5: Deploying ${files.length} files to WfP (script=${appId})…`);
   const wfpStart = Date.now();
   await CloudflareWfp.deployUserWorker({

--- a/services/control-api/src/services/spa-routing-probe.test.ts
+++ b/services/control-api/src/services/spa-routing-probe.test.ts
@@ -100,14 +100,15 @@ describe('probeSpaRouting', () => {
       .fn()
       .mockResolvedValueOnce(new Response('', { status: 404 })) // dispatcher hasn't seen new script yet
       .mockResolvedValueOnce(new Response('', { status: 404 })) // still propagating
-      .mockResolvedValueOnce(html200()); // ok on 3rd try
+      .mockResolvedValueOnce(html200()) // ok on 3rd try (deep-path probe passes)
+      .mockResolvedValueOnce(html200()); // /index.html second probe
     const result = await probeSpaRouting('https://app.example.com', {
       fetchImpl: fetchMock,
       sleep: noSleep,
       retries: 2,
     });
     expect(result.ok).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it('reports the LAST failure when all retries fail', async () => {
@@ -174,5 +175,89 @@ describe('probeSpaRouting', () => {
     expect(sleepMock.mock.invocationCallOrder[0]).toBeLessThan(
       fetchMock.mock.invocationCallOrder[0],
     );
+  });
+
+  describe('/index.html second probe', () => {
+    it('overall probe passes when deep-path and /index.html both return 200 + text/html', async () => {
+      // First call: random deep-path probe; second call: /index.html probe.
+      const fetchMock = vi.fn().mockResolvedValue(html200());
+      const result = await probeSpaRouting('https://app.example.com', {
+        fetchImpl: fetchMock,
+        sleep: noSleep,
+        retries: 0,
+      });
+      expect(result.ok).toBe(true);
+      // Two fetches should have been made: deep-path + /index.html
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls[0]).toMatch(/__bb_route_probe_/);
+      expect(urls[1]).toBe('https://app.example.com/index.html');
+    });
+
+    it('fails with INDEX_HTML_PROBE_FAILED when /index.html returns 404', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(html200()) // deep-path succeeds
+        .mockResolvedValueOnce(new Response('', { status: 404 })); // /index.html 404
+      const result = await probeSpaRouting('https://app.example.com', {
+        fetchImpl: fetchMock,
+        sleep: noSleep,
+        retries: 0,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('INDEX_HTML_PROBE_FAILED');
+        expect(result.status).toBe(404);
+      }
+    });
+
+    it('fails with INDEX_HTML_PROBE_FAILED when /index.html returns non-text/html content-type', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(html200()) // deep-path succeeds
+        .mockResolvedValueOnce(
+          new Response('{"oops":1}', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      const result = await probeSpaRouting('https://app.example.com', {
+        fetchImpl: fetchMock,
+        sleep: noSleep,
+        retries: 0,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('INDEX_HTML_PROBE_FAILED');
+        expect(result.reason).toMatch(/expected content-type text\/html/);
+      }
+    });
+
+    it('does not run /index.html probe if the deep-path probe already fails', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response('', { status: 404 })); // deep-path fails
+      const result = await probeSpaRouting('https://app.example.com', {
+        fetchImpl: fetchMock,
+        sleep: noSleep,
+        retries: 0,
+      });
+      expect(result.ok).toBe(false);
+      // Only one fetch — /index.html probe is skipped when deep-path fails.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('strips a trailing slash from deploymentUrl before appending /index.html', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(html200());
+      await probeSpaRouting('https://app.example.com/', {
+        fetchImpl: fetchMock,
+        sleep: noSleep,
+        retries: 0,
+      });
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls[1]).toBe('https://app.example.com/index.html');
+      // Ensure no double-slash in the path portion (after the protocol)
+      expect(urls[1].replace('https://', '')).not.toMatch(/\/\//);
+    });
   });
 });

--- a/services/control-api/src/services/spa-routing-probe.ts
+++ b/services/control-api/src/services/spa-routing-probe.ts
@@ -33,7 +33,7 @@ export interface ProbeOptions {
 
 export type ProbeResult =
   | { ok: true; status: number; contentType: string }
-  | { ok: false; reason: string; status?: number; contentType?: string | null };
+  | { ok: false; reason: string; code?: string; status?: number; contentType?: string | null };
 
 const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -63,8 +63,31 @@ export async function probeSpaRouting(
   for (let attempt = 0; attempt <= retries; attempt++) {
     if (attempt > 0) await sleep(retryDelayMs);
     lastResult = await singleAttempt(fetchImpl, url, timeoutMs);
-    if (lastResult.ok) return lastResult;
+    if (lastResult.ok) break;
   }
+  if (!lastResult.ok) return lastResult;
+
+  // Second probe: GET /index.html and assert 200 + text/html.
+  // This catches "the worker can't find index.html at all" regardless of framework —
+  // a universal sanity check that complements the random-deep-path SPA-fallback probe.
+  const indexUrl = deploymentUrl.replace(/\/+$/, '') + '/index.html';
+  let indexResult: ProbeResult = { ok: false, reason: 'no attempts made' };
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await sleep(retryDelayMs);
+    indexResult = await singleAttempt(fetchImpl, indexUrl, timeoutMs);
+    if (indexResult.ok) break;
+  }
+  if (!indexResult.ok) {
+    return {
+      ok: false,
+      code: 'INDEX_HTML_PROBE_FAILED',
+      reason: indexResult.reason,
+      status: indexResult.status,
+      contentType: indexResult.contentType,
+    };
+  }
+
   return lastResult;
 }
 


### PR DESCRIPTION
## Summary

Implements [Phase 5 + Phase 6 of the static-frontend-worker plan](../blob/feat/static-frontend-worker-phase-5-6/docs/superpowers/plans/2026-06-06-static-frontend-worker-phase-5-6.md).

- **Phase 5:** Switch WfP `html_handling` from `'auto-trailing-slash'` to `'none'` and let the worker own path resolution via an explicit candidate chain. Removes the `looksLikeAssetMiss` heuristic and the `normalizeRewriteTarget` `.html` stripping — both become dead code.
- **Phase 6:** Delete the duplicate MIME map in `worker.ts`. The outer `dispatch-worker` already re-applies Content-Type on every user-worker response, so the inner copy was dead weight.
- **Side effects:** `_redirects` is now stripped from the uploaded asset bundle at deploy time (parsed rules already govern routing); the post-deploy probe also hits `/index.html` as a universal sanity check.

## Behavior changes (user-visible)

| Request | Old | New |
|---|---|---|
| `/index.html` | 307 → `/`, browser follows | 200 literal |
| `/foo.html` (real file) | 307 → `/foo` (CF canonical) | 200 literal |
| `/missing.png`, `/missing.css` (no matching rule) | 200 with index.html body (broken image) | 404 honestly |
| `/_redirects` | served verbatim | 404 (stripped from upload) |

Users who want the old canonical-redirect behavior can ship explicit `_redirects` rules (`/foo.html /foo 301`). The non-html-extension 404 rule does **not** apply when an explicit `200` rewrite (e.g. `/* /index.html 200`) catches the path — that matches Cloudflare Pages semantics.

## Test plan

- [x] `npm test` in `packages/static-frontend-worker/` — 102/102 (29 redirects-parser + 43 worker unit + 30 Miniflare integration)
- [x] `npm test` for control-api touched files (`cloudflare-wfp.test.ts`, `spa-routing-probe.test.ts`) — 30/30 (pre-existing DB-fixture failures elsewhere are unchanged from main)
- [x] `npm run build` clean in both workspaces
- [x] Layer 3 smoke via `local-server.mjs` against SPA + multi-page + mixed fixtures — 17/17 probes pass
- [x] Dual-worker Miniflare smoke (dispatch-worker → static-frontend-worker via service binding) — `/styles.css` returns `text/css`, `/logo.png` returns `image/png`, confirming dispatch-worker's `withMime` covers asset paths after Phase 6 removal
- [x] Full local docker-compose stack rebuilt + restarted; control-api deploy-flow smoke green

## Rollback

PR revert → wrapper submodule bump → `gh workflow run deploy.yml -f target=platform` → re-run backfill. ~10 minutes. dispatch-worker is untouched.