### PR TITLE
docs(runtime): changelog + functions-api cross-link for ctx platform context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 Migration is mechanical — the new actions take the same parameters as the standalone tools they replace, plus the `action` discriminator.
 
+### Added
+
+- **Runtime**: function `ctx` now surfaces platform-known values so user code doesn't have to set them as env vars by hand. Two parallel surfaces, same source of truth:
+  - Flat `ctx.env.BUTTERBASE_*` (muscle-memory `Deno.env`-style):
+    - Always present: `BUTTERBASE_APP_ID`, `BUTTERBASE_API_URL`, `BUTTERBASE_APP_NAME`, `BUTTERBASE_REGION`, `BUTTERBASE_ANON_KEY`.
+    - Present when configured (omitted otherwise — branch with `typeof === "string"`, not empty-string checks): `BUTTERBASE_FRONTEND_URL`, `BUTTERBASE_SUBDOMAIN`, `BUTTERBASE_STRIPE_ACCOUNT_ID`, `BUTTERBASE_AI_DEFAULT_MODEL`.
+  - Structured `ctx.app = { id, name, ownerId, region, subdomain, anonKey, allowedOrigins, frontend, auth, ai, billing }` with optional sub-objects (`frontend`, `ai`, `billing`) set to `null` when unconfigured. `ctx.app.auth` is always present (`{ accessTokenTtl, refreshTokenTtlDays, hookFunction }`).
+  - Per-invocation `ctx.request = { id, ip, country, functionName }` derived from `X-Request-Id` / `Fly-Client-Ip` / `Cf-Connecting-Ip` / `X-Forwarded-For` / `Cf-Ipcountry` / `Fly-Region` headers.
+  - Platform keys are injected **after** user `envVars` so user-set vars can't shadow them. No new infra; one extended `apps` SELECT in `function-loader.ts`. See `core-concepts/functions` → Platform context.
+
 ## [0.3.0] - 2026-06-08
 
 ### Added

--- a/services/docs/src/content/docs/api-reference/functions-api.md
+++ b/services/docs/src/content/docs/api-reference/functions-api.md
@@ -58,7 +58,7 @@ Authorization: Bearer {token}
 | Field | Default | Description |
 |-------|---------|-------------|
 | `description` | — | What the function does |
-| `envVars` | — | Environment variables (encrypted) |
+| `envVars` | — | Environment variables (encrypted). The platform also auto-injects `BUTTERBASE_*` keys at runtime — see [Platform context](/core-concepts/functions/#platform-context). Platform keys are injected after your `envVars` so you can't shadow them. |
 | `timeoutMs` | 30000 | Max execution time (max: 300000) |
 | `memoryLimitMb` | 128 | Memory limit (range: 64-1024) |
 | `triggers` | `[{type: "http"}]` | Array of trigger configs. At most one per type. |


### PR DESCRIPTION
Follow-up to #49 — documents the runtime ctx surface that shipped but wasn't in CHANGELOG.

- CHANGELOG: Unreleased > Added entry for ctx.env.BUTTERBASE_*, ctx.app, ctx.request.
- functions-api: envVars row cross-links to the Platform context section so users see auto-injected keys at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)