### PR TITLE
feat(ai-meetings): meetings primitive — app-scoped routes, per-app encrypted webhook signing, full SDK/CLI/MCP coverage

### DIFF
--- a/db/control-plane/088_app_meetings_webhooks.sql
+++ b/db/control-plane/088_app_meetings_webhooks.sql
@@ -2,7 +2,7 @@
 -- Per-app forward target for the meetings webhook fan-out.
 
 CREATE TABLE app_meetings_webhooks (
-  app_id              TEXT PRIMARY KEY REFERENCES apps(id) ON DELETE CASCADE,
+  app_id              TEXT PRIMARY KEY,
   forward_url         TEXT NOT NULL,
   forward_secret_hash TEXT NOT NULL,
   events              TEXT[] NOT NULL DEFAULT ARRAY[

--- a/db/control-plane/088_app_meetings_webhooks.sql
+++ b/db/control-plane/088_app_meetings_webhooks.sql
@@ -1,14 +1,19 @@
--- @scope: control
+-- @scope: platform
 -- Per-app forward target for the meetings webhook fan-out.
 
 CREATE TABLE app_meetings_webhooks (
-  app_id              TEXT PRIMARY KEY,
-  forward_url         TEXT NOT NULL,
-  forward_secret_hash TEXT NOT NULL,
-  events              TEXT[] NOT NULL DEFAULT ARRAY[
-                        'bot.in_call_recording','bot.done','bot.fatal',
-                        'recording.done','transcript.done','transcript.failed'
-                      ]::TEXT[],
-  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+  app_id                   TEXT PRIMARY KEY,
+  forward_url              TEXT NOT NULL,
+  -- Raw per-app webhook secret, AES-256-GCM encrypted with AUTH_ENCRYPTION_KEY
+  -- via services/crypto.ts (iv:ciphertext:authTag, base64). The forwarder
+  -- decrypts on each delivery and signs the outbound payload with HMAC-SHA256
+  -- using the plaintext, so receivers can verify with the same secret they
+  -- were handed at PUT / rotate time.
+  forward_secret_encrypted TEXT NOT NULL,
+  events                   TEXT[] NOT NULL DEFAULT ARRAY[
+                             'bot.in_call_recording','bot.done','bot.fatal',
+                             'recording.done','transcript.done','transcript.failed'
+                           ]::TEXT[],
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/db/control-plane/088_app_meetings_webhooks.sql
+++ b/db/control-plane/088_app_meetings_webhooks.sql
@@ -1,0 +1,14 @@
+-- @scope: control
+-- Per-app forward target for the meetings webhook fan-out.
+
+CREATE TABLE app_meetings_webhooks (
+  app_id              TEXT PRIMARY KEY REFERENCES apps(id) ON DELETE CASCADE,
+  forward_url         TEXT NOT NULL,
+  forward_secret_hash TEXT NOT NULL,
+  events              TEXT[] NOT NULL DEFAULT ARRAY[
+                        'bot.in_call_recording','bot.done','bot.fatal',
+                        'recording.done','transcript.done','transcript.failed'
+                      ]::TEXT[],
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/db/control-plane/migrate.test.ts
+++ b/db/control-plane/migrate.test.ts
@@ -60,3 +60,52 @@ describe('applyByScope', () => {
     ).rejects.toThrow(/042_some_migration\.sql/);
   });
 });
+
+import pg from 'pg';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('migrations', () => {
+  it('088_app_meetings_webhooks has correct column schema', async () => {
+    const dbUrl = process.env.TEST_DATABASE_URL;
+    if (!dbUrl) {
+      console.warn('TEST_DATABASE_URL not set, skipping database test');
+      return;
+    }
+
+    const pool = new pg.Pool({ connectionString: dbUrl });
+    const client = await pool.connect();
+    try {
+      // Load and apply the migration
+      const migrationPath = path.join(__dirname, '088_app_meetings_webhooks.sql');
+      const migrationSql = fs.readFileSync(migrationPath, 'utf-8');
+
+      // Skip the @scope comment line and apply the rest
+      const sqlLines = migrationSql.split('\n').filter(line => !line.startsWith('-- @scope'));
+      await client.query(sqlLines.join('\n'));
+
+      // Query the columns from information_schema
+      const { rows } = await client.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'app_meetings_webhooks'
+        ORDER BY ordinal_position
+      `);
+
+      const columnNames = rows.map(row => row.column_name).sort();
+      expect(columnNames).toEqual([
+        'app_id',
+        'created_at',
+        'events',
+        'forward_secret_hash',
+        'forward_url',
+        'updated_at',
+      ]);
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  });
+});

--- a/db/runtime-plane/023_actor_usage_logs.sql
+++ b/db/runtime-plane/023_actor_usage_logs.sql
@@ -1,0 +1,26 @@
+-- @scope: runtime
+-- Time-dimensioned usage for actor-style providers.
+
+CREATE TYPE actor_usage_dimension AS ENUM ('recording', 'transcription');
+
+CREATE TABLE actor_usage_logs (
+  id            BIGSERIAL PRIMARY KEY,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  app_id        TEXT,
+  user_id       TEXT,
+  provider_key  TEXT NOT NULL,
+  actor_id      TEXT NOT NULL,
+  dimension     actor_usage_dimension NOT NULL,
+  seconds       INTEGER NOT NULL CHECK (seconds >= 0),
+  usd_cost      NUMERIC(12,6) NOT NULL,
+  usd_charged   NUMERIC(12,6) NOT NULL,
+  markup_pct    NUMERIC(6,3) NOT NULL,
+  lease_id      TEXT,
+  request_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT actor_usage_logs_actor_id_dimension_key UNIQUE (actor_id, dimension)
+);
+
+CREATE INDEX idx_actor_usage_logs_app_id_created_at
+  ON actor_usage_logs (app_id, created_at DESC);
+CREATE INDEX idx_actor_usage_logs_user_id_created_at
+  ON actor_usage_logs (user_id, created_at DESC);

--- a/db/runtime-plane/migrate.test.ts
+++ b/db/runtime-plane/migrate.test.ts
@@ -19,3 +19,59 @@ describe('resolveRuntimeUrls', () => {
     ).toThrow(/NEON_RUNTIME_PROJECT_ID_EU_WEST_1/);
   });
 });
+
+import pg from 'pg';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('migrations', () => {
+  it('023_actor_usage_logs has correct column schema', async () => {
+    const dbUrl = process.env.TEST_DATABASE_URL;
+    if (!dbUrl) {
+      console.warn('TEST_DATABASE_URL not set, skipping database test');
+      return;
+    }
+
+    const pool = new pg.Pool({ connectionString: dbUrl });
+    const client = await pool.connect();
+    try {
+      // Load and apply the migration
+      const migrationPath = path.join(__dirname, '023_actor_usage_logs.sql');
+      const migrationSql = fs.readFileSync(migrationPath, 'utf-8');
+
+      // Skip the @scope comment line and apply the rest
+      const sqlLines = migrationSql.split('\n').filter(line => !line.startsWith('-- @scope'));
+      await client.query(sqlLines.join('\n'));
+
+      // Query the columns from information_schema
+      const { rows } = await client.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'actor_usage_logs'
+        ORDER BY ordinal_position
+      `);
+
+      const columnNames = rows.map(row => row.column_name);
+      expect(columnNames).toEqual([
+        'id',
+        'created_at',
+        'app_id',
+        'user_id',
+        'provider_key',
+        'actor_id',
+        'dimension',
+        'seconds',
+        'usd_cost',
+        'usd_charged',
+        'markup_pct',
+        'lease_id',
+        'request_metadata',
+      ]);
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  });
+});

--- a/packages/cli/bin/butterbase.ts
+++ b/packages/cli/bin/butterbase.ts
@@ -78,6 +78,13 @@ import {
   aiConfigGetCommand,
   aiConfigSetCommand,
   aiUsageCommand,
+  aiMeetingsStartCommand,
+  aiMeetingsGetCommand,
+  aiMeetingsListCommand,
+  aiMeetingsStopCommand,
+  aiMeetingsEstimateCommand,
+  aiMeetingsUsageCommand,
+  aiMeetingsWebhookCommand,
 } from '../src/commands/ai.js';
 import {
   oauthConfigureCommand, oauthListCommand, oauthGetCommand, oauthUpdateCommand, oauthDeleteCommand,
@@ -1010,6 +1017,70 @@ ai
   .option('--json', 'Output raw JSON')
   .action((opts) => aiUsageCommand({
     app: opts.app, startDate: opts.startDate, endDate: opts.endDate, json: opts.json,
+  }));
+
+// ─── ai meetings ────────────────────────────────────────────────────────────
+const aiMeetings = ai.command('meetings').description('Meeting bots that join Zoom/Meet/Teams/Webex calls and return recordings + transcripts');
+
+aiMeetings
+  .command('start <meetingUrl>')
+  .description('Spawn a meeting bot')
+  .option('--app <appId>', 'Override current app')
+  .option('--no-transcript', 'Disable transcription')
+  .option('--recording <mode>', '"mp4" (default), "audio_only", or "false"', 'mp4')
+  .option('--json', 'Output raw JSON')
+  .action((meetingUrl, opts) => aiMeetingsStartCommand(meetingUrl, {
+    app: opts.app, transcript: opts.transcript, recording: opts.recording, json: opts.json,
+  }));
+
+aiMeetings
+  .command('get <meetingId>')
+  .description('Get current status + recording/transcript URLs (when ready)')
+  .option('--app <appId>', 'Override current app')
+  .option('--json', 'Output raw JSON')
+  .action((meetingId, opts) => aiMeetingsGetCommand(meetingId, opts));
+
+aiMeetings
+  .command('list')
+  .description('List meeting bots for this app')
+  .option('--app <appId>', 'Override current app')
+  .option('--status <phase>', 'Filter to a lifecycle phase (joining|waiting_room|in_call|recording|ended|done|fatal)')
+  .option('--limit <n>', 'Page size', parseInt)
+  .option('--cursor <s>', 'Pagination cursor')
+  .option('--json', 'Output raw JSON')
+  .action((opts) => aiMeetingsListCommand(opts));
+
+aiMeetings
+  .command('stop <meetingId>')
+  .description('Force a bot to leave its call')
+  .option('--app <appId>', 'Override current app')
+  .action((meetingId, opts) => aiMeetingsStopCommand(meetingId, opts));
+
+aiMeetings
+  .command('estimate <durationMinutes>')
+  .description('Predict the USD charge for a session at the given duration')
+  .option('--app <appId>', 'Override current app')
+  .option('--no-transcript', 'Skip transcription in the estimate')
+  .option('--json', 'Output raw JSON')
+  .action((durationMinutes, opts) => aiMeetingsEstimateCommand({
+    app: opts.app, durationMinutes: parseInt(durationMinutes), transcript: opts.transcript, json: opts.json,
+  }));
+
+aiMeetings
+  .command('usage')
+  .description('Recent actor_usage_logs rows for this app')
+  .option('--app <appId>', 'Override current app')
+  .option('--json', 'Output raw JSON')
+  .action((opts) => aiMeetingsUsageCommand(opts));
+
+aiMeetings
+  .command('webhook <forwardUrl>')
+  .description('Set the forward URL for meeting events. Use --rotate-secret to mint a new signing secret (shown once).')
+  .option('--app <appId>', 'Override current app')
+  .option('--rotate-secret', 'Generate a new wsec_... signing secret')
+  .option('--json', 'Output raw JSON')
+  .action((forwardUrl, opts) => aiMeetingsWebhookCommand(forwardUrl, {
+    app: opts.app, rotateSecret: opts.rotateSecret, json: opts.json,
   }));
 
 // OAuth

--- a/packages/cli/src/commands/ai.ts
+++ b/packages/cli/src/commands/ai.ts
@@ -120,3 +120,126 @@ export async function aiUsageCommand(options: { app?: string; startDate?: string
     process.exit(1);
   }
 }
+
+// ─── Meetings ────────────────────────────────────────────────────────────────
+// Spawn / inspect / stop meeting bots that join Zoom/Meet/Teams/Webex calls
+// and return recordings + transcripts. See butterbase_docs topic "meetings".
+
+import { apiGet, apiPost, apiPut, apiDelete } from '../lib/api-client.js';
+
+export async function aiMeetingsStartCommand(meetingUrl: string, options: { app?: string; transcript?: boolean; recording?: 'mp4' | 'audio_only' | 'false'; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  const recording = options.recording === 'false' ? false : (options.recording ?? 'mp4');
+  const spinner = ora('Spawning meeting bot...').start();
+  try {
+    const r: any = await apiPost(`/v1/${appId}/ai/meetings`, {
+      meetingUrl, transcript: options.transcript ?? true, recording,
+    });
+    spinner.stop();
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    console.log(chalk.green('Bot spawned:'), r.id);
+    console.log(chalk.gray('status:'), r.status);
+  } catch (e) {
+    spinner.fail('Spawn failed');
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsGetCommand(meetingId: string, options: { app?: string; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  try {
+    const r: any = await apiGet(`/v1/${appId}/ai/meetings/${encodeURIComponent(meetingId)}`);
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    console.log(chalk.bold(r.id));
+    console.log('  status:        ', r.status);
+    console.log('  startedAt:     ', r.startedAt ?? '—');
+    console.log('  duration (s):  ', r.durationSeconds ?? '—');
+    if (r.recordingUrl) console.log('  recordingUrl:  ', r.recordingUrl);
+    if (r.transcriptUrl) console.log('  transcriptUrl: ', r.transcriptUrl);
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsListCommand(options: { app?: string; status?: string; limit?: number; cursor?: string; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  const q = new URLSearchParams();
+  if (options.status) q.set('status', options.status);
+  if (options.limit !== undefined) q.set('limit', String(options.limit));
+  if (options.cursor) q.set('cursor', options.cursor);
+  const qs = q.toString();
+  try {
+    const r: any = await apiGet(`/v1/${appId}/ai/meetings${qs ? `?${qs}` : ''}`);
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    const rows = r.bots ?? r.rows ?? r;
+    for (const b of rows) {
+      console.log(`${b.id}  ${b.status?.padEnd(10) ?? '-'}  ${b.startedAt ?? ''}`);
+    }
+    if (r.nextCursor) console.log(chalk.gray(`-- next cursor: ${r.nextCursor}`));
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsStopCommand(meetingId: string, options: { app?: string }) {
+  const appId = await requireAppId(options.app);
+  try {
+    await apiDelete(`/v1/${appId}/ai/meetings/${encodeURIComponent(meetingId)}`);
+    console.log(chalk.green('Stopped:'), meetingId);
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsEstimateCommand(options: { app?: string; durationMinutes: number; transcript?: boolean; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  const q = new URLSearchParams();
+  q.set('durationMinutes', String(options.durationMinutes));
+  if (options.transcript !== undefined) q.set('transcript', String(options.transcript));
+  try {
+    const r: any = await apiGet(`/v1/${appId}/ai/meetings/_estimate?${q.toString()}`);
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    console.log(chalk.bold(`$${(r.usd ?? r).toFixed?.(4) ?? r}`), chalk.gray(`for ${options.durationMinutes}min ${options.transcript === false ? '(no transcript)' : 'with transcript'}`));
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsUsageCommand(options: { app?: string; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  try {
+    const r: any = await apiGet(`/v1/${appId}/ai/meetings/usage`);
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    for (const row of r.rows ?? []) {
+      console.log(`${row.created_at}  ${row.dimension.padEnd(14)} ${String(row.seconds).padStart(6)}s  $${row.usd_charged}`);
+    }
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function aiMeetingsWebhookCommand(forwardUrl: string, options: { app?: string; rotateSecret?: boolean; json?: boolean }) {
+  const appId = await requireAppId(options.app);
+  try {
+    const r: any = await apiPut(`/v1/${appId}/ai/meetings/webhook`, {
+      forward_url: forwardUrl,
+      rotate_secret: options.rotateSecret ?? false,
+    });
+    if (options.json) return console.log(JSON.stringify(r, null, 2));
+    console.log(chalk.green('Webhook configured.'));
+    console.log(chalk.gray('forward_url:'), r.forward_url);
+    if (r.secret) {
+      console.log(chalk.yellow('\nNew signing secret (shown once — store it now):'));
+      console.log('  ', r.secret);
+    }
+  } catch (e) {
+    console.error(chalk.red((e as Error).message));
+    process.exit(1);
+  }
+}

--- a/packages/sdk/src/ai/ai-client.test.ts
+++ b/packages/sdk/src/ai/ai-client.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { AiClient } from './ai-client';
+import { MeetingsClient } from './meetings-client.js';
 
 describe('AiClient.embed', () => {
   it('posts to /v1/:app/embeddings with the request body', async () => {
@@ -34,5 +35,12 @@ describe('AiClient.listModels', () => {
     };
     await new AiClient(fc).listModels();
     expect(calls[0]).toEqual({ m: 'GET', p: '/v1/app_x/ai/models' });
+  });
+});
+
+describe('AiClient.meetings', () => {
+  it('exposes .meetings as a MeetingsClient', () => {
+    const ai = new AiClient({ appId: 'app_1', request: vi.fn() } as any);
+    expect(ai.meetings).toBeInstanceOf(MeetingsClient);
   });
 });

--- a/packages/sdk/src/ai/ai-client.ts
+++ b/packages/sdk/src/ai/ai-client.ts
@@ -2,12 +2,20 @@ import type { ButterbaseClient } from '../lib/butterbase-client.js';
 import type { ButterbaseResponse } from '../types/index.js';
 import type { ChatMessage, ChatOptions, ChatCompletion, ChatStreamChunk, AiConfig, AiUsage,
   EmbeddingRequest, EmbeddingResponse, AiModel } from './types.js';
+import { MeetingsClient } from './meetings-client.js';
 
 export class AiClient {
   private client: ButterbaseClient;
 
   constructor(client: ButterbaseClient) {
     this.client = client;
+  }
+
+  private _meetings?: MeetingsClient;
+  /** Meeting bots — start/get/stop/list. Backed by a Butterbase-paid provider; billed per-second against AI credits. */
+  get meetings(): MeetingsClient {
+    if (!this._meetings) this._meetings = new MeetingsClient(this.client);
+    return this._meetings;
   }
 
   /**

--- a/packages/sdk/src/ai/meetings-client.test.ts
+++ b/packages/sdk/src/ai/meetings-client.test.ts
@@ -1,0 +1,53 @@
+// packages/sdk/src/ai/meetings-client.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { MeetingsClient } from './meetings-client.js';
+
+function fakeClient(impl: any) {
+  return { appId: 'app_1', request: vi.fn(impl), requestRaw: vi.fn() } as any;
+}
+
+describe('MeetingsClient', () => {
+  it('start POSTs to /v1/ai/meetings and returns the bot', async () => {
+    const client = fakeClient(async () => ({
+      id: 'bot_1', status: 'joining', startedAt: null, completedAt: null,
+      durationSeconds: null, recordingUrl: null, transcriptUrl: null, metadata: {},
+    }));
+    const meet = new MeetingsClient(client);
+    const { data, error } = await meet.start({ meetingUrl: 'https://meet.google.com/abc' });
+    expect(error).toBeNull();
+    expect(data?.id).toBe('bot_1');
+    expect(client.request).toHaveBeenCalledWith('POST', '/v1/ai/meetings',
+      expect.objectContaining({ meetingUrl: 'https://meet.google.com/abc' }));
+  });
+
+  it('get GETs /v1/ai/meetings/:id', async () => {
+    const client = fakeClient(async () => ({ id: 'bot_1', status: 'done' }));
+    const meet = new MeetingsClient(client);
+    await meet.get('bot_1');
+    expect(client.request).toHaveBeenCalledWith('GET', '/v1/ai/meetings/bot_1');
+  });
+
+  it('stop DELETEs /v1/ai/meetings/:id', async () => {
+    const client = fakeClient(async () => null);
+    const meet = new MeetingsClient(client);
+    const out = await meet.stop('bot_1');
+    expect(out.error).toBeNull();
+    expect(client.request).toHaveBeenCalledWith('DELETE', '/v1/ai/meetings/bot_1');
+  });
+
+  it('list builds the query string', async () => {
+    const client = fakeClient(async () => ({ bots: [], nextCursor: null }));
+    const meet = new MeetingsClient(client);
+    await meet.list({ status: 'done', limit: 50, cursor: 'c1' });
+    expect(client.request).toHaveBeenCalledWith('GET',
+      '/v1/ai/meetings?status=done&limit=50&cursor=c1');
+  });
+
+  it('surfaces errors via {data:null, error}', async () => {
+    const client = fakeClient(async () => { throw new Error('boom'); });
+    const meet = new MeetingsClient(client);
+    const { data, error } = await meet.start({ meetingUrl: 'https://meet.google.com/abc' });
+    expect(data).toBeNull();
+    expect(error?.message).toBe('boom');
+  });
+});

--- a/packages/sdk/src/ai/meetings-client.test.ts
+++ b/packages/sdk/src/ai/meetings-client.test.ts
@@ -50,4 +50,11 @@ describe('MeetingsClient', () => {
     expect(data).toBeNull();
     expect(error?.message).toBe('boom');
   });
+
+  it('estimateCost returns markup-applied USD', async () => {
+    const client = fakeClient(async () => ({ usd: 0.075 }));
+    const meet = new MeetingsClient(client);
+    const { data } = await meet.estimateCost({ durationMinutes: 60 });
+    expect(data?.usd).toBe(0.075);
+  });
 });

--- a/packages/sdk/src/ai/meetings-client.ts
+++ b/packages/sdk/src/ai/meetings-client.ts
@@ -51,4 +51,14 @@ export class MeetingsClient {
       return { data: null, error: error as Error };
     }
   }
+
+  async estimateCost(input: { durationMinutes: number; transcript?: boolean }): Promise<ButterbaseResponse<{ usd: number }>> {
+    try {
+      const qs = new URLSearchParams();
+      qs.set('durationMinutes', String(input.durationMinutes));
+      if (input.transcript !== undefined) qs.set('transcript', String(input.transcript));
+      const data = await this.client.request<{ usd: number }>('GET', `/v1/ai/meetings/_estimate?${qs.toString()}`);
+      return { data, error: null };
+    } catch (error) { return { data: null, error: error as Error }; }
+  }
 }

--- a/packages/sdk/src/ai/meetings-client.ts
+++ b/packages/sdk/src/ai/meetings-client.ts
@@ -5,13 +5,21 @@ import type {
   StartMeetingRequest, MeetingBot, ListMeetingsOptions, ListMeetingsResult,
 } from './meetings-types.js';
 
+/**
+ * MeetingsClient — spawn / inspect / stop meeting bots that join calls and
+ * return recordings + transcripts.
+ *
+ * All endpoints are scoped to the app the SDK was constructed with
+ * (`/v1/{appId}/ai/meetings/...`), matching the rest of the platform's
+ * app-scoped surface.
+ */
 export class MeetingsClient {
   constructor(private readonly client: ButterbaseClient) {}
 
   async start(req: StartMeetingRequest): Promise<ButterbaseResponse<MeetingBot>> {
     try {
       const data = await this.client.request<MeetingBot>(
-        'POST', `/v1/ai/meetings`, req,
+        'POST', `/v1/${this.client.appId}/ai/meetings`, req,
       );
       return { data, error: null };
     } catch (error) {
@@ -21,7 +29,9 @@ export class MeetingsClient {
 
   async get(id: string): Promise<ButterbaseResponse<MeetingBot>> {
     try {
-      const data = await this.client.request<MeetingBot>('GET', `/v1/ai/meetings/${id}`);
+      const data = await this.client.request<MeetingBot>(
+        'GET', `/v1/${this.client.appId}/ai/meetings/${id}`,
+      );
       return { data, error: null };
     } catch (error) {
       return { data: null, error: error as Error };
@@ -30,7 +40,9 @@ export class MeetingsClient {
 
   async stop(id: string): Promise<ButterbaseResponse<null>> {
     try {
-      await this.client.request<null>('DELETE', `/v1/ai/meetings/${id}`);
+      await this.client.request<null>(
+        'DELETE', `/v1/${this.client.appId}/ai/meetings/${id}`,
+      );
       return { data: null, error: null };
     } catch (error) {
       return { data: null, error: error as Error };
@@ -44,7 +56,7 @@ export class MeetingsClient {
       if (opts.limit !== undefined) params.set('limit', String(opts.limit));
       if (opts.cursor) params.set('cursor', opts.cursor);
       const qs = params.toString();
-      const path = `/v1/ai/meetings${qs ? `?${qs}` : ''}`;
+      const path = `/v1/${this.client.appId}/ai/meetings${qs ? `?${qs}` : ''}`;
       const data = await this.client.request<ListMeetingsResult>('GET', path);
       return { data, error: null };
     } catch (error) {
@@ -52,13 +64,19 @@ export class MeetingsClient {
     }
   }
 
-  async estimateCost(input: { durationMinutes: number; transcript?: boolean }): Promise<ButterbaseResponse<{ usd: number }>> {
+  async estimateCost(
+    input: { durationMinutes: number; transcript?: boolean },
+  ): Promise<ButterbaseResponse<{ usd: number }>> {
     try {
       const qs = new URLSearchParams();
       qs.set('durationMinutes', String(input.durationMinutes));
       if (input.transcript !== undefined) qs.set('transcript', String(input.transcript));
-      const data = await this.client.request<{ usd: number }>('GET', `/v1/ai/meetings/_estimate?${qs.toString()}`);
+      const data = await this.client.request<{ usd: number }>(
+        'GET', `/v1/${this.client.appId}/ai/meetings/_estimate?${qs.toString()}`,
+      );
       return { data, error: null };
-    } catch (error) { return { data: null, error: error as Error }; }
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
   }
 }

--- a/packages/sdk/src/ai/meetings-client.ts
+++ b/packages/sdk/src/ai/meetings-client.ts
@@ -1,0 +1,54 @@
+// packages/sdk/src/ai/meetings-client.ts
+import type { ButterbaseClient } from '../lib/butterbase-client.js';
+import type { ButterbaseResponse } from '../types/index.js';
+import type {
+  StartMeetingRequest, MeetingBot, ListMeetingsOptions, ListMeetingsResult,
+} from './meetings-types.js';
+
+export class MeetingsClient {
+  constructor(private readonly client: ButterbaseClient) {}
+
+  async start(req: StartMeetingRequest): Promise<ButterbaseResponse<MeetingBot>> {
+    try {
+      const data = await this.client.request<MeetingBot>(
+        'POST', `/v1/ai/meetings`, req,
+      );
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  async get(id: string): Promise<ButterbaseResponse<MeetingBot>> {
+    try {
+      const data = await this.client.request<MeetingBot>('GET', `/v1/ai/meetings/${id}`);
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  async stop(id: string): Promise<ButterbaseResponse<null>> {
+    try {
+      await this.client.request<null>('DELETE', `/v1/ai/meetings/${id}`);
+      return { data: null, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  async list(opts: ListMeetingsOptions = {}): Promise<ButterbaseResponse<ListMeetingsResult>> {
+    try {
+      const params = new URLSearchParams();
+      if (opts.status) params.set('status', opts.status);
+      if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+      if (opts.cursor) params.set('cursor', opts.cursor);
+      const qs = params.toString();
+      const path = `/v1/ai/meetings${qs ? `?${qs}` : ''}`;
+      const data = await this.client.request<ListMeetingsResult>('GET', path);
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+}

--- a/packages/sdk/src/ai/meetings-types.ts
+++ b/packages/sdk/src/ai/meetings-types.ts
@@ -1,0 +1,34 @@
+// packages/sdk/src/ai/meetings-types.ts
+
+export type MeetingStatus =
+  | 'joining' | 'waiting_room' | 'in_call' | 'recording'
+  | 'ended' | 'done' | 'fatal';
+
+export interface StartMeetingRequest {
+  meetingUrl: string;
+  transcript?: boolean;
+  recording?: 'mp4' | 'audio_only' | false;
+  metadata?: Record<string, string>;
+}
+
+export interface MeetingBot {
+  id: string;
+  status: MeetingStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationSeconds: number | null;
+  recordingUrl: string | null;
+  transcriptUrl: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface ListMeetingsOptions {
+  status?: MeetingStatus;
+  limit?: number;
+  cursor?: string | null;
+}
+
+export interface ListMeetingsResult {
+  bots: MeetingBot[];
+  nextCursor: string | null;
+}

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -74,6 +74,13 @@ export const config = {
     } as const;
   })(),
 
+  meetings: {
+    apiKey: process.env.MEETINGS_API_KEY ?? '',
+    baseUrl: process.env.MEETINGS_BASE_URL ?? 'https://us-east-1.recall.ai',
+    webhookSecret: process.env.MEETINGS_WEBHOOK_SECRET ?? '',
+    internalForwarderSigningSecret: process.env.MEETINGS_FORWARDER_SIGNING_SECRET ?? '',
+  },
+
   /**
    * Platform DB env vars introduced in multi-region Phase 1.
    * In Phase 1, both URLs may point at the same database during initial deployment;

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -78,7 +78,10 @@ export const config = {
     apiKey: process.env.MEETINGS_API_KEY ?? '',
     baseUrl: process.env.MEETINGS_BASE_URL ?? 'https://us-east-1.recall.ai',
     webhookSecret: process.env.MEETINGS_WEBHOOK_SECRET ?? '',
-    internalForwarderSigningSecret: process.env.MEETINGS_FORWARDER_SIGNING_SECRET ?? '',
+    // The outbound webhook forwarder signs with each app's per-app secret
+    // (stored AES-256-GCM-encrypted under AUTH_ENCRYPTION_KEY in
+    // app_meetings_webhooks.forward_secret_encrypted), so no service-wide
+    // signing key is required.
   },
 
   /**

--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -459,6 +459,13 @@ try {
   // @ts-expect-error — path resolved at runtime against the compiled overlay
   const overlay = await import('../../../cloud-overlays/dist/cloud-overlays/bootstrap.js');
   await overlay.bootstrapCloudOverlays();
+  if (config.meetings?.apiKey) {
+    overlay.bootstrapMeetings({
+      apiKey: config.meetings.apiKey,
+      baseUrl: config.meetings.baseUrl,
+    });
+    app.log.info('ai-meetings provider registered');
+  }
   app.log.info('Cloud overlays loaded');
 } catch (err) {
   app.log.info(
@@ -502,6 +509,23 @@ try {
   const overlay = await import('../../../cloud-overlays/dist/cloud-overlays/billing/routes/app-billing.js');
   await app.register(overlay.appBillingRoutes);
 } catch { /* OSS mode: no Stripe app billing */ }
+if (config.meetings?.webhookSecret) {
+  try {
+    // @ts-expect-error — overlay path resolved at runtime
+    const overlay = await import('../../../cloud-overlays/dist/cloud-overlays/bootstrap.js');
+    const { getActorProvider } = await import('./services/actor-providers/registry.js');
+    await app.register(overlay.recallWebhookRoute, {
+      secret: config.meetings.webhookSecret,
+      getProvider: () => getActorProvider('meetings'),
+    });
+    app.log.info('ai-meetings webhook route registered');
+  } catch (err) {
+    app.log.info(
+      { err: err instanceof Error ? err.message : err },
+      'ai-meetings webhook overlay not present, skipping',
+    );
+  }
+}
 try {
   // @ts-expect-error — overlay path resolved at runtime
   const overlay = await import('../../../cloud-overlays/dist/cloud-overlays/substrate/index.js');

--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -68,6 +68,7 @@ import { startForkCountSweeper } from './services/fork-count-sweeper.js';
 import { startCloneJobsPruner } from './services/clone-jobs-pruner.js';
 import { startCloneWebhookSweeper } from './services/clone-webhook-sweeper.js';
 import { gatewayRoutes } from './routes/gateway.js';
+import { aiMeetingsRoutes } from './routes/ai-meetings.js';
 import { autoRefillRoutes } from './routes/auto-refill.js';
 import dashboardProxyPlugin from './plugins/dashboard-proxy.js';
 import subdomainPlugin from './plugins/subdomain.js';
@@ -518,6 +519,7 @@ try {
 app.register(aiConfigRoutes);
 app.register(aiVideoRoutes);
 app.register(gatewayRoutes);
+app.register(aiMeetingsRoutes);
 app.register(autoRefillRoutes);
 app.register(initRoutes);
 app.register(schemaRoutes);

--- a/services/control-api/src/routes/ai-meetings.test.ts
+++ b/services/control-api/src/routes/ai-meetings.test.ts
@@ -158,6 +158,29 @@ describe('GET /v1/ai/meetings/_estimate', () => {
   });
 });
 
+describe('GET /v1/:appId/ai/meetings/usage', () => {
+  it('returns last 100 rows from actor_usage_logs', async () => {
+    const app = buildApp();
+    const runtimeDb = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{ owner_id: 'u_1' }] })         // ownership check
+        .mockResolvedValueOnce({ rows: [
+          { id: 'log_1', dimension: 'recording', seconds: 3600, usd_charged: '0.5', created_at: '2026-06-11T01:00:00Z' },
+          { id: 'log_2', dimension: 'transcription', seconds: 3600, usd_charged: '0.15', created_at: '2026-06-11T01:00:00Z' },
+        ]}),
+    };
+    const { getRuntimeDbForApp } = await import('../services/region-resolver.js');
+    (getRuntimeDbForApp as ReturnType<typeof vi.fn>).mockResolvedValueOnce(runtimeDb);
+
+    const res = await app.inject({ method: 'GET', url: '/v1/app_1/ai/meetings/usage' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows[0].dimension).toBe('recording');
+    expect(body.rows[1].dimension).toBe('transcription');
+  });
+});
+
 describe('PUT /v1/:appId/ai/meetings/webhook', () => {
   it('upserts and returns a raw secret when no existing row', async () => {
     const app = buildApp();

--- a/services/control-api/src/routes/ai-meetings.test.ts
+++ b/services/control-api/src/routes/ai-meetings.test.ts
@@ -66,6 +66,24 @@ describe('POST /v1/ai/meetings', () => {
     );
   });
 
+  // TODO(phase2): when provider.start fails post-lease, settle the lease to zero
+  // to refund credits. Currently the lease leaks until TTL expiry (10min).
+  it('returns 500 when provider.start throws after lease is granted', async () => {
+    const start = vi.fn(async () => { throw new Error('vendor blew up'); });
+    const app = buildApp({
+      key: 'meetings',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0.0000416,
+      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(),
+    } as unknown as ActorProvider);
+    const res = await app.inject({
+      method: 'POST', url: '/v1/ai/meetings',
+      payload: { meetingUrl: 'https://meet.google.com/abc-defg-hij' },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error.code).toBe('internal_error');
+  });
+
   it('400s when metadata key starts with bb_', async () => {
     const app = buildApp({ key: 'meetings' } as any);
     const res = await app.inject({

--- a/services/control-api/src/routes/ai-meetings.test.ts
+++ b/services/control-api/src/routes/ai-meetings.test.ts
@@ -55,7 +55,7 @@ describe('POST /v1/ai/meetings', () => {
       key: 'meetings',
       recordingUsdPerSecond: 0.0001388,
       transcriptionUsdPerSecond: 0.0000416,
-      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(),
+      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(), estimateCost: vi.fn(() => ({ usd: 0 })),
     } as unknown as ActorProvider);
     const res = await app.inject({
       method: 'POST', url: '/v1/ai/meetings',
@@ -80,7 +80,7 @@ describe('POST /v1/ai/meetings', () => {
       key: 'meetings',
       recordingUsdPerSecond: 0.0001388,
       transcriptionUsdPerSecond: 0.0000416,
-      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(),
+      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(), estimateCost: vi.fn(() => ({ usd: 0 })),
     } as unknown as ActorProvider);
     const res = await app.inject({
       method: 'POST', url: '/v1/ai/meetings',
@@ -110,7 +110,7 @@ describe('GET /v1/ai/meetings/:id', () => {
       completedAt: '2026-06-11T01:00:00Z', durationSeconds: 3600,
       recordingUrl: 'https://...', transcriptUrl: 'https://...', metadata: {},
     }));
-    const app = buildApp({ key: 'meetings', get, start: vi.fn(), stop: vi.fn(), list: vi.fn() } as unknown as ActorProvider);
+    const app = buildApp({ key: 'meetings', get, start: vi.fn(), stop: vi.fn(), list: vi.fn(), estimateCost: vi.fn(() => ({ usd: 0 })) } as unknown as ActorProvider);
     const res = await app.inject({ method: 'GET', url: '/v1/ai/meetings/bot_abc' });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).durationSeconds).toBe(3600);
@@ -120,7 +120,7 @@ describe('GET /v1/ai/meetings/:id', () => {
 describe('DELETE /v1/ai/meetings/:id', () => {
   it('calls provider.stop and returns 204', async () => {
     const stop = vi.fn(async () => {});
-    const app = buildApp({ key: 'meetings', stop, start: vi.fn(), get: vi.fn(), list: vi.fn() } as unknown as ActorProvider);
+    const app = buildApp({ key: 'meetings', stop, start: vi.fn(), get: vi.fn(), list: vi.fn(), estimateCost: vi.fn(() => ({ usd: 0 })) } as unknown as ActorProvider);
     const res = await app.inject({ method: 'DELETE', url: '/v1/ai/meetings/bot_abc' });
     expect(res.statusCode).toBe(204);
     expect(stop).toHaveBeenCalled();
@@ -132,12 +132,29 @@ describe('GET /v1/ai/meetings', () => {
     const list = vi.fn(async () => ({
       bots: [{ id: 'bot_a', status: 'done' } as any], nextCursor: 'cur1',
     }));
-    const app = buildApp({ key: 'meetings', list, start: vi.fn(), get: vi.fn(), stop: vi.fn() } as unknown as ActorProvider);
+    const app = buildApp({ key: 'meetings', list, start: vi.fn(), get: vi.fn(), stop: vi.fn(), estimateCost: vi.fn(() => ({ usd: 0 })) } as unknown as ActorProvider);
     const res = await app.inject({ method: 'GET', url: '/v1/ai/meetings?limit=5' });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.bots).toHaveLength(1);
     expect(body.nextCursor).toBe('cur1');
+  });
+});
+
+describe('GET /v1/ai/meetings/_estimate', () => {
+  it('returns usd cost for the given duration', async () => {
+    const estimateCost = vi.fn(() => ({ usd: 0.075 }));
+    const app = buildApp({
+      key: 'meetings',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0.0000416,
+      start: vi.fn(), get: vi.fn(), stop: vi.fn(), list: vi.fn(),
+      estimateCost,
+    } as unknown as ActorProvider);
+    const res = await app.inject({ method: 'GET', url: '/v1/ai/meetings/_estimate?durationMinutes=60' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ usd: 0.075 });
+    expect(estimateCost).toHaveBeenCalledWith(expect.objectContaining({ durationMinutes: 60 }));
   });
 });
 

--- a/services/control-api/src/routes/ai-meetings.test.ts
+++ b/services/control-api/src/routes/ai-meetings.test.ts
@@ -14,6 +14,12 @@ vi.mock('../services/actor-providers/billing.js', () => ({
   settleActorCall: vi.fn(async () => ({ refundedUsd: 0 })),
   FLOOR_LEASE_SECONDS: 300,
 }));
+vi.mock('../services/region-resolver.js', () => ({
+  resolveAppHomeRegion: vi.fn(async () => 'us-east-1'),
+  getRuntimeDbForApp: vi.fn(async () => ({
+    query: vi.fn(async () => ({ rows: [{ owner_id: 'u_1' }] })),
+  })),
+}));
 
 function buildApp(provider?: ActorProvider) {
   _resetRegistryForTests();
@@ -132,5 +138,50 @@ describe('GET /v1/ai/meetings', () => {
     const body = JSON.parse(res.body);
     expect(body.bots).toHaveLength(1);
     expect(body.nextCursor).toBe('cur1');
+  });
+});
+
+describe('PUT /v1/:appId/ai/meetings/webhook', () => {
+  it('upserts and returns a raw secret when no existing row', async () => {
+    const app = buildApp();
+    (app as any).controlDb.query
+      .mockResolvedValueOnce({ rows: [] })   // SELECT existing → empty
+      .mockResolvedValueOnce({ rowCount: 1 }); // INSERT/UPSERT
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/app_1/ai/meetings/webhook',
+      payload: { forward_url: 'https://example.com/wh', rotate_secret: true },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.secret).toMatch(/^wsec_/);
+  });
+
+  it('preserves existing secret when rotate_secret is false', async () => {
+    const app = buildApp();
+    (app as any).controlDb.query
+      .mockResolvedValueOnce({ rows: [{ forward_secret_hash: 'existing-hash' }] }) // SELECT → existing
+      .mockResolvedValueOnce({ rowCount: 1 }); // UPSERT
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/app_1/ai/meetings/webhook',
+      payload: { forward_url: 'https://example.com/wh' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.secret).toBeNull();
+  });
+
+  it('400s when forward_url is not a valid URL', async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/app_1/ai/meetings/webhook',
+      payload: { forward_url: 'not-a-url' },
+    });
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/services/control-api/src/routes/ai-meetings.test.ts
+++ b/services/control-api/src/routes/ai-meetings.test.ts
@@ -1,0 +1,118 @@
+// services/control-api/src/routes/ai-meetings.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import { aiMeetingsRoutes } from './ai-meetings.js';
+import {
+  registerActorProvider, _resetRegistryForTests,
+} from '../services/actor-providers/registry.js';
+import type { ActorProvider } from '../services/actor-providers/types.js';
+
+vi.mock('../services/redis.js', () => ({ getRedisClient: () => ({}) }));
+vi.mock('../services/runtime-db.js', () => ({ getRuntimeDbPool: () => ({ query: vi.fn().mockResolvedValue({ rowCount: 1 }) }) }));
+vi.mock('../services/actor-providers/billing.js', () => ({
+  reserveActorCredits: vi.fn(async () => ({ leaseId: 'lease_1', amountGrantedUsd: 0.05, expiresAt: new Date() })),
+  settleActorCall: vi.fn(async () => ({ refundedUsd: 0 })),
+  FLOOR_LEASE_SECONDS: 300,
+}));
+
+function buildApp(provider?: ActorProvider) {
+  _resetRegistryForTests();
+  if (provider) registerActorProvider(provider);
+  const app = Fastify();
+  app.decorateRequest('auth', null);
+  app.addHook('onRequest', async (req) => {
+    (req as any).auth = { userId: 'u_1', appId: 'app_1', authMethod: 'api_key', scopes: ['*'] };
+  });
+  (app as any).controlDb = { query: vi.fn() };
+  app.register(aiMeetingsRoutes);
+  return app;
+}
+
+describe('POST /v1/ai/meetings', () => {
+  it('501s when no adapter is registered', async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: 'POST', url: '/v1/ai/meetings',
+      payload: { meetingUrl: 'https://meet.google.com/abc-defg-hij' },
+    });
+    expect(res.statusCode).toBe(501);
+    expect(JSON.parse(res.body).error.code).toBe('provider_unavailable');
+  });
+
+  it('200s and returns the bot when adapter is registered', async () => {
+    const start = vi.fn(async () => ({
+      id: 'bot_abc', status: 'joining', startedAt: null, completedAt: null,
+      durationSeconds: null, recordingUrl: null, transcriptUrl: null,
+      metadata: { app_dealId: 'd1' },
+    }));
+    const app = buildApp({
+      key: 'meetings',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0.0000416,
+      start, get: vi.fn(), stop: vi.fn(), list: vi.fn(),
+    } as unknown as ActorProvider);
+    const res = await app.inject({
+      method: 'POST', url: '/v1/ai/meetings',
+      payload: {
+        meetingUrl: 'https://meet.google.com/abc-defg-hij',
+        metadata: { dealId: 'd1' },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).id).toBe('bot_abc');
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 'app_1', userId: 'u_1', leaseId: 'lease_1' }),
+      expect.objectContaining({ metadata: { dealId: 'd1' } }),
+    );
+  });
+
+  it('400s when metadata key starts with bb_', async () => {
+    const app = buildApp({ key: 'meetings' } as any);
+    const res = await app.inject({
+      method: 'POST', url: '/v1/ai/meetings',
+      payload: {
+        meetingUrl: 'https://meet.google.com/abc-defg-hij',
+        metadata: { bb_app_id: 'naughty' },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /v1/ai/meetings/:id', () => {
+  it('returns the bot status', async () => {
+    const get = vi.fn(async () => ({
+      id: 'bot_abc', status: 'done', startedAt: '2026-06-11T00:00:00Z',
+      completedAt: '2026-06-11T01:00:00Z', durationSeconds: 3600,
+      recordingUrl: 'https://...', transcriptUrl: 'https://...', metadata: {},
+    }));
+    const app = buildApp({ key: 'meetings', get, start: vi.fn(), stop: vi.fn(), list: vi.fn() } as unknown as ActorProvider);
+    const res = await app.inject({ method: 'GET', url: '/v1/ai/meetings/bot_abc' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).durationSeconds).toBe(3600);
+  });
+});
+
+describe('DELETE /v1/ai/meetings/:id', () => {
+  it('calls provider.stop and returns 204', async () => {
+    const stop = vi.fn(async () => {});
+    const app = buildApp({ key: 'meetings', stop, start: vi.fn(), get: vi.fn(), list: vi.fn() } as unknown as ActorProvider);
+    const res = await app.inject({ method: 'DELETE', url: '/v1/ai/meetings/bot_abc' });
+    expect(res.statusCode).toBe(204);
+    expect(stop).toHaveBeenCalled();
+  });
+});
+
+describe('GET /v1/ai/meetings', () => {
+  it('returns paginated list', async () => {
+    const list = vi.fn(async () => ({
+      bots: [{ id: 'bot_a', status: 'done' } as any], nextCursor: 'cur1',
+    }));
+    const app = buildApp({ key: 'meetings', list, start: vi.fn(), get: vi.fn(), stop: vi.fn() } as unknown as ActorProvider);
+    const res = await app.inject({ method: 'GET', url: '/v1/ai/meetings?limit=5' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.bots).toHaveLength(1);
+    expect(body.nextCursor).toBe('cur1');
+  });
+});

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -1,6 +1,7 @@
 // services/control-api/src/routes/ai-meetings.ts
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
+import { randomBytes, createHash } from 'node:crypto';
 import { config } from '../config.js';
 import {
   getActorProvider,
@@ -16,6 +17,8 @@ import {
   startMeetingsRequestSchema, listMeetingsRequestSchema,
 } from '../services/actor-providers/schemas.js';
 import { logAuditEvent } from '../services/audit/audit-events-service.js';
+import { requireUserId } from '../utils/require-auth.js';
+import { resolveAppHomeRegion, getRuntimeDbForApp } from '../services/region-resolver.js';
 
 const GATEWAY_SCOPE = 'ai:gateway';
 
@@ -167,6 +170,79 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
       return reply.send({ available: true });
     } catch {
       return reply.send({ available: false });
+    }
+  });
+
+  // Configure the app's meetings webhook forward URL and (optionally) rotate the signing secret.
+  const meetingsWebhookBodySchema = z.object({
+    forward_url: z.string().url(),
+    rotate_secret: z.boolean().optional(),
+  });
+
+  app.put<{ Params: { appId: string } }>('/v1/:appId/ai/meetings/webhook', async (req, reply) => {
+    const { appId } = req.params;
+    const userId = requireUserId(req);
+
+    try {
+      const body = meetingsWebhookBodySchema.parse(req.body);
+
+      // Verify ownership
+      const region = await resolveAppHomeRegion((app as any).controlDb, appId);
+      const runtimeDb = await getRuntimeDbForApp((app as any).controlDb, appId);
+      const ownerResult = await runtimeDb.query(
+        'SELECT owner_id FROM apps WHERE id = $1',
+        [appId],
+      );
+      if (ownerResult.rows.length === 0) {
+        return reply.code(404).send({ error: 'App not found' });
+      }
+      if (ownerResult.rows[0].owner_id !== userId) {
+        return reply.code(403).send({ error: 'Not authorized' });
+      }
+
+      // Check for existing row
+      const existing: { rows: { forward_secret_hash: string }[] } =
+        await (app as any).controlDb.query(
+          'SELECT forward_secret_hash FROM app_meetings_webhooks WHERE app_id = $1',
+          [appId],
+        );
+
+      let rawSecret: string | null = null;
+      let secretHash: string;
+
+      if (body.rotate_secret || existing.rows.length === 0) {
+        // Generate a new secret: wsec_<base64url(32 random bytes)>
+        const raw = randomBytes(32).toString('base64url');
+        rawSecret = `wsec_${raw}`;
+        // Hash with SHA-256 (salted with app_id) — lightweight, no bcrypt dep needed
+        secretHash = createHash('sha256').update(`${appId}:${rawSecret}`).digest('hex');
+      } else {
+        secretHash = existing.rows[0].forward_secret_hash;
+      }
+
+      // Upsert
+      await (app as any).controlDb.query(
+        `INSERT INTO app_meetings_webhooks (app_id, forward_url, forward_secret_hash, updated_at)
+         VALUES ($1, $2, $3, now())
+         ON CONFLICT (app_id) DO UPDATE
+           SET forward_url = EXCLUDED.forward_url,
+               forward_secret_hash = EXCLUDED.forward_secret_hash,
+               updated_at = now()`,
+        [appId, body.forward_url, secretHash],
+      );
+
+      return reply.code(200).send({
+        ok: true,
+        app_id: appId,
+        forward_url: body.forward_url,
+        secret: rawSecret,
+      });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        return reply.code(400).send({ error: 'Invalid request', details: err.errors });
+      }
+      app.log.error({ err }, '[ai-meetings] configure webhook failed');
+      return reply.code(500).send({ error: 'Internal error' });
     }
   });
 }

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -173,6 +173,23 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     }
   });
 
+  app.get('/v1/ai/meetings/_estimate', async (req, reply) => {
+    try {
+      const user = resolveGatewayUser(req);
+      const q = z.object({
+        durationMinutes: z.coerce.number().int().min(1).max(24 * 60),
+        transcript: z.coerce.boolean().default(true),
+      }).parse(req.query);
+      const provider = getActorProvider('meetings');
+      const out = provider.estimateCost({
+        durationMinutes: q.durationMinutes,
+        transcript: q.transcript,
+        markupPct: config.aiRouter.markupPct,
+      });
+      return reply.code(200).send(out);
+    } catch (err) { return handleError(reply, err); }
+  });
+
   // Configure the app's meetings webhook forward URL and (optionally) rotate the signing secret.
   const meetingsWebhookBodySchema = z.object({
     forward_url: z.string().url(),

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -1,7 +1,8 @@
 // services/control-api/src/routes/ai-meetings.ts
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
-import { randomBytes, createHash } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
+import { encrypt } from '../services/crypto.js';
 import { config } from '../config.js';
 import {
   getActorProvider,
@@ -24,9 +25,18 @@ const GATEWAY_SCOPE = 'ai:gateway';
 
 interface GatewayUser { userId: string; appId: string; region: string; }
 
-function resolveGatewayUser(req: FastifyRequest): GatewayUser {
-  const { userId, appId, authMethod, scopes } = req.auth;
-  if (!userId || !appId) {
+// appId comes from the URL path (e.g. /v1/:appId/ai/meetings). The route
+// must verify that the authenticated caller owns the app before any
+// provider call. bb_sk_ keys carry userId only (not appId), so wiring the
+// app context through auth.appId is not viable for this surface; the path
+// is the source of truth.
+async function resolveGatewayUser(
+  app: FastifyInstance,
+  req: FastifyRequest,
+  appId: string,
+): Promise<GatewayUser> {
+  const { userId, authMethod, scopes } = req.auth;
+  if (!userId) {
     const e: any = new Error('missing_credentials');
     e.gatewayStatus = 401; e.gatewayCode = 'missing_credentials';
     throw e;
@@ -34,6 +44,21 @@ function resolveGatewayUser(req: FastifyRequest): GatewayUser {
   if (authMethod === 'api_key' && !scopes.includes('*') && !scopes.includes(GATEWAY_SCOPE)) {
     const e: any = new Error('insufficient_scope');
     e.gatewayStatus = 403; e.gatewayCode = 'insufficient_scope';
+    throw e;
+  }
+  const runtimeDb = await getRuntimeDbForApp((app as any).controlDb, appId);
+  const ownerResult = await runtimeDb.query(
+    'SELECT owner_id FROM apps WHERE id = $1',
+    [appId],
+  );
+  if (ownerResult.rows.length === 0) {
+    const e: any = new Error('app_not_found');
+    e.gatewayStatus = 404; e.gatewayCode = 'app_not_found';
+    throw e;
+  }
+  if (ownerResult.rows[0].owner_id !== userId) {
+    const e: any = new Error('not_authorized');
+    e.gatewayStatus = 403; e.gatewayCode = 'not_authorized';
     throw e;
   }
   return { userId, appId, region: config.aiRouter.defaultRegion };
@@ -71,9 +96,9 @@ function handleError(reply: FastifyReply, err: unknown) {
 }
 
 export async function aiMeetingsRoutes(app: FastifyInstance) {
-  app.post('/v1/ai/meetings', async (req, reply) => {
+  app.post<{ Params: { appId: string } }>('/v1/:appId/ai/meetings', async (req, reply) => {
     try {
-      const user = resolveGatewayUser(req);
+      const user = await resolveGatewayUser(app, req, req.params.appId);
       const body = startMeetingsRequestSchema.parse(req.body);
       const provider = getActorProvider('meetings');
       const handle = await reserveActorCredits((app as any).controlDb, {
@@ -109,7 +134,7 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
       return reply.code(200).send(bot);
     } catch (err) {
       void logAuditEvent((app as any).controlDb, {
-        appId: req.auth?.appId ?? '_unknown',
+        appId: req.params.appId ?? '_unknown',
         category: 'ai',
         eventType: 'ai_meetings.start',
         action: 'invoke',
@@ -127,9 +152,9 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     }
   });
 
-  app.get<{ Params: { id: string } }>('/v1/ai/meetings/:id', async (req, reply) => {
+  app.get<{ Params: { appId: string; id: string } }>('/v1/:appId/ai/meetings/:id', async (req, reply) => {
     try {
-      const user = resolveGatewayUser(req);
+      const user = await resolveGatewayUser(app, req, req.params.appId);
       const provider = getActorProvider('meetings');
       const bot = await provider.get(
         { appId: user.appId, userId: user.userId, leaseId: '' },
@@ -139,9 +164,9 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     } catch (err) { return handleError(reply, err); }
   });
 
-  app.delete<{ Params: { id: string } }>('/v1/ai/meetings/:id', async (req, reply) => {
+  app.delete<{ Params: { appId: string; id: string } }>('/v1/:appId/ai/meetings/:id', async (req, reply) => {
     try {
-      const user = resolveGatewayUser(req);
+      const user = await resolveGatewayUser(app, req, req.params.appId);
       const provider = getActorProvider('meetings');
       await provider.stop(
         { appId: user.appId, userId: user.userId, leaseId: '' },
@@ -151,9 +176,9 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     } catch (err) { return handleError(reply, err); }
   });
 
-  app.get('/v1/ai/meetings', async (req, reply) => {
+  app.get<{ Params: { appId: string } }>('/v1/:appId/ai/meetings', async (req, reply) => {
     try {
-      const user = resolveGatewayUser(req);
+      const user = await resolveGatewayUser(app, req, req.params.appId);
       const query = listMeetingsRequestSchema.parse(req.query);
       const provider = getActorProvider('meetings');
       const out = await provider.list(
@@ -173,9 +198,9 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     }
   });
 
-  app.get('/v1/ai/meetings/_estimate', async (req, reply) => {
+  app.get<{ Params: { appId: string } }>('/v1/:appId/ai/meetings/_estimate', async (req, reply) => {
     try {
-      const user = resolveGatewayUser(req);
+      await resolveGatewayUser(app, req, req.params.appId);
       const q = z.object({
         durationMinutes: z.coerce.number().int().min(1).max(24 * 60),
         transcript: z.coerce.boolean().default(true),
@@ -249,35 +274,43 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
         return reply.code(403).send({ error: 'Not authorized' });
       }
 
+      const encryptionKey = process.env.AUTH_ENCRYPTION_KEY;
+      if (!encryptionKey) {
+        app.log.error('[ai-meetings] AUTH_ENCRYPTION_KEY not set; cannot persist webhook secret');
+        return reply.code(500).send({ error: 'Server encryption not configured' });
+      }
+
       // Check for existing row
-      const existing: { rows: { forward_secret_hash: string }[] } =
+      const existing: { rows: { forward_secret_encrypted: string }[] } =
         await (app as any).controlDb.query(
-          'SELECT forward_secret_hash FROM app_meetings_webhooks WHERE app_id = $1',
+          'SELECT forward_secret_encrypted FROM app_meetings_webhooks WHERE app_id = $1',
           [appId],
         );
 
       let rawSecret: string | null = null;
-      let secretHash: string;
+      let secretEncrypted: string;
 
       if (body.rotate_secret || existing.rows.length === 0) {
-        // Generate a new secret: wsec_<base64url(32 random bytes)>
+        // Generate a new secret: wsec_<base64url(32 random bytes)>.
+        // We store the AES-256-GCM ciphertext so the forwarder can decrypt
+        // and HMAC-sign outbound payloads with it; receivers verify with the
+        // same raw value handed back here (one-time on create / rotate).
         const raw = randomBytes(32).toString('base64url');
         rawSecret = `wsec_${raw}`;
-        // Hash with SHA-256 (salted with app_id) — lightweight, no bcrypt dep needed
-        secretHash = createHash('sha256').update(`${appId}:${rawSecret}`).digest('hex');
+        secretEncrypted = encrypt(rawSecret, encryptionKey);
       } else {
-        secretHash = existing.rows[0].forward_secret_hash;
+        secretEncrypted = existing.rows[0].forward_secret_encrypted;
       }
 
       // Upsert
       await (app as any).controlDb.query(
-        `INSERT INTO app_meetings_webhooks (app_id, forward_url, forward_secret_hash, updated_at)
+        `INSERT INTO app_meetings_webhooks (app_id, forward_url, forward_secret_encrypted, updated_at)
          VALUES ($1, $2, $3, now())
          ON CONFLICT (app_id) DO UPDATE
            SET forward_url = EXCLUDED.forward_url,
-               forward_secret_hash = EXCLUDED.forward_secret_hash,
+               forward_secret_encrypted = EXCLUDED.forward_secret_encrypted,
                updated_at = now()`,
-        [appId, body.forward_url, secretHash],
+        [appId, body.forward_url, secretEncrypted],
       );
 
       return reply.code(200).send({

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -190,6 +190,38 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
     } catch (err) { return handleError(reply, err); }
   });
 
+  // Return the last 100 rows from actor_usage_logs for the given app.
+  app.get<{ Params: { appId: string } }>('/v1/:appId/ai/meetings/usage', async (req, reply) => {
+    const { appId } = req.params;
+    const userId = requireUserId(req);
+    try {
+      const region = await resolveAppHomeRegion((app as any).controlDb, appId);
+      const runtimeDb = await getRuntimeDbForApp((app as any).controlDb, appId);
+      const ownerResult = await runtimeDb.query(
+        'SELECT owner_id FROM apps WHERE id = $1',
+        [appId],
+      );
+      if (ownerResult.rows.length === 0) {
+        return reply.code(404).send({ error: 'App not found' });
+      }
+      if (ownerResult.rows[0].owner_id !== userId) {
+        return reply.code(403).send({ error: 'Not authorized' });
+      }
+      const rows = await runtimeDb.query(
+        `SELECT id, dimension, seconds, usd_charged, created_at
+           FROM actor_usage_logs
+          WHERE app_id = $1
+          ORDER BY created_at DESC
+          LIMIT 100`,
+        [appId],
+      );
+      return reply.code(200).send({ rows: rows.rows });
+    } catch (err) {
+      app.log.error({ err }, '[ai-meetings] usage fetch failed');
+      return reply.code(500).send({ error: 'Internal error' });
+    }
+  });
+
   // Configure the app's meetings webhook forward URL and (optionally) rotate the signing secret.
   const meetingsWebhookBodySchema = z.object({
     forward_url: z.string().url(),

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -15,6 +15,7 @@ import { InsufficientCreditsError } from '../services/ai-router/billing-gate.js'
 import {
   startMeetingsRequestSchema, listMeetingsRequestSchema,
 } from '../services/actor-providers/schemas.js';
+import { logAuditEvent } from '../services/audit/audit-events-service.js';
 
 const GATEWAY_SCOPE = 'ai:gateway';
 
@@ -42,7 +43,10 @@ function openaiError(message: string, type: string, code: string, extra?: Record
 function handleError(reply: FastifyReply, err: unknown) {
   if ((err as any).gatewayStatus) {
     const e = err as any;
-    return reply.code(e.gatewayStatus).send(openaiError(e.gatewayCode, 'authentication_error', e.gatewayCode));
+    const type = e.gatewayStatus === 401
+      ? 'authentication_error'
+      : e.gatewayStatus === 403 ? 'permission_error' : 'api_error';
+    return reply.code(e.gatewayStatus).send(openaiError(e.gatewayCode, type, e.gatewayCode));
   }
   if (err instanceof ProviderUnavailableError) {
     return reply.code(501).send(openaiError(err.message, 'api_error', 'provider_unavailable'));
@@ -80,8 +84,42 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
         { appId: user.appId, userId: user.userId, leaseId: handle.leaseId },
         body,
       );
+      void logAuditEvent((app as any).controlDb, {
+        appId: user.appId,
+        category: 'ai',
+        eventType: 'ai_meetings.start',
+        action: 'invoke',
+        resourceType: 'ai_request',
+        resourceId: bot.id,
+        actorType: 'platform_user',
+        actorId: user.userId,
+        eventData: {
+          transcript: body.transcript,
+          recording: body.recording,
+          lease_id: handle.leaseId,
+        },
+        ipAddress: req.ip ?? null,
+        userAgent: req.headers['user-agent'] ?? null,
+        success: true,
+        errorMessage: null,
+      });
       return reply.code(200).send(bot);
     } catch (err) {
+      void logAuditEvent((app as any).controlDb, {
+        appId: req.auth?.appId ?? '_unknown',
+        category: 'ai',
+        eventType: 'ai_meetings.start',
+        action: 'invoke',
+        resourceType: 'ai_request',
+        resourceId: undefined,
+        actorType: 'platform_user',
+        actorId: req.auth?.userId ?? '_unknown',
+        eventData: { error_code: (err as any).code ?? (err as any).gatewayCode ?? 'error' },
+        ipAddress: req.ip ?? null,
+        userAgent: req.headers['user-agent'] ?? null,
+        success: false,
+        errorMessage: (err as any).message ?? 'unknown',
+      });
       return handleError(reply, err);
     }
   });

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -1,0 +1,134 @@
+// services/control-api/src/routes/ai-meetings.ts
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import { config } from '../config.js';
+import {
+  getActorProvider,
+} from '../services/actor-providers/registry.js';
+import {
+  ProviderUnavailableError, ActorProviderError,
+} from '../services/actor-providers/types.js';
+import {
+  reserveActorCredits,
+} from '../services/actor-providers/billing.js';
+import { InsufficientCreditsError } from '../services/ai-router/billing-gate.js';
+import {
+  startMeetingsRequestSchema, listMeetingsRequestSchema,
+} from '../services/actor-providers/schemas.js';
+
+const GATEWAY_SCOPE = 'ai:gateway';
+
+interface GatewayUser { userId: string; appId: string; region: string; }
+
+function resolveGatewayUser(req: FastifyRequest): GatewayUser {
+  const { userId, appId, authMethod, scopes } = req.auth;
+  if (!userId || !appId) {
+    const e: any = new Error('missing_credentials');
+    e.gatewayStatus = 401; e.gatewayCode = 'missing_credentials';
+    throw e;
+  }
+  if (authMethod === 'api_key' && !scopes.includes('*') && !scopes.includes(GATEWAY_SCOPE)) {
+    const e: any = new Error('insufficient_scope');
+    e.gatewayStatus = 403; e.gatewayCode = 'insufficient_scope';
+    throw e;
+  }
+  return { userId, appId, region: config.aiRouter.defaultRegion };
+}
+
+function openaiError(message: string, type: string, code: string, extra?: Record<string, unknown>) {
+  return { error: { message, type, code, ...(extra ?? {}) } };
+}
+
+function handleError(reply: FastifyReply, err: unknown) {
+  if ((err as any).gatewayStatus) {
+    const e = err as any;
+    return reply.code(e.gatewayStatus).send(openaiError(e.gatewayCode, 'authentication_error', e.gatewayCode));
+  }
+  if (err instanceof ProviderUnavailableError) {
+    return reply.code(501).send(openaiError(err.message, 'api_error', 'provider_unavailable'));
+  }
+  if (err instanceof InsufficientCreditsError) {
+    return reply.code(402).send(openaiError(
+      err.message, 'billing_error', 'insufficient_credits',
+      { required_usd: err.requiredUsd, available_usd: err.availableUsd },
+    ));
+  }
+  if (err instanceof ActorProviderError) {
+    return reply.code(err.statusCode).send(openaiError(err.message, 'api_error', err.code));
+  }
+  if (err instanceof z.ZodError) {
+    return reply.code(400).send(openaiError('Invalid request body', 'invalid_request_error', 'invalid_request', { details: err.errors }));
+  }
+  console.error('[ai-meetings] unhandled', err);
+  return reply.code(500).send(openaiError('Internal error', 'api_error', 'internal_error'));
+}
+
+export async function aiMeetingsRoutes(app: FastifyInstance) {
+  app.post('/v1/ai/meetings', async (req, reply) => {
+    try {
+      const user = resolveGatewayUser(req);
+      const body = startMeetingsRequestSchema.parse(req.body);
+      const provider = getActorProvider('meetings');
+      const handle = await reserveActorCredits((app as any).controlDb, {
+        userId: user.userId, region: user.region,
+        recordingUsdPerSecond: provider.recordingUsdPerSecond,
+        transcriptionUsdPerSecond: provider.transcriptionUsdPerSecond,
+        transcript: body.transcript,
+        markupPct: config.aiRouter.markupPct,
+      });
+      const bot = await provider.start(
+        { appId: user.appId, userId: user.userId, leaseId: handle.leaseId },
+        body,
+      );
+      return reply.code(200).send(bot);
+    } catch (err) {
+      return handleError(reply, err);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>('/v1/ai/meetings/:id', async (req, reply) => {
+    try {
+      const user = resolveGatewayUser(req);
+      const provider = getActorProvider('meetings');
+      const bot = await provider.get(
+        { appId: user.appId, userId: user.userId, leaseId: '' },
+        req.params.id,
+      );
+      return reply.code(200).send(bot);
+    } catch (err) { return handleError(reply, err); }
+  });
+
+  app.delete<{ Params: { id: string } }>('/v1/ai/meetings/:id', async (req, reply) => {
+    try {
+      const user = resolveGatewayUser(req);
+      const provider = getActorProvider('meetings');
+      await provider.stop(
+        { appId: user.appId, userId: user.userId, leaseId: '' },
+        req.params.id,
+      );
+      return reply.code(204).send();
+    } catch (err) { return handleError(reply, err); }
+  });
+
+  app.get('/v1/ai/meetings', async (req, reply) => {
+    try {
+      const user = resolveGatewayUser(req);
+      const query = listMeetingsRequestSchema.parse(req.query);
+      const provider = getActorProvider('meetings');
+      const out = await provider.list(
+        { appId: user.appId, userId: user.userId, leaseId: '' },
+        query,
+      );
+      return reply.code(200).send(out);
+    } catch (err) { return handleError(reply, err); }
+  });
+
+  app.get('/v1/ai/meetings/_status', { config: { public: true } }, async (_req, reply) => {
+    try {
+      getActorProvider('meetings');
+      return reply.send({ available: true });
+    } catch {
+      return reply.send({ available: false });
+    }
+  });
+}

--- a/services/control-api/src/services/actor-providers/billing.test.ts
+++ b/services/control-api/src/services/actor-providers/billing.test.ts
@@ -1,0 +1,111 @@
+// billing.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { reserveActorCredits, settleActorCall, FLOOR_LEASE_SECONDS } from './billing.js';
+import { InsufficientCreditsError } from '../ai-router/billing-gate.js';
+
+vi.mock('../lease-service.js', () => ({
+  grantLease: vi.fn(),
+  settleLease: vi.fn(),
+}));
+
+import { grantLease, settleLease } from '../lease-service.js';
+const grantLeaseMock = grantLease as unknown as ReturnType<typeof vi.fn>;
+const settleLeaseMock = settleLease as unknown as ReturnType<typeof vi.fn>;
+
+const POOL = {} as any;
+const NOW = new Date('2026-06-11T00:00:00Z');
+
+describe('reserveActorCredits', () => {
+  it('leases the floor-seconds * (recording+transcription)/sec when transcript=true', async () => {
+    grantLeaseMock.mockResolvedValueOnce({
+      leaseId: 'lease_1', amountGranted: 0.0542, expiresAt: NOW,
+    });
+    const handle = await reserveActorCredits(POOL, {
+      userId: 'u', region: 'us-east-1',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0.0000416,
+      transcript: true,
+      markupPct: 0,
+    });
+    expect(grantLeaseMock).toHaveBeenCalledWith(POOL, expect.objectContaining({
+      userId: 'u',
+      amountUsd: expect.closeTo(0.05412, 4),
+    }));
+    expect(handle.leaseId).toBe('lease_1');
+  });
+
+  it('skips transcription cost when transcript=false', async () => {
+    grantLeaseMock.mockResolvedValueOnce({
+      leaseId: 'lease_2', amountGranted: 0.0417, expiresAt: NOW,
+    });
+    await reserveActorCredits(POOL, {
+      userId: 'u', region: 'us-east-1',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0.0000416,
+      transcript: false,
+      markupPct: 0,
+    });
+    expect(grantLeaseMock).toHaveBeenCalledWith(POOL, expect.objectContaining({
+      amountUsd: expect.closeTo(0.04164, 4),
+    }));
+  });
+
+  it('applies markup to the lease amount', async () => {
+    grantLeaseMock.mockResolvedValueOnce({
+      leaseId: 'lease_3', amountGranted: 1, expiresAt: NOW,
+    });
+    await reserveActorCredits(POOL, {
+      userId: 'u', region: 'us-east-1',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0,
+      transcript: false,
+      markupPct: 30,
+    });
+    expect(grantLeaseMock).toHaveBeenCalledWith(POOL, expect.objectContaining({
+      amountUsd: expect.closeTo(0.054132, 4),
+    }));
+  });
+
+  it('throws InsufficientCreditsError on partial grant (settles partial back to 0)', async () => {
+    grantLeaseMock.mockResolvedValueOnce({
+      leaseId: 'lease_partial', amountGranted: 0.01, expiresAt: NOW,
+    });
+    settleLeaseMock.mockResolvedValueOnce({ refundedUsd: 0.01 });
+    await expect(reserveActorCredits(POOL, {
+      userId: 'u', region: 'us-east-1',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0,
+      transcript: false,
+      markupPct: 0,
+    })).rejects.toBeInstanceOf(InsufficientCreditsError);
+    expect(settleLeaseMock).toHaveBeenCalledWith(POOL, { leaseId: 'lease_partial', actualUsd: 0 });
+  });
+
+  it('throws InsufficientCreditsError when grantLease returns no lease', async () => {
+    grantLeaseMock.mockResolvedValueOnce({ leaseId: null, amountGranted: 0, expiresAt: NOW });
+    await expect(reserveActorCredits(POOL, {
+      userId: 'u', region: 'us-east-1',
+      recordingUsdPerSecond: 0.0001388,
+      transcriptionUsdPerSecond: 0,
+      transcript: false,
+      markupPct: 0,
+    })).rejects.toBeInstanceOf(InsufficientCreditsError);
+  });
+});
+
+describe('settleActorCall', () => {
+  it('charges actualSeconds * usdPerSecond * (1+markup)', async () => {
+    settleLeaseMock.mockResolvedValueOnce({ refundedUsd: 0.04 });
+    const out = await settleActorCall(POOL, {
+      leaseId: 'lease_1',
+      actualSeconds: 60,
+      usdPerSecond: 0.0001388,
+      markupPct: 30,
+    });
+    expect(settleLeaseMock).toHaveBeenCalledWith(POOL, expect.objectContaining({
+      leaseId: 'lease_1',
+      actualUsd: expect.closeTo(0.0108264, 5),
+    }));
+    expect(out.refundedUsd).toBe(0.04);
+  });
+});

--- a/services/control-api/src/services/actor-providers/billing.test.ts
+++ b/services/control-api/src/services/actor-providers/billing.test.ts
@@ -94,12 +94,12 @@ describe('reserveActorCredits', () => {
 });
 
 describe('settleActorCall', () => {
-  it('charges actualSeconds * usdPerSecond * (1+markup)', async () => {
+  it('charges actualSeconds * dimensionUsdPerSecond * (1+markup)', async () => {
     settleLeaseMock.mockResolvedValueOnce({ refundedUsd: 0.04 });
     const out = await settleActorCall(POOL, {
       leaseId: 'lease_1',
       actualSeconds: 60,
-      usdPerSecond: 0.0001388,
+      dimensionUsdPerSecond: 0.0001388,
       markupPct: 30,
     });
     expect(settleLeaseMock).toHaveBeenCalledWith(POOL, expect.objectContaining({

--- a/services/control-api/src/services/actor-providers/billing.ts
+++ b/services/control-api/src/services/actor-providers/billing.ts
@@ -49,15 +49,26 @@ export async function reserveActorCredits(
 export interface SettleActorCallInput {
   leaseId: string;
   actualSeconds: number;
-  usdPerSecond: number;
+  dimensionUsdPerSecond: number;
   markupPct: number;
 }
 
+/**
+ * Settle one dimension of an actor lease. Called once per (lease, dimension)
+ * from the webhook handler — recording on `bot.done`, transcription on
+ * `transcript.done`. `dimensionUsdPerSecond` is the cost rate for THAT
+ * dimension only (e.g. 0.50/3600 for recording), NOT the combined rate
+ * that was used at reservation time.
+ *
+ * Idempotency is enforced upstream by the actor_usage_logs unique
+ * constraint on (actor_id, dimension); callers should only invoke this
+ * after a successful writeActorUsageRow returns true.
+ */
 export async function settleActorCall(
   platformPool: pg.Pool,
   input: SettleActorCallInput,
 ): Promise<{ refundedUsd: number }> {
-  const actualUsd = input.actualSeconds * input.usdPerSecond * (1 + input.markupPct / 100);
+  const actualUsd = input.actualSeconds * input.dimensionUsdPerSecond * (1 + input.markupPct / 100);
   try {
     return await settleLease(platformPool, { leaseId: input.leaseId, actualUsd });
   } catch (err) {

--- a/services/control-api/src/services/actor-providers/billing.ts
+++ b/services/control-api/src/services/actor-providers/billing.ts
@@ -1,0 +1,67 @@
+import type pg from 'pg';
+import { grantLease, settleLease } from '../lease-service.js';
+import { InsufficientCreditsError, type LeaseHandle } from '../ai-router/billing-gate.js';
+
+export const FLOOR_LEASE_SECONDS = 300;
+export const ACTOR_LEASE_TTL_SECONDS = 600;
+
+export interface ReserveActorCreditsInput {
+  userId: string;
+  region: string;
+  recordingUsdPerSecond: number;
+  transcriptionUsdPerSecond: number;
+  transcript: boolean;
+  markupPct: number;
+}
+
+export async function reserveActorCredits(
+  platformPool: pg.Pool,
+  input: ReserveActorCreditsInput,
+): Promise<LeaseHandle> {
+  const perSec =
+    input.recordingUsdPerSecond +
+    (input.transcript ? input.transcriptionUsdPerSecond : 0);
+  const base = perSec * FLOOR_LEASE_SECONDS;
+  const charged = base * (1 + input.markupPct / 100);
+  const requested = Math.max(charged, 0.0001);
+
+  const res = await grantLease(platformPool, {
+    userId: input.userId,
+    region: input.region,
+    amountUsd: requested,
+    ttlSeconds: ACTOR_LEASE_TTL_SECONDS,
+  });
+
+  if (!res.leaseId) {
+    throw new InsufficientCreditsError(requested, res.amountGranted);
+  }
+  if (res.amountGranted < requested) {
+    await settleLease(platformPool, { leaseId: res.leaseId, actualUsd: 0 });
+    throw new InsufficientCreditsError(requested, res.amountGranted);
+  }
+  return {
+    leaseId: res.leaseId,
+    amountGrantedUsd: res.amountGranted,
+    expiresAt: res.expiresAt,
+  };
+}
+
+export interface SettleActorCallInput {
+  leaseId: string;
+  actualSeconds: number;
+  usdPerSecond: number;
+  markupPct: number;
+}
+
+export async function settleActorCall(
+  platformPool: pg.Pool,
+  input: SettleActorCallInput,
+): Promise<{ refundedUsd: number }> {
+  const actualUsd = input.actualSeconds * input.usdPerSecond * (1 + input.markupPct / 100);
+  try {
+    return await settleLease(platformPool, { leaseId: input.leaseId, actualUsd });
+  } catch (err) {
+    console.error(`[actor-billing] settle failed for lease ${input.leaseId}:`, err);
+    return { refundedUsd: 0 };
+  }
+}

--- a/services/control-api/src/services/actor-providers/registry.test.ts
+++ b/services/control-api/src/services/actor-providers/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { registerActorProvider, getActorProvider, _resetRegistryForTests } from './registry.js';
+import { ProviderUnavailableError } from './types.js';
+import type { ActorProvider } from './types.js';
+
+const stub: ActorProvider = {
+  key: 'meetings',
+  recordingUsdPerSecond: 0.0001388,
+  transcriptionUsdPerSecond: 0.0000416,
+  start: async () => { throw new Error('not used'); },
+  get: async () => { throw new Error('not used'); },
+  stop: async () => { throw new Error('not used'); },
+  list: async () => { throw new Error('not used'); },
+};
+
+describe('actor-providers registry', () => {
+  beforeEach(() => _resetRegistryForTests());
+
+  it('throws ProviderUnavailableError when no adapter registered', () => {
+    expect(() => getActorProvider('meetings')).toThrow(ProviderUnavailableError);
+  });
+
+  it('returns the registered adapter', () => {
+    registerActorProvider(stub);
+    expect(getActorProvider('meetings')).toBe(stub);
+  });
+
+  it('replaces on re-register (last wins)', () => {
+    registerActorProvider(stub);
+    const stub2 = { ...stub, recordingUsdPerSecond: 0.0002 };
+    registerActorProvider(stub2);
+    expect(getActorProvider('meetings').recordingUsdPerSecond).toBe(0.0002);
+  });
+});

--- a/services/control-api/src/services/actor-providers/registry.ts
+++ b/services/control-api/src/services/actor-providers/registry.ts
@@ -1,0 +1,18 @@
+import { ProviderUnavailableError, type ActorProvider } from './types.js';
+
+const registry = new Map<ActorProvider['key'], ActorProvider>();
+
+export function registerActorProvider(p: ActorProvider): void {
+  registry.set(p.key, p);
+}
+
+export function getActorProvider(key: ActorProvider['key']): ActorProvider {
+  const p = registry.get(key);
+  if (!p) throw new ProviderUnavailableError(key);
+  return p;
+}
+
+/** @internal — test-only helper to clear the registry between cases. */
+export function _resetRegistryForTests(): void {
+  registry.clear();
+}

--- a/services/control-api/src/services/actor-providers/schemas.ts
+++ b/services/control-api/src/services/actor-providers/schemas.ts
@@ -1,0 +1,27 @@
+// services/control-api/src/services/actor-providers/schemas.ts
+import { z } from 'zod';
+
+const MAX_METADATA_VALUE_LEN = 500;
+
+const safeMetadata = z.record(
+  z.string().regex(/^(?!bb_)/, 'metadata keys may not start with bb_'),
+  z.string().max(MAX_METADATA_VALUE_LEN),
+).optional();
+
+export const startMeetingsRequestSchema = z.object({
+  meetingUrl: z.string().url(),
+  transcript: z.boolean().default(true),
+  recording: z.union([z.literal('mp4'), z.literal('audio_only'), z.literal(false)]).default('mp4'),
+  metadata: safeMetadata,
+});
+
+export const listMeetingsRequestSchema = z.object({
+  status: z.enum([
+    'joining','waiting_room','in_call','recording','ended','done','fatal',
+  ]).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().nullable().optional(),
+});
+
+export type StartMeetingsRequest = z.infer<typeof startMeetingsRequestSchema>;
+export type ListMeetingsRequest = z.infer<typeof listMeetingsRequestSchema>;

--- a/services/control-api/src/services/actor-providers/types.ts
+++ b/services/control-api/src/services/actor-providers/types.ts
@@ -1,0 +1,83 @@
+// services/control-api/src/services/actor-providers/types.ts
+
+/**
+ * Tenant context every adapter call receives. The adapter MUST inject
+ * these into vendor-side metadata so webhooks can be attributed.
+ */
+export interface ActorTenantContext {
+  appId: string;
+  userId: string;
+  leaseId: string;
+}
+
+export interface StartActorRequest {
+  meetingUrl: string;
+  transcript: boolean;          // true → opt into vendor's built-in transcription
+  recording: 'mp4' | 'audio_only' | false;
+  /** App-supplied metadata. Merged into an `app.*` keyspace; bb_* keys rejected. */
+  metadata?: Record<string, string>;
+}
+
+export type ActorStatus =
+  | 'joining' | 'waiting_room' | 'in_call' | 'recording'
+  | 'ended' | 'done' | 'fatal';
+
+export interface ActorBot {
+  id: string;
+  status: ActorStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationSeconds: number | null;
+  recordingUrl: string | null;
+  transcriptUrl: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface ListActorBotsRequest {
+  status?: ActorStatus;
+  limit?: number;
+  cursor?: string | null;
+}
+
+export interface ListActorBotsResult {
+  bots: ActorBot[];
+  nextCursor: string | null;
+}
+
+/**
+ * Implemented by each actor-style provider (Phase 2 = Recall; future = ...).
+ * The pricing pair drives both lease-time estimates and settle-time charges.
+ */
+export interface ActorProvider {
+  /** Stable key — externally observable as the provider for `ctx.ai.meetings`. */
+  readonly key: 'meetings';
+  /** USD/sec for recording. Used for lease + settlement. */
+  recordingUsdPerSecond: number;
+  /** USD/sec for transcription. 0 if `transcript:false`. */
+  transcriptionUsdPerSecond: number;
+
+  start(ctx: ActorTenantContext, req: StartActorRequest): Promise<ActorBot>;
+  get(ctx: ActorTenantContext, botId: string): Promise<ActorBot>;
+  stop(ctx: ActorTenantContext, botId: string): Promise<void>;
+  list(ctx: ActorTenantContext, req: ListActorBotsRequest): Promise<ListActorBotsResult>;
+}
+
+/** Thrown when no adapter is registered for the key. */
+export class ProviderUnavailableError extends Error {
+  constructor(public readonly key: string) {
+    super(`provider_unavailable: no adapter registered for ${key}`);
+    this.name = 'ProviderUnavailableError';
+  }
+}
+
+/** Adapter-side surfacing of vendor errors. Status code controls the gateway HTTP code. */
+export class ActorProviderError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ActorProviderError';
+  }
+}

--- a/services/control-api/src/services/actor-providers/types.ts
+++ b/services/control-api/src/services/actor-providers/types.ts
@@ -60,6 +60,8 @@ export interface ActorProvider {
   get(ctx: ActorTenantContext, botId: string): Promise<ActorBot>;
   stop(ctx: ActorTenantContext, botId: string): Promise<void>;
   list(ctx: ActorTenantContext, req: ListActorBotsRequest): Promise<ListActorBotsResult>;
+  /** Compute the estimated USD cost for a meeting of the given duration. */
+  estimateCost(req: { durationMinutes: number; transcript: boolean; markupPct: number }): { usd: number };
 }
 
 /** Thrown when no adapter is registered for the key. */

--- a/services/control-api/src/services/actor-providers/usage-log.test.ts
+++ b/services/control-api/src/services/actor-providers/usage-log.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { writeActorUsageRow, type ActorUsageRow } from './usage-log.js';
+
+describe('writeActorUsageRow', () => {
+  const row: ActorUsageRow = {
+    appId: 'app_1', userId: 'u_1',
+    providerKey: 'meetings', actorId: 'bot_abc',
+    dimension: 'recording', seconds: 90,
+    usdCost: 0.0125, usdCharged: 0.01625, markupPct: 30,
+    leaseId: 'lease_1', requestMetadata: { meeting_id: 'm_1' },
+  };
+
+  it('INSERTs ... ON CONFLICT DO NOTHING and returns true on first call', async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rowCount: 1 });
+    const inserted = await writeActorUsageRow({ query } as any, row);
+    expect(inserted).toBe(true);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (actor_id, dimension) DO NOTHING'),
+      expect.arrayContaining(['app_1','u_1','meetings','bot_abc','recording',90]),
+    );
+  });
+
+  it('returns false on conflict (settle-once idempotency)', async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rowCount: 0 });
+    const inserted = await writeActorUsageRow({ query } as any, row);
+    expect(inserted).toBe(false);
+  });
+});

--- a/services/control-api/src/services/actor-providers/usage-log.ts
+++ b/services/control-api/src/services/actor-providers/usage-log.ts
@@ -1,0 +1,40 @@
+import type pg from 'pg';
+
+export interface ActorUsageRow {
+  appId: string | null;
+  userId: string | null;
+  providerKey: string;
+  actorId: string;
+  dimension: 'recording' | 'transcription';
+  seconds: number;
+  usdCost: number;
+  usdCharged: number;
+  markupPct: number;
+  leaseId: string | null;
+  requestMetadata: Record<string, unknown>;
+}
+
+/**
+ * INSERT with ON CONFLICT DO NOTHING — the (actor_id, dimension) unique constraint
+ * makes settlement idempotent across webhook retries. Returns true if a row was
+ * inserted (caller should settle the lease), false if it was a duplicate (caller
+ * should skip settlement).
+ */
+export async function writeActorUsageRow(
+  runtimePool: pg.Pool,
+  row: ActorUsageRow,
+): Promise<boolean> {
+  const res = await runtimePool.query(
+    `INSERT INTO actor_usage_logs (
+       app_id, user_id, provider_key, actor_id, dimension, seconds,
+       usd_cost, usd_charged, markup_pct, lease_id, request_metadata
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+     ON CONFLICT (actor_id, dimension) DO NOTHING`,
+    [
+      row.appId, row.userId, row.providerKey, row.actorId, row.dimension, row.seconds,
+      row.usdCost, row.usdCharged, row.markupPct, row.leaseId,
+      JSON.stringify(row.requestMetadata),
+    ],
+  );
+  return (res.rowCount ?? 0) > 0;
+}

--- a/services/control-api/src/services/ai-usage-logger.test.ts
+++ b/services/control-api/src/services/ai-usage-logger.test.ts
@@ -1,0 +1,51 @@
+// services/control-api/src/services/ai-usage-logger.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRuntimePool = {
+  query: vi.fn(),
+};
+
+vi.mock('./region-resolver.js', () => ({
+  getRuntimeDbForApp: vi.fn(async () => mockRuntimePool),
+}));
+
+import { getAiUsageSummary } from './ai-usage-logger.js';
+
+describe('getAiUsageSummary', () => {
+  beforeEach(() => {
+    mockRuntimePool.query.mockReset();
+  });
+
+  it('includes meetings breakdown from actor_usage_logs', async () => {
+    // First query: ai_usage_logs (no rows)
+    mockRuntimePool.query
+      .mockResolvedValueOnce({ rows: [] })
+      // Second query: actor_usage_logs with recording + transcription rows
+      .mockResolvedValueOnce({
+        rows: [
+          { dimension: 'recording', total_seconds: '3600', total_usd: '0.5' },
+          { dimension: 'transcription', total_seconds: '3600', total_usd: '0.15' },
+        ],
+      });
+
+    const db = {} as any;
+    const result = await getAiUsageSummary(db, 'app_1');
+
+    expect(result.meetings).toHaveLength(2);
+    expect(result.meetings).toContainEqual({ dimension: 'recording', seconds: 3600, usd: 0.5 });
+    expect(result.meetings).toContainEqual({ dimension: 'transcription', seconds: 3600, usd: 0.15 });
+  });
+
+  it('returns empty meetings array when no actor_usage_logs rows', async () => {
+    mockRuntimePool.query
+      .mockResolvedValueOnce({ rows: [] })  // ai_usage_logs
+      .mockResolvedValueOnce({ rows: [] }); // actor_usage_logs
+
+    const db = {} as any;
+    const result = await getAiUsageSummary(db, 'app_1');
+
+    expect(result.meetings).toEqual([]);
+    expect(result.totalTokens).toBe(0);
+    expect(result.totalCost).toBe(0);
+  });
+});

--- a/services/control-api/src/services/ai-usage-logger.ts
+++ b/services/control-api/src/services/ai-usage-logger.ts
@@ -108,6 +108,7 @@ export async function getAiUsageSummary(
   totalTokens: number;
   totalCost: number;
   byModel: Record<string, { tokens: number; cost: number; requests: number }>;
+  meetings: Array<{ dimension: string; seconds: number; usd: number }>;
 }> {
   const runtimePool = await getRuntimeDbForApp(db, appId);
 
@@ -140,5 +141,22 @@ export async function getAiUsageSummary(
     totalCost += cost;
   }
 
-  return { totalTokens, totalCost, byModel };
+  // actor_usage_logs (meetings) is also runtime-tier.
+  const meetingsResult = await runtimePool.query<{ dimension: string; total_seconds: string; total_usd: string }>(
+    `SELECT dimension,
+            SUM(seconds)::TEXT AS total_seconds,
+            SUM(usd_charged)::TEXT AS total_usd
+       FROM actor_usage_logs
+      WHERE app_id = $1
+        AND DATE(created_at) >= $2 AND DATE(created_at) <= $3
+      GROUP BY dimension`,
+    [appId, start, end],
+  );
+  const meetings = meetingsResult.rows.map(r => ({
+    dimension: r.dimension,
+    seconds: Number(r.total_seconds ?? 0),
+    usd: Number(r.total_usd ?? 0),
+  }));
+
+  return { totalTokens, totalCost, byModel, meetings };
 }

--- a/services/control-api/src/services/move-app/runtime-tables.ts
+++ b/services/control-api/src/services/move-app/runtime-tables.ts
@@ -50,6 +50,7 @@ export const MOVE_APP_RUNTIME_TABLES = [
   'audit_events',
   'ai_usage_logs',
   'ai_video_jobs',
+  'actor_usage_logs',
   'mcp_tool_call_log',
 
   // Deployment + billing history (per-app, follow the app on move)

--- a/services/docs/src/content/docs/api-reference/ai-api.md
+++ b/services/docs/src/content/docs/api-reference/ai-api.md
@@ -565,7 +565,7 @@ const { data: estimate } = await bb.ai.meetings.estimateCost({ durationMinutes: 
 
 ### Pricing
 
-Recording costs **$0.50 per hour**, prorated per second. Built-in transcription is an additional **$0.15 per hour**, also prorated per second. Both charges are applied to the app's AI credit balance once the bot reaches `done` status. The app's configured `ai_router.markup_pct` (set via `manage_ai`) applies to both dimensions.
+Recording: **$0.50/hr + markup**, prorated per second. Transcription: **$0.15/hr + markup**, also prorated per second. Both charges are applied to the app's AI credit balance once the bot reaches `done` status.
 
 Use `GET /v1/ai/meetings/_estimate?durationMinutes=N&transcript=true` to project the charge before dispatching a bot.
 

--- a/services/docs/src/content/docs/api-reference/ai-api.md
+++ b/services/docs/src/content/docs/api-reference/ai-api.md
@@ -454,3 +454,159 @@ The response contains the plaintext key once — store it immediately. Subsequen
 | `ai:gateway` | Access to `POST /v1/chat/completions`, `POST /v1/embeddings`, and `GET /v1/models`. Nothing else. |
 
 The dashboard at `/api-keys` lists and revokes keys; for now, scoping a key to `ai:gateway` is done by calling `POST /api-keys` directly.
+
+## Meeting bots
+
+`ctx.ai.meetings` lets your app spawn a bot that joins a Zoom, Google Meet, Microsoft Teams, or Webex call, records it, and transcribes the audio. Your app starts a bot via the REST API or SDK, then waits for webhook events to learn when the call ends and the artifacts (recording, transcript) are ready to download. Recordings and transcripts are billed against the app's AI credit balance using the same ledger as chat completions.
+
+### Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | /v1/ai/meetings | Start a bot |
+| GET | /v1/ai/meetings/\{bot_id} | Get bot status + artifact URLs |
+| DELETE | /v1/ai/meetings/\{bot_id} | Stop a bot |
+| GET | /v1/ai/meetings | List bots |
+| GET | /v1/ai/meetings/_estimate | Estimate cost up front |
+
+### Start a bot
+
+**Request:**
+
+```json
+POST /v1/ai/meetings
+Authorization: Bearer bb_sk_...
+
+{
+  "meetingUrl": "https://meet.google.com/abc-defg-hij",
+  "transcript": true,
+  "recording": "mp4",
+  "metadata": {
+    "dealId": "d_42"
+  }
+}
+```
+
+**Request fields:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `meetingUrl` | string | yes | — | Full URL of the meeting to join. |
+| `transcript` | boolean | no | `true` | Whether to generate a transcript. |
+| `recording` | `"mp4" \| "audio_only" \| false` | no | `"mp4"` | Recording format, or `false` to skip recording. |
+| `metadata` | `Record<string, string>` | no | `{}` | Arbitrary key–value pairs stored on the bot. Keys starting with `bb_` are reserved and will be rejected with `400`. |
+
+**Response (201 Created):**
+
+```json
+{
+  "id": "bot_01j9...",
+  "status": "joining",
+  "startedAt": null,
+  "completedAt": null,
+  "durationSeconds": null,
+  "recordingUrl": null,
+  "transcriptUrl": null,
+  "metadata": {
+    "dealId": "d_42"
+  }
+}
+```
+
+The `MeetingBot` shape is the same for all endpoints that return a bot.
+
+### Bot status lifecycle
+
+Bots move through these states in order:
+
+| Status | Meaning |
+|--------|---------|
+| `joining` | Bot is dialing into the meeting. |
+| `waiting_room` | Bot reached the meeting but is held in the waiting room. |
+| `in_call` | Bot has been admitted to the call. |
+| `recording` | Bot is actively recording (and transcribing, if enabled). |
+| `ended` | The call has ended; artifacts are being processed. |
+| `done` | Artifacts are ready. `recordingUrl` and `transcriptUrl` (if applicable) are now populated. |
+| `fatal` | Bot encountered an unrecoverable error. Check `status` for details and the `bot.fatal` webhook. |
+
+### SDK usage
+
+```ts
+import { butterbase } from '@butterbase/sdk';
+
+const bb = butterbase({ apiKey: '...', appId: '...' });
+
+// Start a bot
+const { data: bot, error } = await bb.ai.meetings.start({
+  meetingUrl: 'https://meet.google.com/abc-defg-hij',
+  transcript: true,
+  recording: 'mp4',
+  metadata: { dealId: 'd_42' },
+});
+
+// Later, after the webhook tells you the bot is done:
+const { data: finished } = await bb.ai.meetings.get(bot!.id);
+// finished.recordingUrl + finished.transcriptUrl are now populated
+```
+
+Additional SDK methods:
+
+```ts
+// Stop a bot early
+await bb.ai.meetings.stop(bot!.id);
+
+// List bots with optional filters
+const { data: bots } = await bb.ai.meetings.list({ status: 'done', limit: 20, cursor: '...' });
+
+// Estimate cost before dispatching
+const { data: estimate } = await bb.ai.meetings.estimateCost({ durationMinutes: 60, transcript: true });
+// estimate.usd — projected total charge
+```
+
+### Pricing
+
+Recording costs **$0.50 per hour**, prorated per second. Built-in transcription is an additional **$0.15 per hour**, also prorated per second. Both charges are applied to the app's AI credit balance once the bot reaches `done` status. The app's configured `ai_router.markup_pct` (set via `manage_ai`) applies to both dimensions.
+
+Use `GET /v1/ai/meetings/_estimate?durationMinutes=N&transcript=true` to project the charge before dispatching a bot.
+
+### Webhook events
+
+Apps receive forwarded events at the URL configured via `manage_ai`'s `configure_meetings_webhook` action. Butterbase re-signs each forwarded event before delivery.
+
+**Event types:**
+
+| Event | When it fires |
+|-------|---------------|
+| `bot.in_call_recording` | Bot has been admitted and recording has started. |
+| `bot.done` | Bot left the call; recording artifact is available. |
+| `bot.fatal` | Bot failed; check bot status for details. |
+| `recording.done` | Recording artifact is ready to download. |
+| `transcript.done` | Transcript artifact is ready to download. |
+| `transcript.failed` | Transcription failed for this bot. |
+
+**Payload shape:**
+
+```json
+POST <your-forward-url>
+Content-Type: application/json
+x-bb-event: bot.done
+x-bb-signature: v1,<base64>
+x-bb-key-id: <16-char identifier>
+
+{
+  "event": "bot.done",
+  "data": { /* event-specific payload */ }
+}
+```
+
+### Signature & freshness
+
+The `x-bb-signature` header is an HMAC-SHA256 of the raw request body bytes, signed with Butterbase's webhook signing key. A valid signature confirms the event originated from Butterbase's infrastructure. Full per-tenant HMAC verification (where each app has its own signing key) is on the roadmap. For now, verify the request arrived over TLS from a Butterbase-owned origin, and confirm that `x-bb-key-id` matches the first 16 characters of the secret returned on the most recent `rotate_secret` call. If it does not match, the event was signed before your latest key rotation — treat it as stale and drop it.
+
+**Do not trigger side-effects (database writes, downstream calls) on duplicate deliveries.** Use the event payload's `bot.id` combined with the event name as an idempotency key. The upstream delivery service may retry for up to 24 hours.
+
+### Limits
+
+- **Single region.** In v1, bots are spawned from the US East workspace. Latency-sensitive multi-region routing is on the roadmap.
+- **No hard duration cap.** Bots run until the call ends or the app's AI credit balance is exhausted.
+- **Artifact retention.** Recording and transcript artifacts are retained for 7 days after the call ends. Download them before the retention window expires.

--- a/services/docs/src/content/docs/api-reference/mcp-tools.md
+++ b/services/docs/src/content/docs/api-reference/mcp-tools.md
@@ -128,6 +128,8 @@ All AI actions are routed through the single `manage_ai` MCP tool. Pass `{ app_i
 | `get_usage` | Aggregate token counts and credit spend over a date window. |
 | `submit_video` | Submit an async video generation job. Pass `model`, `prompt`, optional `duration`, `resolution`, `aspect_ratio`, `generate_audio`, `seed`. Returns `{ job_id, status, polling_url }`. |
 | `poll_video` | Poll a video job's status. Pass `job_id`. Returns the current job state including `content_urls` (absolute) and `charged_credits_usd` when `status === 'completed'`. |
+| `configure_meetings_webhook` | Configure where Butterbase forwards meeting-bot events for this app. Pass `forward_url` and optionally `rotate_secret: true` to mint a fresh signing-secret identifier (returned **once**). The stored hash is used in the `x-bb-key-id` header so your handler can detect post-rotation staleness. |
+| `usage_meetings` | List recent meeting-bot usage rows for this app — `actor_id`, dimension (`recording` or `transcription`), `seconds`, `usd_charged`, `created_at`. Last 100 rows ordered by time desc. |
 
 For the full HTTP request/response shapes and end-to-end video example, see the [AI API reference](./ai-api.md).
 

--- a/services/mcp-server/src/docs/user-documentation.ts
+++ b/services/mcp-server/src/docs/user-documentation.ts
@@ -13,6 +13,7 @@ export const DOC_TOPICS = [
   'functions',
   'frontend',
   'ai',
+  'meetings',
   'billing',
   'platform',
   'regions',
@@ -2163,6 +2164,319 @@ AI usage cost counts against your plan's AI credits allowance when using the pla
 When Pro plan users exceed their included $10, they are not blocked — overage is billed at $0.10 per credit and an email notification is sent. Free plan users must upgrade to continue using AI after exhausting their $0.10 lifetime allowance.
 `,
 
+  meetings: `## AI Meetings
+
+Spawn a meeting bot that joins a Zoom, Google Meet, Microsoft Teams, or Webex call and records + transcribes it. Billed against the same AI credits allowance as chat/embeddings.
+
+### Spawn a bot
+
+\`\`\`
+POST /v1/{app_id}/ai/meetings
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "meetingUrl": "https://zoom.us/j/12345...",
+  "transcript": true,
+  "recording": "mp4",
+  "metadata": { "session_id": "abc123" }
+}
+\`\`\`
+
+Returns:
+
+\`\`\`json
+{
+  "id": "c086e720-d319-44b8-82d8-3a363f2cd9f4",
+  "status": "joining",
+  "startedAt": "2026-06-11T17:01:29Z",
+  "metadata": { "session_id": "abc123" }
+}
+\`\`\`
+
+| Field | Default | Notes |
+|---|---|---|
+| \`meetingUrl\` | required | Any Zoom / Meet / Teams / Webex meeting URL |
+| \`transcript\` | \`true\` | When \`true\`, the call is transcribed in addition to being recorded |
+| \`recording\` | \`"mp4"\` | \`"mp4"\` for video+audio, \`"audio_only"\` for audio only, \`false\` to skip |
+| \`metadata\` | \`{}\` | Arbitrary string→string map. Keys may not start with \`bb_\` (reserved) |
+
+### Get / list / stop
+
+\`\`\`
+GET    /v1/{app_id}/ai/meetings/{bot_id}     # current status + recording/transcript URLs (when ready)
+GET    /v1/{app_id}/ai/meetings              # list bots (?status=&limit=&cursor=)
+DELETE /v1/{app_id}/ai/meetings/{bot_id}     # force the bot to leave the call
+\`\`\`
+
+Possible \`status\` values: \`joining\`, \`waiting_room\`, \`in_call\`, \`recording\`, \`ended\`, \`done\`, \`fatal\`.
+
+### Cost estimate
+
+\`\`\`
+GET /v1/{app_id}/ai/meetings/_estimate?durationMinutes=30&transcript=true
+\`\`\`
+
+Returns the expected USD charge for a hypothetical session at the given duration.
+
+### Webhooks (event-driven flow)
+
+Configure a per-app forward URL once; Butterbase will then POST events to your URL whenever the bot's lifecycle advances or media is ready.
+
+\`\`\`
+PUT /v1/{app_id}/ai/meetings/webhook
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "forward_url": "https://api.your-app.com/recall/events",
+  "rotate_secret": true
+}
+\`\`\`
+
+Returns:
+
+\`\`\`json
+{
+  "ok": true,
+  "app_id": "app_abc123",
+  "forward_url": "https://api.your-app.com/recall/events",
+  "secret": "wsec_<base64url(32 random bytes)>"
+}
+\`\`\`
+
+Store the \`secret\` — it's only returned on initial create and on \`rotate_secret: true\`.
+
+**Subscribed events** (default):
+
+| Event | Fires when |
+|---|---|
+| \`bot.in_call_recording\` | Bot has joined and started recording |
+| \`bot.done\` | Bot has left the call cleanly; recording is finalised |
+| \`bot.fatal\` | Bot failed terminally |
+| \`recording.done\` | Recording artifact is ready for download |
+| \`transcript.done\` | Transcript artifact is ready for download |
+| \`transcript.failed\` | Transcription failed for this recording |
+
+**Body & headers** delivered to your forward URL:
+
+\`\`\`
+POST /your/configured/path
+content-type: application/json
+x-bb-event: bot.done
+x-bb-signature: v1,<base64 HMAC-SHA256>
+
+{
+  "event": "bot.done",
+  "data": { "bot": { "id": "c086e720-...", "metadata": { ... } }, ... }
+}
+\`\`\`
+
+**Verifying the signature.** Recompute \`base64(HMAC-SHA256(<your_app_secret>, <raw body>))\`, prefix with \`v1,\`, and compare to \`x-bb-signature\` in constant time. The secret is the \`wsec_...\` value Butterbase returned to you on PUT or rotate; it's unique to your app, and the platform stores it AES-256-GCM-encrypted so only your app and the platform ever see the plaintext.
+
+### Webhooks carry IDs, not URLs
+
+The \`recording.done\` and \`transcript.done\` event payloads contain the **recording/transcript ID**, not the download URL — by design, since the URLs are short-lived and re-minted on demand. To get the actual download URL, follow up with:
+
+\`\`\`
+GET /v1/{app_id}/ai/meetings/{bot_id}
+\`\`\`
+
+and read \`recordingUrl\` / \`transcriptUrl\` from the normalized response. Example function handler:
+
+\`\`\`typescript
+export default async function handler(req: Request, ctx: any): Promise<Response> {
+  const event = req.headers.get('x-bb-event');
+  const body = await req.json();
+  const botId = body?.data?.bot?.id;
+
+  if (event === 'recording.done' || event === 'transcript.done' || event === 'bot.done') {
+    const res = await fetch(
+      \`\${ctx.env.BUTTERBASE_API_URL}/v1/\${ctx.env.BUTTERBASE_APP_ID}/ai/meetings/\${botId}\`,
+      { headers: { authorization: \`Bearer \${ctx.env.BUTTERBASE_API_KEY}\` } },
+    );
+    const bot = await res.json();
+    // bot.recordingUrl / bot.transcriptUrl are now populated.
+    await ctx.db.query(
+      'UPDATE meetings SET recording_url=$1, transcript_url=$2 WHERE bot_id=$3',
+      [bot.recordingUrl, bot.transcriptUrl, botId],
+    );
+  }
+  return new Response('ok');
+}
+\`\`\`
+
+### Complete worked example
+
+A minimal app that records every Zoom/Meet/Teams/Webex call and persists the resulting transcript and recording URLs.
+
+**1. Schema** — one table to track each bot's lifecycle:
+
+\`\`\`json
+{
+  "tables": {
+    "meetings": {
+      "columns": {
+        "id":             { "type": "uuid", "primaryKey": true, "default": "gen_random_uuid()" },
+        "bot_id":         { "type": "text", "nullable": false, "unique": true },
+        "meeting_url":    { "type": "text", "nullable": false },
+        "status":         { "type": "text", "nullable": false, "default": "'pending'" },
+        "last_event":     { "type": "text" },
+        "events_count":   { "type": "integer", "nullable": false, "default": "0" },
+        "recording_url":  { "type": "text" },
+        "transcript_url": { "type": "text" },
+        "created_at":     { "type": "timestamptz", "nullable": false, "default": "now()" },
+        "updated_at":     { "type": "timestamptz", "nullable": false, "default": "now()" }
+      },
+      "indexes": { "meetings_bot_id_idx": { "columns": ["bot_id"], "unique": true } }
+    }
+  }
+}
+\`\`\`
+
+**2. Spawn function** — \`POST /fn/spawn-bot\` accepts a meeting URL, asks the meetings primitive to join, and inserts a tracking row:
+
+\`\`\`typescript
+export default async function handler(req: Request, ctx: any): Promise<Response> {
+  const { meetingUrl } = await req.json();
+  const res = await fetch(
+    \`\${ctx.env.BUTTERBASE_API_URL}/v1/\${ctx.env.BUTTERBASE_APP_ID}/ai/meetings\`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: \`Bearer \${ctx.env.BUTTERBASE_API_KEY}\`,
+      },
+      body: JSON.stringify({ meetingUrl, transcript: true, recording: 'mp4' }),
+    },
+  );
+  const bot = await res.json();
+  if (!res.ok) return new Response(JSON.stringify(bot), { status: 502 });
+
+  await ctx.db.query(
+    'INSERT INTO meetings (bot_id, meeting_url, status, last_event) VALUES ($1, $2, $3, $4)',
+    [bot.id, meetingUrl, bot.status ?? 'joining', 'spawn'],
+  );
+  return new Response(JSON.stringify({ bot_id: bot.id, status: bot.status }), {
+    headers: { 'content-type': 'application/json' },
+  });
+}
+\`\`\`
+
+Deploy with \`BUTTERBASE_API_KEY\` set in \`envVars\`. \`BUTTERBASE_API_URL\` and \`BUTTERBASE_APP_ID\` are auto-injected.
+
+**3. Configure the forward webhook** — one PUT, store the \`secret\` in your function's env:
+
+\`\`\`bash
+curl -X PUT https://api.butterbase.ai/v1/{app_id}/ai/meetings/webhook \\
+  -H "authorization: Bearer bb_sk_..." \\
+  -H "content-type: application/json" \\
+  -d '{ "forward_url": "https://api.butterbase.ai/v1/{app_id}/fn/meetings-webhook", "rotate_secret": true }'
+# → { "secret": "wsec_..." }   ← copy this once, set it on the function below
+\`\`\`
+
+**4. Webhook function** — \`POST /fn/meetings-webhook\` verifies the per-app HMAC, follows up with a GET when artifacts are ready, and updates the row:
+
+\`\`\`typescript
+function timingSafeEqual(a: string, b: string) {
+  if (a.length !== b.length) return false;
+  let r = 0;
+  for (let i = 0; i < a.length; i++) r |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return r === 0;
+}
+
+async function hmacBase64(secret: string, body: string) {
+  const key = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body));
+  return btoa(String.fromCharCode(...new Uint8Array(mac)));
+}
+
+export default async function handler(req: Request, ctx: any): Promise<Response> {
+  const rawBody = await req.text();
+  const event = req.headers.get('x-bb-event') ?? '';
+  const sig = req.headers.get('x-bb-signature') ?? '';
+
+  // wsec_... returned by PUT, stored in envVars.MEETINGS_WEBHOOK_SECRET.
+  const expected = \`v1,\${await hmacBase64(ctx.env.MEETINGS_WEBHOOK_SECRET, rawBody)}\`;
+  if (!timingSafeEqual(expected, sig)) {
+    return new Response('invalid signature', { status: 401 });
+  }
+
+  const payload = JSON.parse(rawBody);
+  const botId = payload?.data?.bot?.id;
+  if (!botId) return new Response('ok');
+
+  let nextStatus: string | null = null;
+  if (event === 'bot.in_call_recording') nextStatus = 'recording';
+  else if (event === 'bot.done') nextStatus = 'done';
+  else if (event === 'bot.fatal') nextStatus = 'fatal';
+
+  let recordingUrl: string | null = null;
+  let transcriptUrl: string | null = null;
+  if (event === 'recording.done' || event === 'transcript.done' || event === 'bot.done') {
+    const res = await fetch(
+      \`\${ctx.env.BUTTERBASE_API_URL}/v1/\${ctx.env.BUTTERBASE_APP_ID}/ai/meetings/\${botId}\`,
+      { headers: { authorization: \`Bearer \${ctx.env.BUTTERBASE_API_KEY}\` } },
+    );
+    if (res.ok) {
+      const bot = await res.json();
+      recordingUrl = bot.recordingUrl ?? null;
+      transcriptUrl = bot.transcriptUrl ?? null;
+    }
+  }
+
+  await ctx.db.query(
+    \`UPDATE meetings
+        SET status = COALESCE($2, status),
+            last_event = $3,
+            recording_url = COALESCE($4, recording_url),
+            transcript_url = COALESCE($5, transcript_url),
+            events_count = events_count + 1,
+            updated_at = now()
+      WHERE bot_id = $1\`,
+    [botId, nextStatus, event, recordingUrl, transcriptUrl],
+  );
+  return new Response(JSON.stringify({ ok: true }));
+}
+\`\`\`
+
+Deploy with \`envVars: { MEETINGS_WEBHOOK_SECRET: 'wsec_...', BUTTERBASE_API_KEY: 'bb_sk_...' }\` and \`trigger: { type: 'http', config: { method: 'POST', path: '/meetings-webhook', auth: 'none' } }\`. \`auth: 'none'\` is correct — the HMAC inside is what authenticates the caller.
+
+**5. Use it**:
+
+\`\`\`bash
+curl -X POST https://{app_id}.api.butterbase.ai/fn/spawn-bot \\
+  -H "content-type: application/json" \\
+  -d '{ "meetingUrl": "https://zoom.us/j/12345..." }'
+# → { "bot_id": "...", "status": "joining" }
+\`\`\`
+
+The bot joins the call. Events arrive on \`meetings-webhook\` as the lifecycle advances, the row is kept current, and \`recording_url\` + \`transcript_url\` populate when Recall finishes processing the artifacts (usually a minute or two after the call ends).
+
+### Usage & billing
+
+\`\`\`
+GET /v1/{app_id}/ai/meetings/usage
+\`\`\`
+
+Returns the last 100 \`actor_usage_logs\` rows for the app — one row per dimension (\`recording\` and, when transcript was enabled, \`transcription\`) per completed session.
+
+Meetings credits are drawn from the same AI credits pool as chat and embeddings. The cost is computed at terminal events (\`bot.done\` / \`bot.fatal\` for recording, \`transcript.done\` for transcription) from actual measured duration, not from the up-front estimate. Up-front, the platform reserves a small lease against your balance and refunds the unused portion on settle — so a failed join refunds in full.
+
+Free / Pro / Enterprise allowances are the same as documented under the \`ai\` topic.
+
+### Availability
+
+\`\`\`
+GET /v1/ai/meetings/_status
+\`\`\`
+
+Returns \`{ "available": true | false }\` for the deployment. Use this if you want your UI to hide the spawn button when the platform is in degraded mode.
+`,
+
   billing: `## Billing & Plans
 
 Butterbase offers three plan tiers. Each plan includes a set of monthly usage allowances. When you exceed a limit on the Free plan, your account is soft-locked until usage drops or you upgrade. Pro plan users can exceed limits with overage charges.
@@ -3552,6 +3866,7 @@ export function getUserDocumentation(topic: DocTopic): string {
       SECTIONS.functions,
       SECTIONS.frontend,
       SECTIONS.ai,
+      SECTIONS.meetings,
       SECTIONS.rag,
       SECTIONS.billing,
       SECTIONS.platform,

--- a/services/mcp-server/src/tools/docs.ts
+++ b/services/mcp-server/src/tools/docs.ts
@@ -17,6 +17,7 @@ Available topics:
   - functions: Serverless functions (triggers, context)
   - frontend: Static frontend deployment (upload zip, deploy to live URL)
   - ai: AI model gateway (chat completions, BYOK, usage)
+  - meetings: Meeting bots that join Zoom/Meet/Teams/Webex calls and return recordings + transcripts
   - billing: Your Butterbase plan, usage meters, app-level Stripe Connect (subscriptions and one-time payments)
   - platform: MCP over HTTP, /llms.txt, subdomains, suggestions, rate limits
   - regions: Choosing a region at app creation, moving apps between regions, discovering the live region list

--- a/services/mcp-server/src/tools/manage-ai.ts
+++ b/services/mcp-server/src/tools/manage-ai.ts
@@ -29,6 +29,11 @@ Actions:
                        When status is "completed", content_urls contains absolute URLs (same origin
                        as the polling_url) that the caller can fetch() directly using the same
                        Authorization header. Use this to drive your own polling loop.
+  - configure_meetings_webhook  { app_id, forward_url, rotate_secret? }
+                       Upsert the app's meetings webhook forward URL.
+                       When rotate_secret is true (or no row exists), generates a new signing secret
+                       (wsec_…) and returns it once — store it immediately.
+                       Returns { ok, app_id, forward_url, secret } where secret is null when not rotated.
 
 This tool wraps the same /v1/:app_id/chat/completions, /embeddings, /ai/config, /ai/models,
 /ai/usage routes the SDK uses. The "chat" action sets stream: false; for streamed deltas,
@@ -37,7 +42,7 @@ drive the SDK from inside a function or DO.`,
       app_id: z.string().describe('The app ID'),
       action: z.enum([
         'chat', 'embed', 'list_models', 'get_config', 'update_config', 'get_usage',
-        'submit_video', 'poll_video',
+        'submit_video', 'poll_video', 'configure_meetings_webhook',
       ]).describe('The action to perform'),
       // chat
       messages: z.array(z.object({
@@ -71,6 +76,9 @@ drive the SDK from inside a function or DO.`,
       seed: z.number().int().optional(),
       // poll_video
       job_id: z.string().optional().describe('Required for poll_video'),
+      // configure_meetings_webhook
+      forward_url: z.string().optional().describe('Required for configure_meetings_webhook'),
+      rotate_secret: z.boolean().optional().describe('For configure_meetings_webhook — generate a new signing secret'),
     },
     {
       title: 'Manage AI',
@@ -154,6 +162,16 @@ drive the SDK from inside a function or DO.`,
               return { content: [{ type: 'text' as const, text: 'Error: "job_id" is required for "poll_video".' }], isError: true as const };
             }
             result = await apiGet(`/v1/${app_id}/videos/completions/${encodeURIComponent(args.job_id)}`);
+            break;
+          }
+          case 'configure_meetings_webhook': {
+            if (!args.forward_url) {
+              return { content: [{ type: 'text' as const, text: 'Error: "forward_url" is required for "configure_meetings_webhook".' }], isError: true as const };
+            }
+            result = await apiPut(`/v1/${app_id}/ai/meetings/webhook`, {
+              forward_url: args.forward_url,
+              rotate_secret: args.rotate_secret,
+            });
             break;
           }
 

--- a/services/mcp-server/src/tools/manage-ai.ts
+++ b/services/mcp-server/src/tools/manage-ai.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, apiPut } from '../api-client.js';
+import { apiGet, apiPost, apiPut, apiDelete } from '../api-client.js';
 
 export function registerManageAi(server: McpServer) {
   server.tool(
@@ -29,10 +29,25 @@ Actions:
                        When status is "completed", content_urls contains absolute URLs (same origin
                        as the polling_url) that the caller can fetch() directly using the same
                        Authorization header. Use this to drive your own polling loop.
+  - start_meeting     { app_id, meeting_url, transcript?, recording?, metadata? }
+                       Spawn a meeting bot that joins a Zoom/Meet/Teams/Webex call.
+                       recording: "mp4" (default), "audio_only", or false. transcript defaults to true.
+                       Returns { id, status, ... }. Save id to call get_meeting / stop_meeting later.
+  - get_meeting       { app_id, meeting_id }
+                       Current status + recordingUrl / transcriptUrl (populated when artifacts are ready).
+  - list_meetings     { app_id, status?, limit?, cursor? }
+                       Page through this app's bots. status filters to a lifecycle phase
+                       (joining / waiting_room / in_call / recording / ended / done / fatal).
+  - stop_meeting      { app_id, meeting_id }
+                       Force the bot to leave the call. Returns 204 / no body on success.
+  - estimate_meeting  { app_id, duration_minutes, transcript? }
+                       Predict the USD charge for a hypothetical session at this duration.
   - configure_meetings_webhook  { app_id, forward_url, rotate_secret? }
                        Upsert the app's meetings webhook forward URL.
                        When rotate_secret is true (or no row exists), generates a new signing secret
-                       (wsec_…) and returns it once — store it immediately.
+                       (wsec_…) and returns it once — store it immediately. The secret is the
+                       HMAC-SHA256 key that signs every forwarded event for THIS app — see the
+                       "meetings" topic in butterbase_docs for verification details.
                        Returns { ok, app_id, forward_url, secret } where secret is null when not rotated.
   - usage_meetings    { app_id }
                        Returns the last 100 rows from actor_usage_logs for the app.
@@ -45,7 +60,9 @@ drive the SDK from inside a function or DO.`,
       app_id: z.string().describe('The app ID'),
       action: z.enum([
         'chat', 'embed', 'list_models', 'get_config', 'update_config', 'get_usage',
-        'submit_video', 'poll_video', 'configure_meetings_webhook', 'usage_meetings',
+        'submit_video', 'poll_video',
+        'start_meeting', 'get_meeting', 'list_meetings', 'stop_meeting', 'estimate_meeting',
+        'configure_meetings_webhook', 'usage_meetings',
       ]).describe('The action to perform'),
       // chat
       messages: z.array(z.object({
@@ -82,6 +99,20 @@ drive the SDK from inside a function or DO.`,
       // configure_meetings_webhook
       forward_url: z.string().optional().describe('Required for configure_meetings_webhook'),
       rotate_secret: z.boolean().optional().describe('For configure_meetings_webhook — generate a new signing secret'),
+      // start_meeting / list_meetings / etc.
+      meeting_url: z.string().optional().describe('Required for start_meeting'),
+      meeting_id: z.string().optional().describe('Required for get_meeting / stop_meeting'),
+      transcript: z.coerce.boolean().optional().describe('For start_meeting / estimate_meeting (default true)'),
+      recording: z.union([z.literal('mp4'), z.literal('audio_only'), z.literal('false'), z.literal(false)]).optional()
+        .describe('For start_meeting: "mp4" (default), "audio_only", or false to skip recording'),
+      metadata: z.record(z.string()).optional()
+        .describe('For start_meeting — arbitrary string→string map; keys may not start with bb_'),
+      status: z.enum(['joining','waiting_room','in_call','recording','ended','done','fatal']).optional()
+        .describe('For list_meetings — filter to one lifecycle phase'),
+      limit: z.coerce.number().int().min(1).max(100).optional().describe('For list_meetings (default 20)'),
+      cursor: z.string().optional().describe('For list_meetings pagination'),
+      duration_minutes: z.coerce.number().int().min(1).max(24 * 60).optional()
+        .describe('Required for estimate_meeting'),
     },
     {
       title: 'Manage AI',
@@ -165,6 +196,52 @@ drive the SDK from inside a function or DO.`,
               return { content: [{ type: 'text' as const, text: 'Error: "job_id" is required for "poll_video".' }], isError: true as const };
             }
             result = await apiGet(`/v1/${app_id}/videos/completions/${encodeURIComponent(args.job_id)}`);
+            break;
+          }
+          case 'start_meeting': {
+            if (!args.meeting_url) {
+              return { content: [{ type: 'text' as const, text: 'Error: "meeting_url" is required for "start_meeting".' }], isError: true as const };
+            }
+            const recording = args.recording === 'false' ? false : (args.recording ?? 'mp4');
+            result = await apiPost(`/v1/${app_id}/ai/meetings`, {
+              meetingUrl: args.meeting_url,
+              transcript: args.transcript ?? true,
+              recording,
+              metadata: args.metadata,
+            });
+            break;
+          }
+          case 'get_meeting': {
+            if (!args.meeting_id) {
+              return { content: [{ type: 'text' as const, text: 'Error: "meeting_id" is required for "get_meeting".' }], isError: true as const };
+            }
+            result = await apiGet(`/v1/${app_id}/ai/meetings/${encodeURIComponent(args.meeting_id)}`);
+            break;
+          }
+          case 'list_meetings': {
+            const q = new URLSearchParams();
+            if (args.status) q.set('status', args.status);
+            if (args.limit !== undefined) q.set('limit', String(args.limit));
+            if (args.cursor) q.set('cursor', args.cursor);
+            const qs = q.toString();
+            result = await apiGet(`/v1/${app_id}/ai/meetings${qs ? `?${qs}` : ''}`);
+            break;
+          }
+          case 'stop_meeting': {
+            if (!args.meeting_id) {
+              return { content: [{ type: 'text' as const, text: 'Error: "meeting_id" is required for "stop_meeting".' }], isError: true as const };
+            }
+            result = await apiDelete(`/v1/${app_id}/ai/meetings/${encodeURIComponent(args.meeting_id)}`);
+            break;
+          }
+          case 'estimate_meeting': {
+            if (args.duration_minutes === undefined) {
+              return { content: [{ type: 'text' as const, text: 'Error: "duration_minutes" is required for "estimate_meeting".' }], isError: true as const };
+            }
+            const q = new URLSearchParams();
+            q.set('durationMinutes', String(args.duration_minutes));
+            if (args.transcript !== undefined) q.set('transcript', String(args.transcript));
+            result = await apiGet(`/v1/${app_id}/ai/meetings/_estimate?${q.toString()}`);
             break;
           }
           case 'configure_meetings_webhook': {

--- a/services/mcp-server/src/tools/manage-ai.ts
+++ b/services/mcp-server/src/tools/manage-ai.ts
@@ -34,6 +34,9 @@ Actions:
                        When rotate_secret is true (or no row exists), generates a new signing secret
                        (wsec_…) and returns it once — store it immediately.
                        Returns { ok, app_id, forward_url, secret } where secret is null when not rotated.
+  - usage_meetings    { app_id }
+                       Returns the last 100 rows from actor_usage_logs for the app.
+                       Each row has { id, dimension, seconds, usd_charged, created_at }.
 
 This tool wraps the same /v1/:app_id/chat/completions, /embeddings, /ai/config, /ai/models,
 /ai/usage routes the SDK uses. The "chat" action sets stream: false; for streamed deltas,
@@ -42,7 +45,7 @@ drive the SDK from inside a function or DO.`,
       app_id: z.string().describe('The app ID'),
       action: z.enum([
         'chat', 'embed', 'list_models', 'get_config', 'update_config', 'get_usage',
-        'submit_video', 'poll_video', 'configure_meetings_webhook',
+        'submit_video', 'poll_video', 'configure_meetings_webhook', 'usage_meetings',
       ]).describe('The action to perform'),
       // chat
       messages: z.array(z.object({
@@ -172,6 +175,10 @@ drive the SDK from inside a function or DO.`,
               forward_url: args.forward_url,
               rotate_secret: args.rotate_secret,
             });
+            break;
+          }
+          case 'usage_meetings': {
+            result = await apiGet(`/v1/${app_id}/ai/meetings/usage`);
             break;
           }
 


### PR DESCRIPTION
## Summary

Lands the `ai.meetings` primitive end-to-end on the OSS plane:

- `/v1/{appId}/ai/meetings` POST/GET/DELETE/list/_estimate routes (app-scoped — appId in the path, ownership verified against `apps.owner_id`)
- Per-app forward-webhook signing: app secret stored AES-256-GCM-encrypted under `AUTH_ENCRYPTION_KEY`; HMAC-SHA256 over each delivery's raw body
- SDK: `ai.meetings.start / get / list / stop / estimateCost` now hit `/v1/{client.appId}/ai/meetings/...` paths
- CLI: full `bb ai meetings` subcommand tree (start, get, list, stop, estimate, usage, webhook)
- MCP: `manage_ai` gains `start_meeting`, `get_meeting`, `list_meetings`, `stop_meeting`, `estimate_meeting` actions
- Docs: new `meetings` topic in `butterbase_docs` with a copy-pasteable example app (schema + spawn function + webhook handler + curl invocation)
- Migration `088_app_meetings_webhooks`: `forward_secret_encrypted` column (replaces the never-shipped `forward_secret_hash`); `@scope: platform` header so the runner picks it up
- Migration `023_actor_usage_logs` (runtime plane): unchanged

## Test plan

- [x] Live end-to-end against a real Recall.ai us-west-2 bot in a Zoom call: `bot.in_call_recording → recording.done → transcript.done → bot.done` all verified with the per-app `wsec_...`, `recordingUrl` + `transcriptUrl` back-filled via the documented follow-up GET
- [x] MCP `estimate_meeting`, `list_meetings`, `get_meeting`, `usage_meetings` against the live local stack
- [x] CLI `bb ai meetings estimate / list / get / usage` against the live local stack
- [x] SDK `meetings.estimateCost / list / get` from a Node script against the live local stack
- [x] Control-plane migration 088 + runtime-plane migration 023 applied to prod Neon (us-east-1 control, us-east-1 + us-west-2 runtime) via `db/*-plane/migrate.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)