### PR TITLE
fix(edge-ssr): restore html_handling=auto-trailing-slash for next-on-pages

### DIFF
--- a/services/control-api/src/services/__tests__/edge-ssr-deployment.test.ts
+++ b/services/control-api/src/services/__tests__/edge-ssr-deployment.test.ts
@@ -166,7 +166,7 @@ describe('runEdgeSsrPipeline — _worker.js detection', () => {
     // deployUserWorkerWithScript called exactly once with correct shape
     expect(CloudflareWfp.deployUserWorkerWithScript).toHaveBeenCalledTimes(1);
     const args = (CloudflareWfp.deployUserWorkerWithScript as ReturnType<typeof vi.fn>).mock.calls[0];
-    const [input, scriptStr, additionalModules] = args;
+    const [input, scriptStr, additionalModules, compatFlags, htmlHandling] = args;
     expect(input.scriptName).toBe('app_abc');
     expect(input.files).toBeInstanceOf(Map);
     expect(input.files.size).toBe(2);
@@ -175,6 +175,11 @@ describe('runEdgeSsrPipeline — _worker.js detection', () => {
     expect(scriptStr).toBe(workerSrc);
     expect(additionalModules).toBeInstanceOf(Map);
     expect(additionalModules.size).toBe(0);
+    // Edge SSR needs nodejs_compat + auto-trailing-slash so env.ASSETS.fetch('/')
+    // resolves to /index.html for prerendered pages (next-on-pages has no
+    // resolution chain of its own, unlike the static-frontend-worker).
+    expect(compatFlags).toEqual(['nodejs_compat']);
+    expect(htmlHandling).toBe('auto-trailing-slash');
 
     expect(CloudflareWfp.writeSubdomainMapping).toHaveBeenCalledWith('myapp', 'app_abc', 'local');
 

--- a/services/control-api/src/services/cloudflare-wfp.test.ts
+++ b/services/control-api/src/services/cloudflare-wfp.test.ts
@@ -202,6 +202,40 @@ describe('deployUserWorkerWithScript', () => {
     expect(metadataJson.main_module).toBe('worker.mjs');
   });
 
+  it('defaults html_handling to none and forwards the override into CF metadata', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okText({ jwt: 'session-jwt' }))
+      .mockResolvedValueOnce(okText({ id: 'script-id' }))
+      .mockResolvedValueOnce(okText({ jwt: 'session-jwt-2' }))
+      .mockResolvedValueOnce(okText({ id: 'script-id-2' }));
+
+    const script = 'export default { async fetch() { return new Response("x"); } };';
+
+    // Default: 'none' (static-frontend-worker contract — has its own resolution chain)
+    await deployUserWorkerWithScript(
+      { scriptName: 'app_default', files: new Map(), envVars: {} },
+      script,
+    );
+    let metadataJson = JSON.parse(
+      await ((fetchMock.mock.calls[1][1].body as FormData).get('metadata') as Blob).text(),
+    );
+    expect(metadataJson.assets.config.html_handling).toBe('none');
+
+    // Override: 'auto-trailing-slash' (edge-ssr contract — relies on CF to rewrite / -> /index.html)
+    await deployUserWorkerWithScript(
+      { scriptName: 'app_edge', files: new Map(), envVars: {} },
+      script,
+      undefined,
+      ['nodejs_compat'],
+      'auto-trailing-slash',
+    );
+    metadataJson = JSON.parse(
+      await ((fetchMock.mock.calls[3][1].body as FormData).get('metadata') as Blob).text(),
+    );
+    expect(metadataJson.assets.config.html_handling).toBe('auto-trailing-slash');
+    expect(metadataJson.compatibility_flags).toEqual(['nodejs_compat']);
+  });
+
   it('deploys without additionalModules when the parameter is omitted', async () => {
     fetchMock
       .mockResolvedValueOnce(okText({ jwt: 'session-jwt' }))

--- a/services/control-api/src/services/cloudflare-wfp.ts
+++ b/services/control-api/src/services/cloudflare-wfp.ts
@@ -33,11 +33,18 @@ function hash32(buf: Buffer): string {
 // to the WfP dispatch namespace verbatim. To modify worker behavior, edit
 // packages/static-frontend-worker/src/worker.ts and rebuild.
 
+export type AssetsHtmlHandling =
+  | 'none'
+  | 'auto-trailing-slash'
+  | 'drop-trailing-slash'
+  | 'force-trailing-slash';
+
 export async function deployUserWorkerWithScript(
   input: DeployInput,
   workerScript: string,
   additionalModules?: Map<string, Buffer>,
   compatibilityFlags?: string[],
+  htmlHandling: AssetsHtmlHandling = 'none',
 ): Promise<void> {
   const { scriptName, files, envVars } = input;
 
@@ -87,7 +94,7 @@ export async function deployUserWorkerWithScript(
     assets: {
       jwt: completionToken,
       config: {
-        html_handling: 'none',
+        html_handling: htmlHandling,
       },
     },
     bindings: [

--- a/services/control-api/src/services/edge-ssr-deployment.service.ts
+++ b/services/control-api/src/services/edge-ssr-deployment.service.ts
@@ -613,11 +613,17 @@ export async function deployArtifact(
     // (node:buffer, node:async_hooks, etc.), so the script needs the
     // nodejs_compat flag at deploy time. Without it, Cloudflare serves the
     // built-in /cdn-cgi/errors/no-nodejs_compat.html page for every request.
+    //
+    // html_handling: 'auto-trailing-slash' is required so env.ASSETS.fetch('/')
+    // resolves to /index.html for prerendered pages. The static-frontend-worker
+    // uses 'none' because it implements its own candidate-resolution chain;
+    // next-on-pages has no such chain and relies on CF's auto handling.
     await CloudflareWfp.deployUserWorkerWithScript(
       { scriptName: appId, files: assetMap, envVars },
       workerScript.toString('utf-8'),
       additionalModules,
-      ['nodejs_compat']
+      ['nodejs_compat'],
+      'auto-trailing-slash'
     );
     console.log(`${tag} Step 3/6: WfP deploy completed in ${Date.now() - wfpStart}ms`);
 


### PR DESCRIPTION
## Summary
- Phase 5+6 (#40) flipped `html_handling` from `auto-trailing-slash` to `none` in the *shared* `deployUserWorkerWithScript` helper. Correct for static-frontend-worker (it has its own `resolveAssetPath` chain), but it silently broke edge-ssr: `@cloudflare/next-on-pages` has no in-worker resolution and relies on `env.ASSETS.fetch()` to rewrite `/` → `/index.html`.
- Parameterize `htmlHandling` on `deployUserWorkerWithScript` (default `'none'`, preserving the static-worker contract). Edge-ssr call site now passes `'auto-trailing-slash'` explicitly.

## Repro (Miniflare, isolated to the asset-binding layer)
```
[none]               /            -> 404
[none]               /index.html  -> 200
[auto-trailing-slash] /           -> 200
[auto-trailing-slash] /index.html -> 307 (redirects to /)
```
Reporter's symptom — "`/` 404s, `/index.html` 200s, x-nextjs-prerender:1 set" — is exactly the `html_handling: 'none'` signature. `nodejs_compat` and the `ASSETS` binding were already wired correctly; the diagnosis in the bug report was a red herring.

## Test plan
- [x] `cloudflare-wfp.test.ts`: assert default `'none'` + override `'auto-trailing-slash'` both reach CF metadata (14/14 pass).
- [x] `edge-ssr-deployment.test.ts`: assert the edge-ssr call site passes `['nodejs_compat']` + `'auto-trailing-slash'`.
- [x] Static-worker regression: 102/102 unit + Miniflare tests still pass under `'none'`.
- [x] Live Miniflare probe against the real worker source under `'none'`: `/`, `/index.html`, `/about`, `/about/`, deep SPA route, `/missing.png`, `/missing.js` — all behave per contract.
- [ ] Post-merge: bump wrapper submodule and verify on a real edge-ssr deploy.