### PR TITLE
feat: ctx.caller + ctx.invoke + per-fn impersonation gate + one-key-per-clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Migration is mechanical — the new actions take the same parameters as the stan
 
 ### Added
 
+- **Runtime**: `ctx.caller` on every function invocation surfaces validated caller identity — `{ type: 'service_key' | 'end_user_jwt' | 'loopback' | 'anonymous', keyId, scope, userId }`. Use this instead of parsing `req.headers.authorization` by hand for audit logging or in-function policy checks. `keyId` is a non-secret api-key row id safe to log; `userId` is the user the request is acting on behalf of (propagated through `ctx.invoke` chains and `X-Butterbase-As-User` impersonation). See `core-concepts/functions` → Server-to-server function calls.
+- **Runtime**: `ctx.invoke('fn-name', body, opts?)` for same-app function-to-function calls. Authenticated with the per-app internal function key (auto-injected, never exposed via `ctx.env`), `ctx.user.id` propagates automatically to the callee, `ctx.caller.type === 'loopback'`. Cycle guard caps chains at depth 4; the 5th hop throws synchronously with `ctx.invoke loop limit exceeded`. Returns a standard `Response`.
+- **Runtime / control-api**: per-function impersonation gate via `X-Butterbase-As-User`. App-scoped service keys (`bb_sk_*` with `app:<this-app>` scope) and same-app loopbacks may set this header; the runtime populates `ctx.user.id` with the asserted id before invoking. The gate is per-function (`app_functions.allow_service_key_impersonation`, default `true`) — flip to `false` on admin-only or billing-webhook handlers and the platform 403s any `X-Butterbase-As-User` header on those endpoints at the edge. End-user JWTs and keys scoped to other apps cannot impersonate. Audit rows on impersonated invocations carry `event_data.impersonated_user_id` for downstream "what was done as me" surfaces.
+- **MCP / CLI / SDK / dashboard**: `allow_service_key_impersonation` exposed end-to-end. `deploy_function` accepts the field at deploy time; `manage_function` gains a new action `update_settings` (and the underlying `PATCH /v1/{app_id}/functions/{name}/settings`) to flip it without redeploying code; `bb functions deploy --no-allow-impersonation` for the CLI; `apiClient.updateFunctionSettings()` in `@butterbase/sdk`; a "Security — Service-key impersonation" toggle on the function detail page in the dashboard with cache-invalidation so the new value takes effect immediately.
+- **Shared types**: new `FunctionCaller` interface in `@butterbase/shared` mirrors `ctx.caller`. Importable from user function code that wants types on the runtime context.
+- **Runtime migration**: `024_function_impersonation_flag.sql` adds `app_functions.allow_service_key_impersonation BOOLEAN NOT NULL DEFAULT true`. Defaults preserve pre-Phase-2 behavior — existing functions keep working without any code changes.
+
+### Changed
+
+- **Clone job**: auto-mints **one** `bb_sk_*` per cloned app instead of one per function. Previously the clone replay minted a distinct key per function, with the label `Auto-mint for clone (<dest_app_id>/<fn_name>)`; cross-function calls that compared the bearer to `ctx.env.BUTTERBASE_API_KEY` therefore 401d because each fn's env held a different key. The new shape labels the key `Auto-mint for clone (<dest_app_id>)` and writes the same value into every fn's env. Existing already-cloned apps are not retroactively fixed by this change — run `scripts/backfill-consolidate-clone-keys.ts` against the affected runtime DBs to consolidate retroactively.
+
+### Deprecated
+
+- **Templates / user code**: the bearer-equality auth pattern in function code is deprecated. Code that compared `req.headers.get('authorization') === \`Bearer ${ctx.env.BUTTERBASE_API_KEY}\`` to decide whether to trust an `as_user_id` body field worked only when every caller and callee shared one key — a coincidence the clone job no longer (and arguably never should have) guaranteed. Replace with `ctx.user.id` (impersonation is now a platform concern, gated per-function) or `ctx.invoke('fn-name', body)` for same-app calls (no bearer involved). The platform will keep accepting the old pattern for back-compat in this release; it will not be removed without a separate breaking-change notice.
+
+### Operational
+
+- **Backfill script**: `scripts/backfill-consolidate-clone-keys.ts` scans every runtime DB for apps whose functions disagree on the value of `BUTTERBASE_API_KEY` / `BB_SUBSTRATE_KEY` and rewrites every function's env to one canonical value (the alphabetically-first existing value — deterministic, no new key mint). Dry-run by default; `--fix` to apply; `--app <id>` to scope to one app. Safe to run multiple times (idempotent), and does not revoke the displaced api_keys rows (orphan revocation is a separate ops task).
+
 - **Runtime**: function `ctx` now surfaces platform-known values so user code doesn't have to set them as env vars by hand. Two parallel surfaces, same source of truth:
   - Flat `ctx.env.BUTTERBASE_*` (muscle-memory `Deno.env`-style):
     - Always present: `BUTTERBASE_APP_ID`, `BUTTERBASE_API_URL`, `BUTTERBASE_APP_NAME`, `BUTTERBASE_REGION`, `BUTTERBASE_ANON_KEY`.

--- a/db/runtime-plane/024_function_impersonation_flag.sql
+++ b/db/runtime-plane/024_function_impersonation_flag.sql
@@ -1,0 +1,26 @@
+-- @scope: runtime
+-- Phase 2: per-function impersonation gate.
+--
+-- Lets a service-key caller assert "act on behalf of user X" via the
+-- `X-Butterbase-As-User` header. The runtime sets `ctx.user.id` to the
+-- impersonated id BEFORE invoking the function. This replaces the
+-- bearer-equality anti-pattern (`req.headers.authorization === Bearer
+-- ctx.env.BUTTERBASE_API_KEY`) which broke under per-function key minting
+-- and any future key rotation.
+--
+-- Default TRUE preserves existing behavior: legacy templates that already
+-- implicitly trusted any app-scoped service key with an as-user assertion
+-- (the equality-check pattern was trying to express exactly this) keep
+-- working without changes. Functions that should never accept impersonation
+-- (admin-only mutators, billing webhooks, etc.) flip the flag to FALSE at
+-- deploy time via the new `allowServiceKeyImpersonation` deploy parameter
+-- or `manage_function` update action.
+--
+-- Enforcement lives in control-api/routes/auto-api.ts: when an as-user
+-- header is present and the caller is an app-scoped service key, the route
+-- looks up this flag on the target function and 403s if FALSE before
+-- forwarding to the runtime. The flag is loaded by function-loader and
+-- cached alongside the function code, so the hot path stays one DB hit.
+
+ALTER TABLE public.app_functions
+  ADD COLUMN IF NOT EXISTS allow_service_key_impersonation BOOLEAN NOT NULL DEFAULT true;

--- a/packages/cli/bin/butterbase.ts
+++ b/packages/cli/bin/butterbase.ts
@@ -401,6 +401,8 @@ functions
   .option('--agent-tool-description <desc>', 'Description shown to the LLM when this function is exposed as an agent tool')
   .option('--agent-tool-mode <mode>', 'read_only (default) | read_write (read_write requires HITL approval)')
   .option('--agent-tool-exposed-to <scope>', 'developer_only (default) | end_user')
