### PR TITLE
feat(functions): expose deployed source via MCP, CLI, and REST

### DIFF
--- a/packages/cli/bin/butterbase.ts
+++ b/packages/cli/bin/butterbase.ts
@@ -9,7 +9,7 @@ import { initCommand } from '../src/commands/init.js';
 import { loginCommand, logoutCommand, configGetCommand, configSetCommand } from '../src/commands/config.js';
 import { appsListCommand, appsCreateCommand, appsUseCommand, appsDeleteCommand, appsPauseCommand, appsResumeCommand, appsLinkSubstrateCommand, appsUnlinkSubstrateCommand } from '../src/commands/apps.js';
 import { schemaGetCommand, schemaApplyCommand } from '../src/commands/schema.js';
-import { functionsListCommand, functionsDeployCommand, functionsLogsCommand, functionsDeleteCommand, functionsInvokeCommand, functionsEnvSetCommand, functionsEnvListCommand } from '../src/commands/functions.js';
+import { functionsListCommand, functionsGetCommand, functionsDeployCommand, functionsLogsCommand, functionsDeleteCommand, functionsInvokeCommand, functionsEnvSetCommand, functionsEnvListCommand } from '../src/commands/functions.js';
 import { storageListCommand, storageUploadCommand, storageDeleteCommand, storageConfigCommand } from '../src/commands/storage.js';
 import { realtimeEnableCommand, realtimeConfigCommand, realtimeDisableCommand } from '../src/commands/realtime.js';
 import { deployCommand } from '../src/commands/deploy.js';
@@ -369,6 +369,15 @@ functions
   .description('List deployed functions')
   .option('--app <app-id>', 'App ID (uses current app if not specified)')
   .action(functionsListCommand);
+
+functions
+  .command('get <function-name>')
+  .description('Show a deployed function including its source code')
+  .option('--app <app-id>', 'App ID (uses current app if not specified)')
+  .option('--output <file>', 'Write source code to a file instead of stdout')
+  .option('--source-only', 'Print only the source code (no metadata)')
+  .option('--json', 'Print full function detail as JSON')
+  .action(functionsGetCommand);
 
 functions
   .command('deploy <file>')

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -54,6 +54,48 @@ export async function functionsListCommand(options: { app?: string }) {
   }
 }
 