+  .option('--allow-impersonation', 'Allow service-key callers to impersonate via X-Butterbase-As-User (default)')
+  .option('--no-allow-impersonation', 'Reject any X-Butterbase-As-User header — for admin-only / billing-webhook handlers')
   .action(functionsDeployCommand);
 
 functions

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -109,6 +109,8 @@ export async function functionsDeployCommand(file: string, options: {
   agentToolDescription?: string;
   agentToolMode?: string;
   agentToolExposedTo?: string;
+  /** --allow-impersonation / --no-allow-impersonation */
+  allowImpersonation?: boolean;
 }) {
   const appId = await requireAppId(options.app);
 
@@ -172,6 +174,10 @@ export async function functionsDeployCommand(file: string, options: {
       ...(options.agentToolDescription !== undefined ? { agent_tool_description: options.agentToolDescription } : {}),
       ...(mode ? { agent_tool_mode: mode as 'read_only' | 'read_write' } : {}),
       ...(exposed ? { agent_tool_exposed_to: exposed as 'developer_only' | 'end_user' } : {}),
+      // Phase 2: per-fn impersonation gate. Default-on at the API; the flag
+      // only travels in the body when the user explicitly passes --allow-
+      // impersonation or --no-allow-impersonation.
+      ...(options.allowImpersonation !== undefined ? { allow_service_key_impersonation: options.allowImpersonation } : {}),
     });
 
     spinner.succeed(`Deployed function "${functionName}"`);

--- a/packages/sdk/src/admin/types.ts
+++ b/packages/sdk/src/admin/types.ts
@@ -156,6 +156,13 @@ export interface DeployFunctionParams extends AgentToolFields {
   trigger?: FunctionTrigger;
   /** Canonical multi-trigger array. At most one trigger per type. */
   triggers?: FunctionTrigger[];
+  /**
+   * Default true. When true, this function accepts an `X-Butterbase-As-User`
+   * header from app-scoped service-key callers and treats `ctx.user.id` as
+   * the asserted user. Set to false for admin-only or billing-webhook
+   * handlers that must never be invoked on behalf of an end-user.
+   */
+  allow_service_key_impersonation?: boolean;
 }
 
 export interface FunctionSummary extends AgentToolFields {
@@ -171,6 +178,8 @@ export interface FunctionSummary extends AgentToolFields {
   invocationCount?: number;
   errorRate?: number;
   avgDuration?: number;
+  /** Phase 2 impersonation gate. See DeployFunctionParams. */
+  allow_service_key_impersonation?: boolean;
 }
 
 export interface FunctionDetails extends FunctionSummary {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -115,6 +115,43 @@ export interface AuthContext {
   rawToken?: string;
 }
 
+/**
+ * Caller identity surfaced as `ctx.caller` inside a deployed function.
+ *
+ * Populated from the validated Authorization header at the control-api edge
+ * (or filled with `{ type: 'anonymous', ... }` when no bearer was present).
+ * User code SHOULD prefer reading this over decoding `req.headers.authorization`
+ * by hand — the platform has already done the cryptographic checks.
+ *
+ * Identity propagation rule of thumb:
+ *   - `type === 'end_user_jwt'`: `userId` is the app-user who hit the endpoint.
+ *     `ctx.user.id` is set; `keyId`/`scope` are null.
+ *   - `type === 'service_key'`: a `bb_sk_*` key authenticated the request.
+ *     `keyId` is the row id of the key (safe to log/audit, never the secret).
+ *     `scope` is one of the key's `app:<app_id>` / `ai:gateway` entries —
+ *     useful for "is this an app-scoped caller?" checks.
+ *   - `type === 'anonymous'`: no bearer, or the bearer was invalid/revoked.
+ */
+export interface FunctionCaller {
+  /**
+   * - `service_key` — user-managed bb_sk_*
+   * - `end_user_jwt` — an app end-user
+   * - `loopback` — same-app ctx.invoke from a sibling function
+   * - `anonymous` — no/invalid bearer
+   */
+  type: 'service_key' | 'end_user_jwt' | 'loopback' | 'anonymous';
+  /** API-key row id (e.g. `ak_…`). Present iff `type === 'service_key'`. */
+  keyId: string | null;
+  /** First app- or gateway-scope on the key (e.g. `app:app_xyz`). */
+  scope: string | null;
+  /**
+   * The user this request is acting *on behalf of*. For `end_user_jwt` this is
+   * the JWT subject; for `service_key` it is null today (Phase 2 enables an
+   * impersonation header that populates this).
+   */
+  userId: string | null;
+}
+
 export interface AppSigningKey {
   id: string;
   app_id: string;

--- a/scripts/backfill-consolidate-clone-keys.ts
+++ b/scripts/backfill-consolidate-clone-keys.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill: consolidate per-function `BUTTERBASE_API_KEY` / `BB_SUBSTRATE_KEY`
+ * values to a single shared key per app.
+ *
+ * Background: prior to the "one shared key per clone" change, the clone job
+ * minted a distinct `bb_sk_*` for every function on the cloned app. Functions
+ * that called sibling functions and compared `req.headers.authorization` to
+ * their own `ctx.env.BUTTERBASE_API_KEY` then failed with 401 because the
+ * caller's bearer (its own minted key) never equalled the callee's env key.
+ *
+ * This script consolidates: for every app whose functions disagree on the
+ * value of `BUTTERBASE_API_KEY` (and `BB_SUBSTRATE_KEY`), it picks one of the
+ * existing values as canonical and rewrites every function's env to use it.
+ *
+ * Canonical selection: deterministic — the alphabetically first key among the
+ * distinct values. Picking any one of the already-minted, already-app-scoped
+ * keys is safe; the platform's auth layer accepts any of them. We don't mint
+ * new keys (would orphan more rows) and we don't revoke the displaced ones
+ * (would risk breaking any caller we missed) — orphan revocation is a
+ * follow-up ops task.
+ *
+ * Usage:
+ *   tsx scripts/backfill-consolidate-clone-keys.ts          # dry-run (default)
+ *   tsx scripts/backfill-consolidate-clone-keys.ts --fix    # apply
+ *   tsx scripts/backfill-consolidate-clone-keys.ts --app app_xyz   # one app
+ */
+import pg from 'pg';
+import { encrypt, decrypt } from '../services/control-api/src/services/crypto.js';
+
+const FIX = process.argv.includes('--fix');
+const APP_ARG_IDX = process.argv.indexOf('--app');
+const APP_FILTER = APP_ARG_IDX >= 0 ? process.argv[APP_ARG_IDX + 1] : null;
+
+const KEYS_TO_CONSOLIDATE = ['BUTTERBASE_API_KEY', 'BB_SUBSTRATE_KEY'];
+
+interface FnEnvRow {
+  id: string;
+  name: string;
+  encrypted_env_vars: string | null;
+}
+
+interface AppPlan {
+  appId: string;
+  canonicalValue: string;
+  affected: { fnId: string; fnName: string; oldValue: string | null; keysToWrite: string[] }[];
+  displacedValues: Set<string>;
+}
+
+function pickCanonical(distinctValues: Set<string>): string {
+  // Deterministic: alphabetically first. Any of the existing values would
+  // work — they're all already-minted, already-app-scoped keys.
+  return [...distinctValues].sort()[0];
+}
+
+function planForApp(appId: string, fns: FnEnvRow[], encKey: string): AppPlan | null {
+  // Decrypt each function's env once. Track per-function values for each
+  // consolidation key.
+  const perFn: { row: FnEnvRow; env: Record<string, string> | null }[] = [];
+  for (const row of fns) {
+    if (!row.encrypted_env_vars) {
+      perFn.push({ row, env: null });
+      continue;
+    }
+    try {
+      const env = JSON.parse(decrypt(row.encrypted_env_vars, encKey)) as Record<string, string>;
+      perFn.push({ row, env });
+    } catch (err) {
+      console.warn(`[${appId}] could not decrypt env for fn=${row.name}: ${(err as Error).message}`);
+      perFn.push({ row, env: null });
+    }
+  }
+
+  // Collect distinct values across the keys we want to consolidate.
+  const distinct = new Set<string>();
+  for (const { env } of perFn) {
+    if (!env) continue;
+    for (const k of KEYS_TO_CONSOLIDATE) {
+      if (typeof env[k] === 'string') distinct.add(env[k]);
+    }
+  }
+
+  // Skip apps that are already in good shape: 0 or 1 distinct value across
+  // all functions/keys means nothing to do.
+  if (distinct.size <= 1) return null;
+
+  const canonical = pickCanonical(distinct);
+  const affected: AppPlan['affected'] = [];
+  const displaced = new Set<string>();
+
+  for (const { row, env } of perFn) {
+    if (!env) continue;
+    const keysToWrite: string[] = [];
+    for (const k of KEYS_TO_CONSOLIDATE) {
+      const current = env[k];
+      if (typeof current !== 'string') continue;
+      if (current !== canonical) {
+        keysToWrite.push(k);
+        displaced.add(current);
+      }
+    }
+    if (keysToWrite.length > 0) {
+      affected.push({
+        fnId: row.id,
+        fnName: row.name,
+        oldValue: env[keysToWrite[0]] ?? null,
+        keysToWrite,
+      });
+    }
+  }
+
+  if (affected.length === 0) return null;
+
+  return { appId, canonicalValue: canonical, affected, displacedValues: displaced };
+}
+
+async function applyPlan(pool: pg.Pool, encKey: string, plan: AppPlan): Promise<void> {
+  // Re-read + decrypt + merge + encrypt per row so we don't trample any
+  // unrelated env vars that have been edited since we planned.
+  for (const change of plan.affected) {
+    const res = await pool.query<{ encrypted_env_vars: string | null }>(
+      `SELECT encrypted_env_vars FROM app_functions WHERE id = $1`,
+      [change.fnId],
+    );
+    const blob = res.rows[0]?.encrypted_env_vars;
+    if (!blob) {
+      console.warn(`  [${plan.appId}/${change.fnName}] env vanished between plan and apply; skipping`);
+      continue;
+    }
+    const env = JSON.parse(decrypt(blob, encKey)) as Record<string, string>;
+    for (const k of change.keysToWrite) {
+      env[k] = plan.canonicalValue;
+    }
+    const enc = encrypt(JSON.stringify(env), encKey);
+    await pool.query(
+      `UPDATE app_functions SET encrypted_env_vars = $1, updated_at = now() WHERE id = $2`,
+      [enc, change.fnId],
+    );
+  }
+}
+
+async function processRegion(region: string, runtimeUrl: string, encKey: string): Promise<{ plansFound: number; plansApplied: number }> {
+  const pool = new pg.Pool({ connectionString: runtimeUrl });
+  let plansFound = 0;
+  let plansApplied = 0;
+  try {
+    // Find candidate apps: any app that has 2+ functions with encrypted_env_vars.
+    // We can't filter on "disagrees on api key" in SQL because envs are
+    // encrypted — but the candidate set is small (cloned apps), so a per-app
+    // decrypt is cheap.
+    const filterClause = APP_FILTER ? 'AND app_id = $1' : '';
+    const params = APP_FILTER ? [APP_FILTER] : [];
+    const candidates = await pool.query<{ app_id: string }>(
+      `SELECT app_id
+         FROM app_functions
+        WHERE deleted_at IS NULL AND encrypted_env_vars IS NOT NULL ${filterClause}
+        GROUP BY app_id
+       HAVING COUNT(*) >= 2`,
+      params,
+    );
+
+    console.log(`[${region}] ${candidates.rows.length} candidate apps`);
+
+    for (const { app_id } of candidates.rows) {
+      const fns = await pool.query<FnEnvRow>(
+        `SELECT id, name, encrypted_env_vars
+           FROM app_functions
+          WHERE app_id = $1 AND deleted_at IS NULL`,
+        [app_id],
+      );
+      const plan = planForApp(app_id, fns.rows, encKey);
+      if (!plan) continue;
+      plansFound++;
+
+      const canonPrefix = plan.canonicalValue.slice(0, 12);
+      const displacedPrefixes = [...plan.displacedValues].map(v => v.slice(0, 12)).sort();
+      console.log(`  [${app_id}] needs consolidation`);
+      console.log(`    canonical:  ${canonPrefix}…`);
+      console.log(`    displaced:  ${displacedPrefixes.join(', ')}`);
+      console.log(`    affected fns (${plan.affected.length}):`);
+      for (const a of plan.affected) {
+        console.log(`      - ${a.fnName}  keys=[${a.keysToWrite.join(',')}]`);
+      }
+
+      if (FIX) {
+        await applyPlan(pool, encKey, plan);
+        plansApplied++;
+        console.log(`    ✓ applied`);
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+  return { plansFound, plansApplied };
+}
+
+async function main(): Promise<void> {
+  const encKey = process.env.AUTH_ENCRYPTION_KEY;
+  if (!encKey) throw new Error('AUTH_ENCRYPTION_KEY is required');
+
+  const regions = (process.env.BUTTERBASE_REGIONS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+  if (regions.length === 0) throw new Error('BUTTERBASE_REGIONS is empty');
+
+  console.log(`mode: ${FIX ? 'APPLY' : 'dry-run'} ${APP_FILTER ? `(app=${APP_FILTER})` : ''}`);
+  let totalFound = 0;
+  let totalApplied = 0;
+
+  for (const region of regions) {
+    const urlVar = `NEON_RUNTIME_PROJECT_ID_${region.toUpperCase().replace(/-/g, '_')}`;
+    const url = process.env[urlVar];
+    if (!url) {
+      console.warn(`[${region}] no ${urlVar}; skipping`);
+      continue;
+    }
+    const { plansFound, plansApplied } = await processRegion(region, url, encKey);
+    totalFound += plansFound;
+    totalApplied += plansApplied;
+  }
+
+  console.log(`\nsummary: ${totalFound} apps needed consolidation, ${totalApplied} applied`);
+  if (!FIX && totalFound > 0) {
+    console.log('(run with --fix to apply)');
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/control-api/src/routes/auto-api.ts
+++ b/services/control-api/src/routes/auto-api.ts
@@ -5,6 +5,7 @@ import { introspectSchema } from '../services/schema-introspector.js';
 import { buildSelectQuery } from '../services/query-builder.js';
 import { AppResolver, AppNotFoundError, AppAuthRequiredError, AppPausedError, assertAppNotPaused } from '../services/app-resolver.js';
 import { verifyEndUserJwt } from '../services/end-user-auth.js';
+import { ApiKeyService } from '../services/api-key-service.js';
 import type { EndUserClaims } from '@butterbase/shared/types';
 import {
   createAgentError,
@@ -384,8 +385,10 @@ export async function autoApiRoutes(app: FastifyInstance) {
         paused: boolean;
         paused_reason: string | null;
         trigger_config: { auth?: 'required' | 'optional' | 'none' } | null;
+        allow_service_key_impersonation: boolean | null;
       }>(
-        `SELECT a.paused, a.paused_reason, ft.trigger_config
+        `SELECT a.paused, a.paused_reason, ft.trigger_config,
+                f.allow_service_key_impersonation
          FROM apps a
          LEFT JOIN app_functions f
            ON f.app_id = a.id AND f.name = $2 AND f.deleted_at IS NULL
@@ -399,18 +402,65 @@ export async function autoApiRoutes(app: FastifyInstance) {
         throw new AppPausedError(app_id, meta.paused_reason ?? null);
       }
 
-      // Extract user ID from end-user JWT (if present)
+      // Extract caller identity. Two paths:
+      //   1) Bearer is a bb_sk_* service key — validate and surface key_id +
+      //      scopes to the runtime. This is the path cron / cross-fn callers
+      //      take, and it's what `ctx.caller` exposes in the runtime so user
+      //      code doesn't have to do its own bearer comparisons.
+      //   2) Bearer is an end-user JWT — verify and surface user id.
+      // The two paths are mutually exclusive on a single request, so try the
+      // cheap shape check (bb_sk_* prefix) before the expensive JWT verify.
       const authHeader = request.headers.authorization;
+      let callerType: 'service_key' | 'end_user_jwt' | 'loopback' | 'anonymous' = 'anonymous';
+      let callerKeyId: string | null = null;
+      let callerScope: string | null = null;
 
       if (authHeader && authHeader.startsWith('Bearer ')) {
         const token = authHeader.substring(7);
-        try {
-          // Verify end-user JWT
-          const claims = await verifyEndUserJwt(app.controlDb, app_id, token);
-          userId = claims.sub;
-        } catch (error) {
-          app.log.warn({ error }, 'Invalid end-user JWT');
-          // Continue without user ID - function can handle auth
+        if (token.startsWith('bb_sk_')) {
+          const auth = await ApiKeyService.validateApiKey(app.controlDb, token);
+          if (auth) {
+            callerType = 'service_key';
+            callerKeyId = auth.keyId ?? null;
+            // Pick the first app-scoped scope that names this app, if any.
+            // Format on the wire is `app:<app_id>`; fall back to the literal
+            // scope list if no app-scoped entry exists (lets ai:gateway-only
+            // keys still surface SOMETHING in ctx.caller).
+            const appScoped = auth.scopes?.find(s => s.startsWith('app:')) ?? null;
+            callerScope = appScoped ?? auth.scopes?.[0] ?? null;
+          } else {
+            // Invalid / revoked bb_sk_* — leave as anonymous and let the
+            // user function decide. Same posture as a missing bearer.
+            app.log.warn({ app_id, functionName }, 'invalid bb_sk_* on function invocation');
+          }
+        } else if (/^[a-f0-9]{40,80}$/.test(token)) {
+          // Phase 3: per-app internal function key (40–80 hex chars, no
+          // prefix). Used by ctx.invoke for same-app function-to-function
+          // calls — the runtime injected this key on the calling function's
+          // ctx, so a valid match here implies "this app's runtime is
+          // calling itself." Treat as `loopback`: equivalent trust to a
+          // service key scoped to this app, but distinguishable in audit
+          // logs and ctx.caller for downstream debugging.
+          const { KvCredentialsService } = await import('../services/kv-credentials.js');
+          const svc = new KvCredentialsService(app.controlDb);
+          const resolved = await svc.resolveFunctionKeyWithOwner(token, app_id);
+          if (resolved) {
+            callerType = 'loopback';
+            callerScope = `app:${app_id}`;
+            // keyId stays null — function_keys aren't first-class api_keys
+            // rows; we don't have a stable id to surface.
+          } else {
+            app.log.warn({ app_id, functionName }, 'unrecognized function_key on fn invocation');
+          }
+        } else {
+          try {
+            const claims = await verifyEndUserJwt(app.controlDb, app_id, token);
+            userId = claims.sub;
+            callerType = 'end_user_jwt';
+          } catch (error) {
+            app.log.warn({ error }, 'Invalid end-user JWT');
+            // Continue without user ID - function can handle auth
+          }
         }
       }
 
@@ -422,6 +472,50 @@ export async function autoApiRoutes(app: FastifyInstance) {
       // its own 404 / 405 so error semantics stay consistent.
       if (meta?.trigger_config?.auth === 'required' && !userId) {
         return reply.code(401).send(AUTH_REQUIRED_ERROR);
+      }
+
+      // Phase 2: service-key impersonation via `X-Butterbase-As-User`.
+      //   - Header is honored ONLY when the caller is an app-scoped service
+      //     key for THIS app (scope starts with `app:<app_id>`). Anonymous
+      //     callers and end-user JWTs cannot impersonate — letting an end
+      //     user claim to be another user is an obvious privilege break.
+      //   - The target function must allow impersonation. The flag defaults
+      //     to true (preserves the implicit pre-Phase-2 contract) and is
+      //     flipped to false for admin/billing-webhook handlers.
+      //   - When honored, the impersonated id wins over any user id we may
+      //     have derived from an end-user JWT path (which isn't possible
+      //     here anyway — service-key path doesn't set userId).
+      const asUserHeader = request.headers['x-butterbase-as-user'];
+      const asUser = typeof asUserHeader === 'string' ? asUserHeader.trim() : null;
+      if (asUser) {
+        // Phase 3: `loopback` calls (same-app ctx.invoke) are internally
+        // trusted — the runtime authenticated with the per-app function
+        // key, which only the platform-managed runtime holds. Accept them
+        // the same as app-scoped service keys here.
+        const isAppScopedServiceKey =
+          callerType === 'service_key' && callerScope === `app:${app_id}`;
+        const isLoopback = callerType === 'loopback';
+        if (!isAppScopedServiceKey && !isLoopback) {
+          return reply.code(403).send(createAgentError({
+            code: 'AUTH_IMPERSONATION_FORBIDDEN',
+            message: 'X-Butterbase-As-User requires an app-scoped service key',
+            remediation: 'Send the request with a bb_sk_* key whose scope includes `app:<this app>`. End-user JWTs cannot impersonate other users.',
+            documentation_url: getDocUrl('AUTH_IMPERSONATION_FORBIDDEN'),
+          }));
+        }
+        // meta.allow_service_key_impersonation is null when the function row
+        // or HTTP trigger is missing — same NULL path as trigger_config. In
+        // that case we don't know whether impersonation is allowed; fall
+        // through and let the runtime return its 404.
+        if (meta?.allow_service_key_impersonation === false) {
+          return reply.code(403).send(createAgentError({
+            code: 'AUTH_IMPERSONATION_DISABLED',
+            message: `Function ${functionName} does not accept service-key impersonation`,
+            remediation: 'Enable impersonation via `manage_function` (allowServiceKeyImpersonation: true), or call the function with an end-user JWT instead of a service key + as-user header.',
+            documentation_url: getDocUrl('AUTH_IMPERSONATION_DISABLED'),
+          }));
+        }
+        userId = asUser;
       }
 
       // Forward to Deno runtime (preserve query string)
@@ -460,6 +554,13 @@ export async function autoApiRoutes(app: FastifyInstance) {
       // Platform headers always override whatever the caller sent
       forwardHeaders['x-user-id'] = userId || '';
       forwardHeaders['x-app-id'] = app_id;
+      // Caller identity (Phase 1: ctx.caller). Always set the type so the
+      // runtime can normalize; key_id/scope only present for service-key
+      // calls. Headers are platform-injected — anything the user sent under
+      // these names was already overwritten by this assignment.
+      forwardHeaders['x-butterbase-caller-type'] = callerType;
+      if (callerKeyId) forwardHeaders['x-butterbase-caller-key-id'] = callerKeyId;
+      if (callerScope) forwardHeaders['x-butterbase-caller-scope'] = callerScope;
 
       // Forward the raw body without re-serialization:
       //   - Buffer: wildcard parser captured multipart / octet-stream / etc.
@@ -491,9 +592,19 @@ export async function autoApiRoutes(app: FastifyInstance) {
         action: 'invoke',
         resourceType: 'function',
         resourceId: functionName,
-        actorType: userId ? 'app_user' : 'anonymous',
-        actorId: userId ?? null,
-        eventData: { duration_ms: durationMs, status_code: denoResponse.status, method: request.method },
+        // When a service key impersonates an end-user, attribute the action
+        // to the key (not the impersonated user) so the audit trail shows
+        // who actually invoked the request. The impersonated user lives in
+        // event_data.impersonated_user_id alongside, queryable for
+        // user-facing "what was done as me" surfaces.
+        actorType: callerType === 'service_key' ? 'api_key' : (userId ? 'app_user' : 'anonymous'),
+        actorId: callerType === 'service_key' ? (callerKeyId ?? null) : (userId ?? null),
+        eventData: {
+          duration_ms: durationMs,
+          status_code: denoResponse.status,
+          method: request.method,
+          ...(asUser ? { impersonated_user_id: asUser } : {}),
+        },
         ipAddress: request.ip ?? null,
         userAgent: (request.headers['user-agent'] as string | undefined) ?? null,
         success: denoResponse.ok,

--- a/services/control-api/src/routes/functions.ts
+++ b/services/control-api/src/routes/functions.ts
@@ -37,6 +37,8 @@ const deployFunctionSchema = z.object({
   agent_tool_description: z.string().max(500).optional(),
   agent_tool_mode: z.enum(['read_only', 'read_write']).default('read_only'),
   agent_tool_exposed_to: z.enum(['developer_only', 'end_user']).default('developer_only'),
+  /** Phase 2: per-function gate for X-Butterbase-As-User impersonation. */
+  allow_service_key_impersonation: z.boolean().default(true),
 });
 
 type TriggerInput = z.infer<typeof triggerInputSchema>;
@@ -157,8 +159,9 @@ export async function registerFunctionRoutes(fastify: FastifyInstance) {
         `INSERT INTO app_functions (
           app_id, name, code, description, encrypted_env_vars,
           timeout_ms, memory_limit_mb, deployed_by,
-          agent_tool, agent_tool_description, agent_tool_mode, agent_tool_exposed_to
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          agent_tool, agent_tool_description, agent_tool_mode, agent_tool_exposed_to,
+          allow_service_key_impersonation
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
         ON CONFLICT (app_id, name)
         DO UPDATE SET
           code = $3,
@@ -173,13 +176,15 @@ export async function registerFunctionRoutes(fastify: FastifyInstance) {
           agent_tool = $9,
           agent_tool_description = COALESCE($10, app_functions.agent_tool_description),
           agent_tool_mode = $11,
-          agent_tool_exposed_to = $12
+          agent_tool_exposed_to = $12,
+          allow_service_key_impersonation = $13
         RETURNING id, name, deployed_at`,
         [
           appId, body.name, body.code, body.description ?? null, encryptedEnvVars,
           body.timeoutMs ?? 30000, body.memoryLimitMb ?? 128, requireUserId(request),
           body.agent_tool, body.agent_tool_description ?? null,
           body.agent_tool_mode, body.agent_tool_exposed_to,
+          body.allow_service_key_impersonation,
         ],
       );
 
@@ -334,6 +339,69 @@ export async function registerFunctionRoutes(fastify: FastifyInstance) {
     });
   });
 
+  // PATCH /v1/:appId/functions/:name/settings — toggle per-function settings
+  // without redeploying code. Currently only `allow_service_key_impersonation`
+  // (Phase 2 impersonation gate), but the route is extensible for future
+  // per-function knobs. Skips the encryption + re-deploy round-trip the
+  // INSERT/ON CONFLICT path takes, so it's safe to call on hot functions.
+  fastify.patch('/v1/:appId/functions/:name/settings', { config: { requiresAppRegion: true, migrationGuard: true } }, async (request, reply) => {
+    const { appId, name } = request.params as { appId: string; name: string };
+    const body = request.body as { allow_service_key_impersonation?: boolean };
+
+    await AppResolver.resolveApp(controlDb, appId, requireUserId(request));
+
+    if (body.allow_service_key_impersonation === undefined) {
+      return reply.code(400).send(createAgentError({
+        code: VALIDATION_INVALID_SCHEMA,
+        message: 'Provide at least one setting to update',
+        remediation: 'Currently supported: allow_service_key_impersonation (boolean).',
+        documentation_url: getDocUrl(VALIDATION_INVALID_SCHEMA),
+      }));
+    }
+
+    const result = await (await runtimeDb(appId)).query(
+      `UPDATE app_functions
+         SET allow_service_key_impersonation = $1, updated_at = now()
+       WHERE app_id = $2 AND name = $3 AND deleted_at IS NULL
+       RETURNING id, name, allow_service_key_impersonation, updated_at`,
+      [body.allow_service_key_impersonation, appId, name]
+    );
+
+    if (result.rows.length === 0) {
+      return reply.code(404).send(createAgentError({
+        code: RESOURCE_NOT_FOUND,
+        message: 'Function not found',
+        remediation: 'Verify the function name. Use list_functions to see available functions.',
+        documentation_url: getDocUrl(RESOURCE_NOT_FOUND),
+      }));
+    }
+
+    // Invalidate function cache so the runtime picks up the new flag on next
+    // invocation. Without this, an in-cache metadata row would keep the old
+    // `allow_service_key_impersonation` value until natural expiry (5 min).
+    const invalidationResult = await invalidateFunctionCache(appId, name);
+
+    logFromRequest(request, {
+      appId,
+      category: 'admin',
+      eventType: 'function.settings.update',
+      action: 'update',
+      resourceType: 'function',
+      resourceId: name,
+      eventData: { allow_service_key_impersonation: body.allow_service_key_impersonation },
+      success: true,
+    });
+
+    return reply.send({
+      message: 'Function settings updated successfully',
+      function: result.rows[0],
+      cache_invalidation: {
+        success: invalidationResult.success,
+        attempts: invalidationResult.attempts,
+      },
+    });
+  });
+
   // List functions for an app
   fastify.get('/v1/:appId/functions', { config: { requiresAppRegion: true, migrationGuard: true } }, async (request, reply) => {
     const { appId } = request.params as { appId: string };
@@ -347,6 +415,7 @@ export async function registerFunctionRoutes(fastify: FastifyInstance) {
         f.deployed_at, f.last_invoked_at, f.last_status_code,
         f.invocation_count AS invocation_count_total,
         f.agent_tool, f.agent_tool_description, f.agent_tool_mode, f.agent_tool_exposed_to,
+        f.allow_service_key_impersonation,
         COALESCE(stats.invocation_count_24h, 0) AS invocation_count_24h,
         COALESCE(stats.error_count_24h, 0) AS error_count_24h,
         stats.avg_duration_24h,

--- a/services/control-api/src/services/__tests__/clone-env-vars.test.ts
+++ b/services/control-api/src/services/__tests__/clone-env-vars.test.ts
@@ -102,7 +102,6 @@ describeDb('mintApiKeyForClone', () => {
     const { key, keyId } = await mintApiKeyForClone(controlDb, {
       ownerId,
       destAppId,
-      fnName: 'agent-chat',
     });
     expect(key.startsWith('bb_sk_')).toBe(true);
 
@@ -112,8 +111,10 @@ describeDb('mintApiKeyForClone', () => {
     );
     expect(row.rows[0].user_id).toBe(ownerId);
     expect(row.rows[0].scopes).toEqual(expect.arrayContaining([`app:${destAppId}`, 'ai:gateway']));
-    expect(row.rows[0].name).toContain('agent-chat');
-    expect(row.rows[0].name).toContain('clone');
+    // Per Phase 4: the auto-minted key is one-per-app, NOT one-per-function —
+    // function name is intentionally absent from the label so all functions on
+    // a cloned app share one credential.
+    expect(row.rows[0].name).toBe(`Auto-mint for clone (${destAppId})`);
 
     await controlDb.query(`DELETE FROM api_keys WHERE id = $1`, [keyId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);

--- a/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
+++ b/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
@@ -87,4 +87,71 @@ describeDb('replayFunctions with pending env vars', () => {
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
   });
+
+  // Phase 4 contract: one shared bb_sk_* per clone, fanned out to every fn
+  // that needs BUTTERBASE_API_KEY. Pre-Phase-4 the clone job minted a distinct
+  // key per function, which broke any in-app function-to-function call whose
+  // callee compared the bearer to its own env. See
+  // backfill-consolidate-clone-keys.ts for the matching cleanup script.
+  it('mints exactly one shared bb_sk_* and assigns the same value to every fn', async () => {
+    const ownerId = randomUUID();
+    await controlDb.query(
+      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
+      [ownerId, `replay-shared-${ownerId}@x.com`],
+    );
+    const srcId = `app_replay_shared_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_replay_shared_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+         ON CONFLICT (id) DO NOTHING`,
+        [id, ownerId],
+      );
+    }
+    const { encrypt } = await import('../crypto.js');
+    const enc = encrypt(
+      JSON.stringify({ BUTTERBASE_API_KEY: 'placeholder' }),
+      process.env.AUTH_ENCRYPTION_KEY!,
+    );
+    for (const fn of ['auto-sync', 'ingest-gmail', 'ingest-calendar']) {
+      await runtimeDb.query(
+        `INSERT INTO app_functions (id, app_id, name, code, encrypted_env_vars, deployed_by)
+         VALUES (gen_random_uuid(), $1, $2, '/* code */', $3, $4)`,
+        [srcId, fn, enc, ownerId],
+      );
+    }
+
+    const result = await replayFunctions(
+      runtimeDb, runtimeDb, srcId, destId, ownerId, noopLogger,
+      { controlPool: controlDb, destAppOwnerId: ownerId },
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.unfilledEnvVars).toEqual({});
+
+    const rows = await runtimeDb.query<{ name: string; encrypted_env_vars: string }>(
+      `SELECT name, encrypted_env_vars FROM app_functions WHERE app_id = $1 ORDER BY name`,
+      [destId],
+    );
+    const distinctKeys = new Set<string>();
+    for (const r of rows.rows) {
+      const env = JSON.parse(decrypt(r.encrypted_env_vars, process.env.AUTH_ENCRYPTION_KEY!));
+      expect(typeof env.BUTTERBASE_API_KEY).toBe('string');
+      expect(env.BUTTERBASE_API_KEY.startsWith('bb_sk_')).toBe(true);
+      distinctKeys.add(env.BUTTERBASE_API_KEY);
+    }
+    expect(distinctKeys.size).toBe(1);
+
+    const keyRows = await controlDb.query<{ name: string }>(
+      `SELECT name FROM api_keys WHERE user_id = $1 AND name LIKE $2`,
+      [ownerId, `Auto-mint for clone (${destId})%`],
+    );
+    // Exactly ONE auto-minted key for this clone — no per-fn proliferation.
+    expect(keyRows.rows.length).toBe(1);
+    expect(keyRows.rows[0].name).toBe(`Auto-mint for clone (${destId})`);
+
+    await controlDb.query(`DELETE FROM api_keys WHERE user_id = $1`, [ownerId]);
+    await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
+    await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+    await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+  });
 });

--- a/services/control-api/src/services/clone-env-vars.ts
+++ b/services/control-api/src/services/clone-env-vars.ts
@@ -123,15 +123,24 @@ export interface MintedCloneKey {
  * app's AI gateway. Used when the user opts into auto-mint for the
  * BUTTERBASE_API_KEY convention. Scope is intentionally limited to
  * `app:<destAppId>` + `ai:gateway` so a leaked key cannot be repurposed.
+ *
+ * One key per cloned app (not per function). Functions on the same app
+ * frequently call each other (cron fn calls ingest fn, ingest fn calls
+ * enrichment fn, …) and any in-function caller-equality check on the bearer
+ * (`req.headers.authorization === Bearer ctx.env.BUTTERBASE_API_KEY`) only
+ * works when every function sees the same key. The `fnName` arg is accepted
+ * but currently only used in the key's display name when supplied — multiple
+ * call sites within a single clone job MUST pass the same key to every
+ * function (use `mintSharedCloneKey` from replayFunctions).
  */
 export async function mintApiKeyForClone(
   controlPool: pg.Pool,
-  args: { ownerId: string; destAppId: string; fnName: string },
+  args: { ownerId: string; destAppId: string },
 ): Promise<MintedCloneKey> {
   const result = await ApiKeyService.generateApiKey(
     controlPool,
     args.ownerId,
-    `Auto-mint for clone (${args.destAppId}/${args.fnName})`,
+    `Auto-mint for clone (${args.destAppId})`,
     [`app:${args.destAppId}`, 'ai:gateway'],
     'app',
   );

--- a/services/control-api/src/services/clone-replay.ts
+++ b/services/control-api/src/services/clone-replay.ts
@@ -387,6 +387,44 @@ export async function replayFunctions(
     logger.warn({ err }, '[clone] listSourceEnvVarKeys failed; unfilledEnvVars will be empty');
   }
 
+  // Mint at most ONE shared bb_sk_* key for the entire clone — every function
+  // that needs BUTTERBASE_API_KEY / BB_SUBSTRATE_KEY (and isn't satisfied by
+  // user-supplied values) gets the same key. This is what makes intra-app
+  // function calls work: a cron fn that POSTs to a sibling fn with
+  // `Authorization: Bearer ctx.env.BUTTERBASE_API_KEY` only succeeds if the
+  // callee's env carries the same value. Pre-cloud this was minted per
+  // function, which silently 401d every sibling call.
+  //
+  // We mint only after confirming at least one function actually needs a key
+  // and the caller passed the credentials to mint with — otherwise the mint
+  // is skipped and unfilled keys surface to the dashboard banner as usual.
+  let sharedMintedKey: string | null = null;
+  let sharedMintError: string | null = null;
+  const anyFnNeedsMint =
+    (opts?.autoMintRequests?.length ?? 0) > 0 ||
+    [...sourceKeysMap.values()].some(keys =>
+      [...keys].some(k => AUTO_MINT_CONVENTION_KEYS.includes(k)),
+    );
+  if (anyFnNeedsMint) {
+    if (!opts?.controlPool || !opts?.destAppOwnerId) {
+      sharedMintError = 'auto-mint required but controlPool or destAppOwnerId missing';
+      logger.warn({ destAppId }, `[clone] ${sharedMintError}; skipping shared key mint`);
+    } else {
+      try {
+        const minted = await mintApiKeyForClone(opts.controlPool, {
+          ownerId: opts.destAppOwnerId,
+          destAppId,
+        });
+        sharedMintedKey = minted.key;
+        logger.info({ destAppId, keyId: minted.keyId }, '[clone] shared API key minted for clone');
+      } catch (mintErr) {
+        sharedMintError = `shared key mint failed: ${(mintErr as Error).message}`;
+        warnings.push(sharedMintError);
+        logger.warn({ err: mintErr, destAppId }, '[clone] shared key mint failed; per-function keys will remain unfilled');
+      }
+    }
+  }
+
   for (const f of src.rows) {
     try {
       const ins = await destRuntimePool.query<{ id: string }>(
@@ -444,11 +482,10 @@ export async function replayFunctions(
         const provided = opts?.pendingEnvVarValues?.[f.name] ?? {};
         const merged: Record<string, string> = { ...provided };
 
-        // Explicit per-function mint requests + implicit convention mints. A
-        // single bb_sk_* satisfies every convention key (see CONVENTIONS in
-        // clone-env-vars.ts) so we mint at most one key per function and reuse
-        // it for all matching keys. Skip any key the caller already supplied
-        // via pendingEnvVarValues.
+        // Explicit per-function mint requests + implicit convention mints.
+        // Skip any key the caller already supplied via pendingEnvVarValues.
+        // All target keys for all functions receive the SAME app-wide minted
+        // bb_sk_* (sharedMintedKey, minted once above the loop).
         const explicit = opts?.autoMintRequests?.filter(r => r.fn_name === f.name) ?? [];
         const conventionMintTargets = (sourceKeysMap.get(f.name) ? [...sourceKeysMap.get(f.name)!] : [])
           .filter(k => AUTO_MINT_CONVENTION_KEYS.includes(k) && !(k in merged));
@@ -456,23 +493,17 @@ export async function replayFunctions(
         const mintTargets = Array.from(new Set([...explicitKeys, ...conventionMintTargets]));
 
         if (mintTargets.length > 0) {
-          if (!opts?.controlPool || !opts?.destAppOwnerId) {
-            logger.warn(
-              { fn: f.name, keys: mintTargets },
-              '[clone] auto-mint required but controlPool or destAppOwnerId missing; skipping',
-            );
+          if (sharedMintedKey) {
+            for (const k of mintTargets) merged[k] = sharedMintedKey;
           } else {
-            try {
-              const minted = await mintApiKeyForClone(opts.controlPool, {
-                ownerId: opts.destAppOwnerId,
-                destAppId,
-                fnName: f.name,
-              });
-              for (const k of mintTargets) merged[k] = minted.key;
-            } catch (mintErr) {
-              warnings.push(`Auto-mint failed for ${f.name} (${mintTargets.join(',')}): ${(mintErr as Error).message}`);
-              logger.warn({ err: mintErr, fn: f.name, keys: mintTargets }, '[clone] auto-mint failed; continuing');
-            }
+            // Shared mint either wasn't attempted (no credentials) or failed —
+            // surface per-fn so the dashboard banner shows what's unfilled.
+            // `sharedMintError` is already warned + (when it failed at mint
+            // time) pushed to top-level warnings, so don't double-record.
+            logger.warn(
+              { fn: f.name, keys: mintTargets, sharedMintError },
+              '[clone] shared key unavailable; mint targets will remain unfilled',
+            );
           }
         }
 

--- a/services/deno-runtime/function-loader.ts
+++ b/services/deno-runtime/function-loader.ts
@@ -82,6 +82,15 @@ export interface FunctionMetadata {
   internal_fn_key: string | null;
   timeout_ms: number;
   memory_limit_mb: number;
+  /**
+   * Per-function gate for service-key impersonation (Phase 2). When false,
+   * the control-api edge will 403 any call carrying `X-Butterbase-As-User`
+   * before the function runs. Default true preserves the implicit pre-Phase-2
+   * contract (bearer-equality check was implicitly allowing this for any
+   * app-scoped key) — flip to false in `manage_function` for admin-only or
+   * billing-webhook handlers that should never accept an as-user assertion.
+   */
+  allow_service_key_impersonation: boolean;
   db_connection_string: string | null;
   substrate_user_id: string | null;
   /**
@@ -176,6 +185,7 @@ export async function loadFunction(
       `SELECT
         id, app_id, name, code, encrypted_env_vars,
         timeout_ms, memory_limit_mb,
+        allow_service_key_impersonation,
         deployed_at
        FROM app_functions
        WHERE app_id = $1 AND name = $2 AND deleted_at IS NULL`,
@@ -254,6 +264,7 @@ export async function loadFunction(
       internal_fn_key: kvKey,
       timeout_ms: row.timeout_ms,
       memory_limit_mb: row.memory_limit_mb,
+      allow_service_key_impersonation: row.allow_service_key_impersonation !== false,
       db_connection_string: dbConnectionString,
       substrate_user_id: app.substrate_user_id ?? null,
       platform: {

--- a/services/deno-runtime/server.ts
+++ b/services/deno-runtime/server.ts
@@ -109,15 +109,27 @@ serve(async (req: Request) => {
       );
     }
 
-    // Extract user ID from headers
+    // Extract user ID + caller identity from platform-injected headers.
+    // `x-user-id` is the effective user (end-user JWT subject, or null for
+    // service-key/anonymous). `x-butterbase-caller-*` describes WHO made the
+    // request: type=service_key|end_user_jwt|anonymous, plus key_id/scope for
+    // service-key calls. Phase 1 surfaces these as `ctx.caller` in user code.
     const userId = req.headers.get("x-user-id") || undefined;
+    const callerTypeRaw = req.headers.get("x-butterbase-caller-type");
+    const callerKeyId = req.headers.get("x-butterbase-caller-key-id") || null;
+    const callerScope = req.headers.get("x-butterbase-caller-scope") || null;
+    const callerType: "service_key" | "end_user_jwt" | "loopback" | "anonymous" =
+      callerTypeRaw === "service_key" || callerTypeRaw === "end_user_jwt" || callerTypeRaw === "loopback"
+        ? callerTypeRaw
+        : "anonymous";
+    const caller = { type: callerType, keyId: callerKeyId, scope: callerScope, userId: userId ?? null };
 
     // Execute function
     activeWorkers++;
     const startTime = Date.now();
 
     try {
-      const result = await executeFunction(metadata, req, userId);
+      const result = await executeFunction(metadata, req, userId, caller);
 
       // Log invocation (async, fire-and-forget)
       logInvocation(metadata, req, result, userId).catch((err) =>

--- a/services/deno-runtime/worker-executor.ts
+++ b/services/deno-runtime/worker-executor.ts
@@ -26,10 +26,18 @@ export interface ExecutionResult {
   };
 }
 
+export interface CallerInfo {
+  type: "service_key" | "end_user_jwt" | "loopback" | "anonymous";
+  keyId: string | null;
+  scope: string | null;
+  userId: string | null;
+}
+
 export async function executeFunction(
   metadata: FunctionMetadata,
   request: Request,
-  userId?: string
+  userId?: string,
+  caller?: CallerInfo
 ): Promise<ExecutionResult> {
   const startTime = Date.now();
   const startMemory = (performance as any).memory?.usedJSHeapSize || 0;
@@ -60,6 +68,7 @@ export async function executeFunction(
       requestHeaders,
       requestBody,
       userId,
+      caller,
     });
 
     // Execute in Web Worker with timeout
@@ -245,6 +254,7 @@ function buildWorkerCode(
     requestHeaders: Record<string, string>;
     requestBody: string | null;
     userId?: string;
+    caller?: CallerInfo;
   }
 ): string {
   return `
@@ -468,6 +478,16 @@ function buildWorkerCode(
         };
       })())},
       user: ${context.userId ? `{ id: "${context.userId}" }` : "null"},
+      caller: ${JSON.stringify(
+        context.caller
+          ? {
+              type: context.caller.type,
+              keyId: context.caller.keyId,
+              scope: context.caller.scope,
+              userId: context.caller.userId,
+            }
+          : { type: "anonymous", keyId: null, scope: null, userId: null }
+      )},
       app: ${JSON.stringify({
         id: metadata.app_id,
         name: metadata.platform.app_name,
@@ -501,6 +521,48 @@ function buildWorkerCode(
           ?? null,
         functionName: metadata.function_name,
       })},
+      /**
+       * Phase 3: ctx.invoke('fn', body) — same-app function-to-function call.
+       *
+       * Auth: uses the per-app internal function key (already injected on
+       * loadFunction, never exposed via ctx.env). Identity: ctx.user.id is
+       * propagated as X-Butterbase-As-User so the callee sees the same end
+       * user. Cycle guard: X-Butterbase-Loop-Depth is incremented per hop;
+       * at MAX (4) we throw locally instead of letting the platform 508.
+       *
+       * Returns a standard Response. opts.method defaults to POST; pass
+       * 'GET'/'PUT'/etc. as needed. opts.headers overlays on top of the
+       * platform-injected ones (the platform headers always win for
+       * authorization, x-butterbase-loop-depth, x-butterbase-as-user).
+       */
+      invoke: async (fnName, body, opts) => {
+        const MAX_DEPTH = 4;
+        const incomingDepth = parseInt(${JSON.stringify(context.requestHeaders["x-butterbase-loop-depth"] || "0")}, 10) || 0;
+        const nextDepth = incomingDepth + 1;
+        if (nextDepth > MAX_DEPTH) {
+          throw new Error("ctx.invoke loop limit exceeded (depth " + nextDepth + " > " + MAX_DEPTH + ")");
+        }
+        const apiUrl = ${JSON.stringify(Deno.env.get("API_BASE_URL") || Deno.env.get("CONTROL_API_URL") || "http://localhost:4000")};
+        const internalKey = ${JSON.stringify(metadata.internal_fn_key || '')};
+        if (!internalKey) {
+          throw new Error("ctx.invoke unavailable: no internal function key on this runtime");
+        }
+        const userHeaders = (opts && typeof opts.headers === "object" && opts.headers) || {};
+        const platformHeaders = {
+          "content-type": "application/json",
+          "authorization": "Bearer " + internalKey,
+          "x-butterbase-loop-depth": String(nextDepth),
+          "x-butterbase-caller-source-fn": ${JSON.stringify(metadata.function_name)},
+        };
+        ${context.userId ? `platformHeaders["x-butterbase-as-user"] = ${JSON.stringify(context.userId)};` : ''}
+        const merged = { ...userHeaders, ...platformHeaders };
+        const method = (opts && typeof opts.method === "string") ? opts.method : "POST";
+        const url = apiUrl + "/v1/" + ${JSON.stringify(metadata.app_id)} + "/fn/" + encodeURIComponent(fnName);
+        const bodyInit = body === undefined || method === "GET" || method === "HEAD"
+          ? undefined
+          : (typeof body === "string" ? body : JSON.stringify(body));
+        return fetch(url, { method, headers: merged, body: bodyInit });
+      },
       idempotency: db ? {
         // Atomically claim a key. Returns true if newly claimed (caller should
         // proceed), false if the key was already processed (caller should treat

--- a/services/docs/src/content/docs/api-reference/functions-api.md
+++ b/services/docs/src/content/docs/api-reference/functions-api.md
@@ -67,6 +67,7 @@ Authorization: Bearer {token}
 | `agent_tool_description` | — | Short description shown to the LLM (max 500 chars). |
 | `agent_tool_mode` | `read_only` | `read_only` or `read_write`. `read_write` requires HITL approval. |
 | `agent_tool_exposed_to` | `developer_only` | `developer_only` or `end_user`. |
+| `allow_service_key_impersonation` | `true` | When `true`, this function accepts `X-Butterbase-As-User` from app-scoped service keys and the runtime populates `ctx.user.id` accordingly. Set to `false` on admin-only or billing-webhook handlers — the platform 403s any `X-Butterbase-As-User` header on them at the edge. See [Server-to-server function calls](/core-concepts/functions/#server-to-server-function-calls). |
 
 ### Trigger types
 
@@ -96,6 +97,22 @@ When `agent_tool: true`, this function becomes callable from any agent in the sa
 ```
 
 The 4 `agent_tool*` fields are returned on `GET /functions` and `GET /functions/{name}` so clients can render UI state.
+
+## Update function settings
+
+```json
+PATCH /v1/{app_id}/functions/{name}/settings
+Authorization: Bearer {token}
+
+{
+  "allow_service_key_impersonation": false
+}
+```
+
+Toggle per-function settings without redeploying code. Currently the only
+supported field is `allow_service_key_impersonation` (the Phase 2
+impersonation gate). On success, the runtime cache is invalidated so the new
+value takes effect on the next invocation.
 
 ## Update environment variables
 

--- a/services/docs/src/content/docs/core-concepts/functions.md
+++ b/services/docs/src/content/docs/core-concepts/functions.md
@@ -91,7 +91,9 @@ export default async function handler(req: Request, ctx: any): Promise<Response>
 - Standard Web APIs (fetch, Request, Response, Headers, URL, etc.)
 - Environment variables via `ctx.env.VAR_NAME`
 - Database access via `ctx.db.query(sql)`
-- User info via `ctx.user` (when invoked with end-user JWT)
+- User info via `ctx.user` (populated for end-user JWTs, or for service-key callers that pass `X-Butterbase-As-User` — see "Server-to-server function calls" below)
+- Caller identity via `ctx.caller` — type, key id, scope, propagated user id (see "Server-to-server function calls" below)
+- Sibling-function calls via `ctx.invoke('fn-name', body)` — no manual auth, identity propagates automatically
 - App metadata via `ctx.app` and per-request data via `ctx.request` — see "Platform context" below
 - Console output (`console.log`, `console.info`, `console.warn`, `console.error`, `console.debug`) — captured and visible in invocation logs
 - Network access
@@ -141,6 +143,99 @@ ctx.request = { id, ip, country, functionName }
 ```
 
 Platform keys are injected **after** your function-specific env vars, so a user-set `BUTTERBASE_APP_ID` will not shadow the real one.
+
+## Server-to-server function calls
+
+A common pattern is a cron-triggered function that fans out to sibling
+functions on the same app — e.g. `auto-sync-google` calls `ingest-gmail` and
+`ingest-calendar`. The platform gives you three tools for this:
+
+### `ctx.invoke('fn-name', body)` — the easy path
+
+Use this for any same-app function call. No bearer ceremony, no env-var keys.
+
+```typescript
+export async function handler(req, ctx) {
+  // Identity propagates automatically: if this fn was invoked with an
+  // end-user JWT, the callee sees the same ctx.user.id.
+  const r = await ctx.invoke('ingest-gmail', { workspace_id: 'ws_abc' });
+  const data = await r.json();
+  return new Response(JSON.stringify({ enqueued: data.queued }), { status: 200 });
+}
+```
+
+Behavior:
+- Authenticated with the per-app internal function key (auto-injected, never
+  exposed via `ctx.env`).
+- `ctx.user.id` propagates: the callee sees the same user the caller saw.
+- `ctx.caller.type === 'loopback'` in the callee.
+- Cycle guard: `ctx.invoke` chains are capped at depth 4; the 5th hop throws
+  `ctx.invoke loop limit exceeded` synchronously.
+- Returns a standard `Response` (just like `fetch`).
+
+### `ctx.caller` — who called this function
+
+Populated on every invocation. Use it for audit logging or to make policy
+decisions in user code without parsing `req.headers.authorization` by hand.
+
+```ts
+ctx.caller = {
+  type: 'service_key' | 'end_user_jwt' | 'loopback' | 'anonymous',
+  keyId: string | null,  // present iff type === 'service_key'
+  scope: string | null,  // first app- or gateway-scope on the key
+  userId: string | null, // user this request is acting on behalf of
+}
+```
+
+| Caller | type | userId | keyId |
+|--------|------|--------|-------|
+| Browser with end-user JWT | `end_user_jwt` | JWT `sub` | `null` |
+| Cron / external service with `bb_sk_*` | `service_key` | `null` (unless impersonating) | api key row id |
+| Sibling function via `ctx.invoke` | `loopback` | propagated | `null` |
+| No bearer / invalid bearer | `anonymous` | `null` | `null` |
+
+### `X-Butterbase-As-User` — when you have to call from outside
+
+For callers that can't use `ctx.invoke` (cron jobs running outside the
+runtime, external services, scripts), send the header alongside an
+app-scoped `bb_sk_*`:
+
+```http
+POST /v1/app_abc/fn/ingest-gmail
+Authorization: Bearer bb_sk_…
+X-Butterbase-As-User: 11111111-2222-3333-4444-555555555555
+Content-Type: application/json
+
+{ "workspace_id": "ws_abc" }
+```
+
+The runtime populates `ctx.user.id` with the asserted id before invoking the
+function — no in-function bearer comparison required.
+
+**Per-function gate.** Functions can opt out of impersonation with
+`allow_service_key_impersonation: false` at deploy time (or via
+`manage_function action: "update_settings"`). The platform 403s any
+`X-Butterbase-As-User` header on those functions at the edge. Use this for
+admin-only or billing-webhook handlers that must never act on behalf of an
+end user.
+
+### Anti-pattern: bearer-equality checks
+
+Some older templates compared the incoming bearer to their own
+`ctx.env.BUTTERBASE_API_KEY` to decide whether to trust an `as_user_id` body
+field:
+
+```ts
+// ❌ Don't do this — fragile under key rotation, multi-key environments,
+//    or cloned apps where every function gets a different key.
+const expected = `Bearer ${ctx.env.BUTTERBASE_API_KEY}`;
+if (req.headers.get('authorization') === expected) {
+  userId = body.as_user_id;
+}
+```
+
+Replace with `ctx.user.id` (impersonation is now a platform concern) or
+`ctx.invoke` (no bearer involved at all).
 
 ## RLS in functions
 

--- a/services/docs/src/data/changelog.ts
+++ b/services/docs/src/data/changelog.ts
@@ -21,6 +21,38 @@ export interface RoadmapItem {
  */
 export const changelog: RoadmapItem[] = [
   {
+    date: '2026-06-14',
+    category: 'functions',
+    title: 'ctx.invoke for same-app function-to-function calls',
+    description: 'Call sibling functions on the same app with `ctx.invoke(\'fn-name\', body)` — no bearer ceremony, no env vars. Authenticated with the per-app internal function key (never exposed to user code), `ctx.user.id` propagates automatically to the callee, and a depth-4 cycle guard throws synchronously on the 5th hop. Replaces the brittle pattern of having one fn call another over HTTP with `Bearer ctx.env.BUTTERBASE_API_KEY`.',
+    href: '/core-concepts/functions/#server-to-server-function-calls',
+    icon: '🔗',
+  },
+  {
+    date: '2026-06-14',
+    category: 'functions',
+    title: 'ctx.caller — validated caller identity',
+    description: 'Every function invocation now surfaces `ctx.caller = { type, keyId, scope, userId }`. Type is one of `service_key`, `end_user_jwt`, `loopback`, or `anonymous`. The `keyId` is a non-secret api-key row id safe to log in audit trails; `userId` is the user the request is acting on behalf of (propagated through ctx.invoke chains and X-Butterbase-As-User impersonation). Stop parsing `req.headers.authorization` by hand.',
+    href: '/core-concepts/functions/#ctx-caller-who-called-this-function',
+    icon: '🪪',
+  },
+  {
+    date: '2026-06-14',
+    category: 'functions',
+    title: 'Service-key impersonation gate',
+    description: 'App-scoped service keys can now assert "act on behalf of user X" via the `X-Butterbase-As-User` header — the runtime populates `ctx.user.id` before invoking. Per-function `allow_service_key_impersonation` (default `true`) lets admin-only and billing-webhook handlers opt out; the platform 403s any X-Butterbase-As-User on those endpoints at the edge. End-user JWTs and out-of-app service keys cannot impersonate. Surfaced through `deploy_function`, `manage_function action: "update_settings"`, the CLI (`bb functions deploy --no-allow-impersonation`), the SDK (`apiClient.updateFunctionSettings`), and a toggle on the dashboard function detail page.',
+    href: '/core-concepts/functions/#x-butterbase-as-user-when-you-have-to-call-from-outside',
+    icon: '🛂',
+  },
+  {
+    date: '2026-06-14',
+    category: 'tooling',
+    title: 'Cloned apps now mint one shared API key',
+    description: 'Previously the clone job auto-minted a distinct `bb_sk_*` per function on the cloned app — any sibling-fn call that compared its bearer to its own `ctx.env.BUTTERBASE_API_KEY` 401d because every fn carried a different key. Clones now mint one key per app, fanned out to every function that needs `BUTTERBASE_API_KEY` / `BB_SUBSTRATE_KEY`. Existing already-cloned apps can be consolidated with `scripts/backfill-consolidate-clone-keys.ts`.',
+    href: '/core-concepts/functions/#server-to-server-function-calls',
+    icon: '🔑',
+  },
+  {
     date: '2026-06-08',
     category: 'ai',
     title: 'Agents',

--- a/services/mcp-server/src/tools/deploy-function.ts
+++ b/services/mcp-server/src/tools/deploy-function.ts
@@ -156,6 +156,13 @@ Next steps: Use invoke_function to test, then manage_function (action: "get_logs
         'developer_only (default) — only dashboard/CLI test runs can call it. ' +
         'end_user — also callable by public agent invocations.'
       ),
+      allow_service_key_impersonation: z.boolean().optional().describe(
+        'Default true. Lets an app-scoped service-key caller assert "act as ' +
+        'user X" via the X-Butterbase-As-User header — the runtime populates ' +
+        'ctx.user with the asserted id before invoking. Set to false on ' +
+        'admin-only or billing-webhook handlers that must never accept an ' +
+        'as-user assertion: control-api will 403 such calls at the edge.'
+      ),
     },
     {
       title: 'Deploy Function',
@@ -169,6 +176,7 @@ Next steps: Use invoke_function to test, then manage_function (action: "get_logs
         app_id, name, code, description, envVars, timeoutMs, memoryLimitMb,
         trigger, triggers,
         agent_tool, agent_tool_description, agent_tool_mode, agent_tool_exposed_to,
+        allow_service_key_impersonation,
       } = args;
 
       const result = await apiPost(`/v1/${app_id}/functions`, {
@@ -184,6 +192,7 @@ Next steps: Use invoke_function to test, then manage_function (action: "get_logs
         ...(agent_tool_description !== undefined ? { agent_tool_description } : {}),
         ...(agent_tool_mode !== undefined ? { agent_tool_mode } : {}),
         ...(agent_tool_exposed_to !== undefined ? { agent_tool_exposed_to } : {}),
+        ...(allow_service_key_impersonation !== undefined ? { allow_service_key_impersonation } : {}),
       });
 
       return {

--- a/services/mcp-server/src/tools/manage-function.ts
+++ b/services/mcp-server/src/tools/manage-function.ts
@@ -72,6 +72,7 @@ Actions:
   - "delete":     Delete a deployed function permanently (IRREVERSIBLE)
   - "get_logs":   Retrieve recent invocation logs for debugging and monitoring
   - "update_env": Update environment variables for a deployed function without redeploying code
+  - "update_settings": Toggle per-function settings (currently: allow_service_key_impersonation)
 
 Parameters by action:
   list:       { app_id, action: "list" }
@@ -79,6 +80,7 @@ Parameters by action:
   delete:     { app_id, action: "delete", function_name }
   get_logs:   { app_id, action: "get_logs", function_name, limit?, since?, level?, include_deleted? }
   update_env: { app_id, action: "update_env", function_name, env }
+  update_settings: { app_id, action: "update_settings", function_name, allow_service_key_impersonation? }
 
 Common errors:
   - RESOURCE_NOT_FOUND: Function doesn't exist
@@ -87,8 +89,8 @@ Common errors:
 Idempotency: Safe to call anytime (list is read-only; delete is idempotent; update_env is safe to call multiple times).`,
     {
       app_id: z.string().describe('The app ID'),
-      action: z.enum(['list', 'get', 'delete', 'get_logs', 'update_env']).describe('The action to perform'),
-      function_name: z.string().optional().describe('The function name (required for get, delete, get_logs, update_env)'),
+      action: z.enum(['list', 'get', 'delete', 'get_logs', 'update_env', 'update_settings']).describe('The action to perform'),
+      function_name: z.string().optional().describe('The function name (required for get, delete, get_logs, update_env, update_settings)'),
       // get_logs params
       limit: z.number().optional().describe('Maximum number of logs to return (default: 100)'),
       since: z.string().optional().describe('ISO timestamp to filter logs after this time'),
@@ -96,6 +98,12 @@ Idempotency: Safe to call anytime (list is read-only; delete is idempotent; upda
       include_deleted: z.boolean().optional().describe('Include logs for soft-deleted functions (post-incident forensics). Default: false.'),
       // update_env params
       env: z.record(z.union([z.string(), z.null()])).optional().describe('Environment variables to set (string) or delete (null)'),
+      // update_settings params
+      allow_service_key_impersonation: z.boolean().optional().describe(
+        'Per-function gate (Phase 2). When false, the platform 403s any call ' +
+        'carrying X-Butterbase-As-User at the edge — use for admin-only or ' +
+        'billing-webhook handlers that must never accept an as-user assertion.'
+      ),
     },
     {
       title: 'Manage Function',
@@ -195,6 +203,29 @@ Idempotency: Safe to call anytime (list is read-only; delete is idempotent; upda
               },
             ],
           };
+        }
+        case 'update_settings': {
+          const err = need(args.function_name, '"function_name" is required for the "update_settings" action.');
+          if (err) return err;
+          if (args.allow_service_key_impersonation === undefined) {
+            return {
+              content: [{ type: 'text' as const, text: 'Error: provide at least one setting to update (currently: allow_service_key_impersonation).' }],
+              isError: true,
+            };
+          }
+          const url = `${getBaseUrl()}/v1/${args.app_id}/functions/${args.function_name}/settings`;
+          const res = await fetch(url, {
+            method: 'PATCH',
+            headers: getHeaders(),
+            body: JSON.stringify({
+              allow_service_key_impersonation: args.allow_service_key_impersonation,
+            }),
+          });
+          const data = await res.json();
+          if (!res.ok) {
+            return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }], isError: true };
+          }
+          return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
         }
       }
     }


### PR DESCRIPTION
## Summary

Surfaces validated caller identity on every function invocation (`ctx.caller`), adds a same-app function-to-function call primitive (`ctx.invoke`), gates service-key impersonation per-function, and stops the clone job from minting one bb_sk_* per function (it now mints one shared key per app).

Fixes the failure mode where `auto-sync-google` invoked sibling `ingest-gmail` / `ingest-calendar` with `Authorization: Bearer ctx.env.BUTTERBASE_API_KEY` and the callee compared the bearer to its OWN env key (= different key after a clone) → 401 on every cron tick.

## What's in here (commit message has the full surface)

- **Phase 1 — `ctx.caller`**: `{ type, keyId, scope, userId }` on every fn ctx
- **Phase 2 — impersonation gate**: `X-Butterbase-As-User` header, per-fn `allow_service_key_impersonation` flag (default true), runtime migration 024
- **Phase 3 — `ctx.invoke`**: same-app fn-to-fn calls, identity propagation, depth-4 cycle guard
- **Phase 4 — clone job**: one shared `bb_sk_*` per cloned app instead of one per fn
- **Phase 5 — docs + changelog**: `core-concepts/functions` server-to-server section, API ref, dated changelog entries
- **MCP / CLI / SDK**: `deploy_function`, `manage_function update_settings`, `--allow-impersonation`, `DeployFunctionParams`, `FunctionCaller` type
- **Backfill script**: `scripts/backfill-consolidate-clone-keys.ts` for retroactively fixing already-cloned apps

## Test plan

Local smokes (all green against dev stack — `npm run migrate:runtime` + `docker compose -f docker-compose.local.yml up -d --build control-api deno-runtime`):

- [x] `scripts/seed-broken-app-phase0.ts` + `scripts/backfill-consolidate-clone-keys.ts` — seed → consolidate → idempotent
- [x] `scripts/smoke-phase1.ts` — `ctx.caller` for anonymous, service_key, invalid bearer
- [x] `scripts/smoke-phase2.ts` — allow=true → 200, allow=false → 403, anon+as-user → 403, cross-app sk → 403, PATCH /settings toggle, no-op pass-through
- [x] `scripts/smoke-phase3.ts` — identity propagates, depth cap fires at hop 5
- [x] vitest `clone-env-vars.test.ts` + `clone-replay-env-vars.test.ts` (11 pass, incl. new "one shared key" contract test)

Prod status at PR open time:

- [x] Migration 024 applied to us-east-1 + us-west-2 prod runtime DBs (manual psql; `_runtime_migrations` updated)
- [x] Backfill script applied to all 9 affected prod apps (`app_dg2qf46ssuu6` + 8 others) — dry-run re-confirms 0 candidates remain