+export async function functionsGetCommand(name: string, options: { app?: string; output?: string; json?: boolean; sourceOnly?: boolean }) {
+  const appId = await requireAppId(options.app);
+  const spinner = ora(`Fetching function "${name}"...`).start();
+
+  try {
+    const fn: any = await getFunction(appId, name);
+    spinner.stop();
+
+    if (options.output) {
+      await fs.writeFile(options.output, fn.code ?? '', 'utf-8');
+      console.log(chalk.green(`✓ Wrote source code to ${options.output}`));
+      return;
+    }
+
+    if (options.sourceOnly) {
+      process.stdout.write(fn.code ?? '');
+      return;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(fn, null, 2));
+      return;
+    }
+
+    console.log(chalk.bold(`\n${fn.name}`));
+    if (fn.description) console.log(chalk.gray(`  Description: ${fn.description}`));
+    const triggerTypes = Array.isArray(fn.triggers)
+      ? fn.triggers.map((t: { type: string }) => t.type).join(', ')
+      : '—';
+    console.log(chalk.gray(`  Triggers: ${triggerTypes}`));
+    console.log(chalk.gray(`  Deployed: ${fn.deployedAt}`));
+    if (fn.timeoutMs) console.log(chalk.gray(`  Timeout: ${fn.timeoutMs}ms`));
+    if (fn.memoryLimitMb) console.log(chalk.gray(`  Memory: ${fn.memoryLimitMb}MB`));
+    console.log(chalk.blue('\n--- Source ---'));
+    console.log(fn.code ?? '');
+  } catch (error) {
+    spinner.fail('Failed to fetch function');
+    console.error(chalk.red((error as Error).message));
+    process.exit(1);
+  }
+}
+
 export async function functionsDeployCommand(file: string, options: {
   app?: string;
   name?: string;

--- a/services/mcp-server/src/tools/manage-function.ts
+++ b/services/mcp-server/src/tools/manage-function.ts
@@ -27,6 +27,25 @@ interface ListFunctionsResponse {
   }>;
 }
 
+interface FunctionDetailResponse {
+  id: string;
+  name: string;
+  description?: string;
+  code: string;
+  triggers: Array<{ type: string; config: unknown; enabled?: boolean }>;
+  timeoutMs?: number;
+  memoryLimitMb?: number;
+  deployedAt: string;
+  lastInvoked?: string;
+  invocationCount: number;
+  errorCount: number;
+  avgDuration: number;
+  agent_tool?: boolean;
+  agent_tool_description?: string | null;
+  agent_tool_mode?: 'read_only' | 'read_write' | null;
+  agent_tool_exposed_to?: 'developer_only' | 'end_user' | null;
+}
+
 interface FunctionLogsResponse {
   logs: Array<{
     timestamp: string;
@@ -45,16 +64,18 @@ interface FunctionLogsResponse {
 export function registerManageFunction(server: McpServer) {
   server.tool(
     'manage_function',
-    `Manage function lifecycle: list, delete, get logs, and update environment variables.
+    `Manage function lifecycle: list, get source, delete, get logs, and update environment variables.
 
 Actions:
   - "list":       List all deployed functions with status, metrics, and invocation URLs
+  - "get":        Retrieve a single function's full detail including its deployed source code
   - "delete":     Delete a deployed function permanently (IRREVERSIBLE)
   - "get_logs":   Retrieve recent invocation logs for debugging and monitoring
   - "update_env": Update environment variables for a deployed function without redeploying code
 
 Parameters by action:
   list:       { app_id, action: "list" }
+  get:        { app_id, action: "get", function_name }
   delete:     { app_id, action: "delete", function_name }
   get_logs:   { app_id, action: "get_logs", function_name, limit?, since?, level?, include_deleted? }
   update_env: { app_id, action: "update_env", function_name, env }
@@ -66,8 +87,8 @@ Common errors:
 Idempotency: Safe to call anytime (list is read-only; delete is idempotent; update_env is safe to call multiple times).`,
     {
       app_id: z.string().describe('The app ID'),
-      action: z.enum(['list', 'delete', 'get_logs', 'update_env']).describe('The action to perform'),
-      function_name: z.string().optional().describe('The function name (required for delete, get_logs, update_env)'),
+      action: z.enum(['list', 'get', 'delete', 'get_logs', 'update_env']).describe('The action to perform'),
+      function_name: z.string().optional().describe('The function name (required for get, delete, get_logs, update_env)'),
       // get_logs params
       limit: z.number().optional().describe('Maximum number of logs to return (default: 100)'),
       since: z.string().optional().describe('ISO timestamp to filter logs after this time'),
@@ -91,6 +112,14 @@ Idempotency: Safe to call anytime (list is read-only; delete is idempotent; upda
       switch (action) {
         case 'list': {
           const result = await apiGet<ListFunctionsResponse>(`/v1/${args.app_id}/functions`);
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        }
+        case 'get': {
+          const err = need(args.function_name, '"function_name" is required for the "get" action.');
+          if (err) return err;
+          const result = await apiGet<FunctionDetailResponse>(
+            `/v1/${args.app_id}/functions/${args.function_name}`
+          );
           return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
         }
         case 'delete': {


### PR DESCRIPTION
## Summary
- New \`get\` action on \`manage_function\` MCP tool returns full function detail including \`code\`.
- New \`butterbase functions get <name>\` CLI command with \`--source-only\`, \`--output <file>\`, and \`--json\` flags.
- REST endpoint \`GET /v1/:appId/functions/:name\` already returns \`code\` — no change needed.

Closes the gap where users could deploy a function but had no read path to retrieve the deployed source.

## Test plan
- [x] HTTP: \`curl GET /v1/<app>/functions/<name>\` returns \`code\` field
- [x] MCP: \`tools/call manage_function {action:"get", function_name:...}\` returns code in JSON
- [x] CLI: \`butterbase functions get <name>\` prints formatted metadata + source
- [x] CLI: \`--source-only\` prints only source
- [x] CLI: \`--output <file>\` writes source to disk
- [ ] CLI: \`--json\` (compiled but not run; trivial passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)