### PR TITLE
fix(runtime): retry once on dead pooled DB connections + surface ctx.app.substrateUserId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Migration is mechanical — the new actions take the same parameters as the stan
   - Flat `ctx.env.BUTTERBASE_*` (muscle-memory `Deno.env`-style):
     - Always present: `BUTTERBASE_APP_ID`, `BUTTERBASE_API_URL`, `BUTTERBASE_APP_NAME`, `BUTTERBASE_REGION`, `BUTTERBASE_ANON_KEY`.
     - Present when configured (omitted otherwise — branch with `typeof === "string"`, not empty-string checks): `BUTTERBASE_FRONTEND_URL`, `BUTTERBASE_SUBDOMAIN`, `BUTTERBASE_STRIPE_ACCOUNT_ID`, `BUTTERBASE_AI_DEFAULT_MODEL`.
-  - Structured `ctx.app = { id, name, ownerId, region, subdomain, anonKey, allowedOrigins, frontend, auth, ai, billing }` with optional sub-objects (`frontend`, `ai`, `billing`) set to `null` when unconfigured. `ctx.app.auth` is always present (`{ accessTokenTtl, refreshTokenTtlDays, hookFunction }`).
+  - Structured `ctx.app = { id, name, ownerId, substrateUserId, region, subdomain, anonKey, allowedOrigins, frontend, auth, ai, billing }` with optional sub-objects (`frontend`, `ai`, `billing`) set to `null` when unconfigured. `ctx.app.auth` is always present (`{ accessTokenTtl, refreshTokenTtlDays, hookFunction }`). `ctx.app.substrateUserId` is the linked substrate user id (or `null` when the app is not substrate-linked — `ctx.substrate` is omitted in that case for the same reason).
   - Per-invocation `ctx.request = { id, ip, country, functionName }` derived from `X-Request-Id` / `Fly-Client-Ip` / `Cf-Connecting-Ip` / `X-Forwarded-For` / `Cf-Ipcountry` / `Fly-Region` headers.
   - Platform keys are injected **after** user `envVars` so user-set vars can't shadow them. No new infra; one extended `apps` SELECT in `function-loader.ts`. See `core-concepts/functions` → Platform context.
 

--- a/services/deno-runtime/function-loader.ts
+++ b/services/deno-runtime/function-loader.ts
@@ -1,5 +1,5 @@
 // Function metadata loader with LRU cache
-import { Pool } from "https://deno.land/x/postgres@v0.19.3/mod.ts";
+import { Pool, type PoolClient } from "https://deno.land/x/postgres@v0.19.3/mod.ts";
 import { decryptEnvVars } from "./crypto.ts";
 
 // Multi-region: resolve instance region from BUTTERBASE_REGION (explicit)
@@ -128,6 +128,70 @@ const cache = new Map<string, CacheEntry>();
 // Connection pool to the runtime DB (app_functions, apps, app_db_connections)
 const runtimePool = new Pool(getRuntimeDbUrl(), 10);
 
+// Neon's pooler silently drops idle TCP sessions (~5 min). A client checked out
+// from runtimePool can hold a dead socket whose first write fails with
+// BrokenPipe / EPIPE / ConnectionAborted. Detect that surface so withRuntimeClient
+// can drop the poisoned client and retry once on a fresh connection instead of
+// surfacing a 500 to the caller.
+//
+// Exported for invocation-logger.ts (which keeps a separate loggingPool against
+// the same runtime DB and has the same idle-eviction problem).
+export function isDeadConnectionError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as { name?: string; message?: string; code?: string; cause?: unknown };
+  if (e.name === "BrokenPipe" || e.name === "ConnectionReset" || e.name === "ConnectionAborted") return true;
+  if (e.code === "EPIPE" || e.code === "ECONNRESET" || e.code === "ECONNABORTED") return true;
+  const msg = String(e.message ?? "").toLowerCase();
+  if (
+    msg.includes("broken pipe") ||
+    msg.includes("connection reset") ||
+    msg.includes("connection refused") ||
+    msg.includes("connection closed") ||
+    msg.includes("connection is closed") ||
+    msg.includes("unexpected eof") ||
+    msg.includes("not connected") ||
+    // deno-postgres surface when the backend sent a FATAL terminate notice
+    // (e.g. Neon idle eviction reaping the session, or admin-initiated
+    // pg_terminate_backend). Same operational meaning as BrokenPipe — the
+    // pooled client is unusable and must be dropped before retry.
+    msg.includes("session was terminated") ||
+    msg.includes("terminating connection")
+  ) return true;
+  return e.cause ? isDeadConnectionError(e.cause) : false;
+}
+
+// Drop a poisoned client without returning it to the pool. deno-postgres'
+// PoolClient.release() puts the connection back on the free list — if the
+// underlying TCP is dead, the next caller picks up the same broken socket.
+// end() closes the connection (mirrors the safeCommit pattern in
+// worker-executor.ts); release() is then a best-effort cleanup of the pool slot.
+async function dropClient(client: PoolClient): Promise<void> {
+  try { await (client as unknown as { end?: () => Promise<void> }).end?.(); } catch { /* ignore */ }
+  try { client.release(); } catch { /* ignore */ }
+}
+
+// Acquire → run → release helper that retries once on a dead connection.
+// The callback must be safe to re-run (all runtimePool callers here are
+// read-only metadata lookups, so idempotency is trivially satisfied).
+async function withRuntimeClient<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const client = await runtimePool.connect();
+    try {
+      const result = await fn(client);
+      client.release();
+      return result;
+    } catch (err) {
+      await dropClient(client);
+      if (attempt === 1 || !isDeadConnectionError(err)) throw err;
+      console.warn(
+        `[function-loader] runtimePool dead connection (${(err as Error).message ?? err}); retrying once`,
+      );
+    }
+  }
+  // Unreachable: loop either returns or throws on each iteration.
+  throw new Error("withRuntimeClient: exhausted retries");
+}
+
 function getCacheKey(appId: string, functionName: string): string {
   return `${appId}:${functionName}`;
 }
@@ -136,17 +200,14 @@ async function getDeployedAt(
   appId: string,
   functionName: string
 ): Promise<Date | null> {
-  const client = await runtimePool.connect();
-  try {
+  return withRuntimeClient(async (client) => {
     const result = await client.queryObject(
       `SELECT deployed_at FROM app_functions
        WHERE app_id = $1 AND name = $2 AND deleted_at IS NULL`,
       [appId, functionName]
     );
     return result.rows.length > 0 ? (result.rows[0] as any).deployed_at : null;
-  } finally {
-    client.release();
-  }
+  });
 }
 
 export async function loadFunction(
@@ -178,9 +239,10 @@ export async function loadFunction(
 
   console.log(`Cache miss: ${cacheKey}, loading from DB...`);
 
-  // Load from database
-  const client = await runtimePool.connect();
-  try {
+  // Load from database. withRuntimeClient retries once on a dead pooled
+  // connection (BrokenPipe from Neon's idle-socket eviction) so a stale slot
+  // doesn't surface as a 500 to the function caller.
+  return withRuntimeClient(async (client): Promise<FunctionMetadata | null> => {
     const result = await client.queryObject(
       `SELECT
         id, app_id, name, code, encrypted_env_vars,
@@ -296,9 +358,7 @@ export async function loadFunction(
     });
 
     return metadata;
-  } finally {
-    client.release();
-  }
+  });
 }
 
 export function invalidateCache(appId: string, functionName: string): void {

--- a/services/deno-runtime/invocation-logger.ts
+++ b/services/deno-runtime/invocation-logger.ts
@@ -1,5 +1,6 @@
 // Invocation logger for usage tracking and debugging
-import { Pool } from "https://deno.land/x/postgres@v0.19.3/mod.ts";
+import { Pool, type PoolClient } from "https://deno.land/x/postgres@v0.19.3/mod.ts";
+import { isDeadConnectionError } from "./function-loader.ts";
 import type { FunctionMetadata } from "./function-loader.ts";
 import type { ExecutionResult } from "./worker-executor.ts";
 
@@ -50,6 +51,33 @@ function getRuntimeDbUrl(): string {
 // Separate pool for logging (don't block function execution)
 const loggingPool = new Pool(getRuntimeDbUrl(), 5);
 
+// Mirror of function-loader's dead-conn recovery: Neon idle-evicts pooled
+// TCP sessions, so the first write on a checked-out client can hit BrokenPipe
+// (or a deno-postgres "session was terminated" surface) and otherwise drop
+// the function_invocations row for that call.
+async function dropLoggingClient(client: PoolClient): Promise<void> {
+  try { await (client as unknown as { end?: () => Promise<void> }).end?.(); } catch { /* ignore */ }
+  try { client.release(); } catch { /* ignore */ }
+}
+
+async function withLoggingClient<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const client = await loggingPool.connect();
+    try {
+      const result = await fn(client);
+      client.release();
+      return result;
+    } catch (err) {
+      await dropLoggingClient(client);
+      if (attempt === 1 || !isDeadConnectionError(err)) throw err;
+      console.warn(
+        `[invocation-logger] loggingPool dead connection (${(err as Error).message ?? err}); retrying once`,
+      );
+    }
+  }
+  throw new Error("withLoggingClient: exhausted retries");
+}
+
 export async function logInvocation(
   metadata: FunctionMetadata,
   request: Request,
@@ -74,8 +102,7 @@ export async function logInvocation(
     const billedMemory = Math.ceil(result.metrics.memory_used_mb);
 
     // Log invocation
-    const client = await loggingPool.connect();
-    try {
+    await withLoggingClient(async (client) => {
       await client.queryObject(
         `INSERT INTO function_invocations (
           function_id, app_id, user_id, method, path, headers,
@@ -106,7 +133,9 @@ export async function logInvocation(
         ]
       );
 
-      // Update function stats (fire-and-forget)
+      // Update function stats (fire-and-forget — runs on the same client
+      // before release; if the conn went bad mid-batch, dropLoggingClient
+      // tears it down rather than returning a poisoned slot to the pool).
       client.queryObject(
         `UPDATE app_functions SET
           last_invoked_at = now(),
@@ -117,9 +146,7 @@ export async function logInvocation(
          WHERE id = $1`,
         [metadata.id, !result.success, result.metrics.duration_ms, statusCode]
       ).catch((err) => console.error("Failed to update function stats:", err));
-    } finally {
-      client.release();
-    }
+    });
   } catch (err) {
     console.error("Failed to log invocation:", err);
   }

--- a/services/deno-runtime/worker-executor.ts
+++ b/services/deno-runtime/worker-executor.ts
@@ -492,6 +492,7 @@ function buildWorkerCode(
         id: metadata.app_id,
         name: metadata.platform.app_name,
         ownerId: metadata.platform.owner_id,
+        substrateUserId: metadata.substrate_user_id,
         region: metadata.platform.region,
         subdomain: metadata.platform.subdomain,
         anonKey: metadata.platform.anon_key,

--- a/services/docs/src/content/docs/core-concepts/functions.md
+++ b/services/docs/src/content/docs/core-concepts/functions.md
@@ -129,6 +129,7 @@ Optional keys are **omitted** rather than empty-stringed. Branch on `typeof ctx.
 ```ts
 ctx.app = {
   id, name, ownerId, region, subdomain, anonKey, allowedOrigins,
+  substrateUserId,                    // substrate user the app is linked to, or null if not linked. ctx.substrate is also null in that case.
   frontend: { url } | null,           // null when no frontend deployed
   auth:     { accessTokenTtl, refreshTokenTtlDays, hookFunction },
   ai:       { defaultModel } | null,  // null when AI config empty

--- a/services/docs/src/data/changelog.ts
+++ b/services/docs/src/data/changelog.ts
@@ -24,7 +24,7 @@ export const changelog: RoadmapItem[] = [
     date: '2026-06-14',
     category: 'functions',
     title: 'ctx.invoke for same-app function-to-function calls',
-    description: 'Call sibling functions on the same app with `ctx.invoke(\'fn-name\', body)` — no bearer ceremony, no env vars. Authenticated with the per-app internal function key (never exposed to user code), `ctx.user.id` propagates automatically to the callee, and a depth-4 cycle guard throws synchronously on the 5th hop. Replaces the brittle pattern of having one fn call another over HTTP with `Bearer ctx.env.BUTTERBASE_API_KEY`.',
+    description: 'Call sibling functions on the same app with `ctx.invoke(\'fn-name\', body)` — no bearer ceremony, no env vars. Authenticated with the per-app internal function key (never exposed to user code), `ctx.user.id` propagates automatically to the callee, and a depth-4 cycle guard throws synchronously on the 5th hop. Replaces the brittle pattern of having one fn call another over HTTP with `Bearer ctx.env.BUTTERBASE_API_KEY`. Same release: `ctx.app.substrateUserId` surfaces the linked substrate user id (or `null` when the app is not substrate-linked) so you can stop using `if (ctx.substrate)` as a proxy for "is this app linked?".',
     href: '/core-concepts/functions/#server-to-server-function-calls',
     icon: '🔗',
   },


### PR DESCRIPTION
## Summary

- **Runtime: dead-connection recovery.** `deno-runtime`'s `runtimePool` (function-metadata reads) and `loggingPool` (function_invocations writes) kept Neon-evicted idle TCP sockets in the free list. The first query after idle wrote into a closed FD and threw `BrokenPipe: broken pipe` — surfacing as `500 {\"error\":\"broken pipe\"}` with no handler-side logs and ~8 ms duration. Added a one-shot retry wrapper that drops the poisoned client (`client.end?.()`, mirroring `safeCommit`) and acquires a fresh one. Pattern covers BrokenPipe / EPIPE / ECONNRESET plus the deno-postgres ``\"session was terminated\"`` / ``\"terminating connection\"`` surface.
- **Functions: expose ``ctx.app.substrateUserId``.** Surfaces ``apps.substrate_user_id`` on the FunctionMetadata projection passed to user code via ``ctx.app``. Lets user code branch on ``ctx.app.substrateUserId !== null`` instead of ``if (ctx.substrate)`` as a proxy for ""is this app substrate-linked?"". CHANGELOG + functions.md + changelog.ts updated.

## Why

Prod hit: ``app_xp9i4qc7fin4`` (clone-of-butterbase-crm-new) was 500-ing on every ``auto-sync-google`` cron tick. 5-min cron period lined up exactly with Neon's idle-socket eviction, so every tick hit a stale slot. Stack pointed at ``function-loader.ts:184`` (the metadata SELECT) and the same signature was firing for unrelated apps — confirming a pool-wide bug, not anything app-specific.

The bug was latent — pre-PR #51, cron failed at 401 in ~2 ms before any runtime-DB read, so the pool barely warmed. After #51 enabled ``ctx.invoke`` for sibling-fn calls, every cron tick exercised a cache-miss path against the runtime DB, exposing the dead-conn problem.

## Test plan

- [x] Happy path locally: deploy + invoke fn 3× → 3× 200, no retry log lines.
- [x] ``pg_terminate_backend`` all 15 ``deno-runtime`` backends mid-flight, then invoke 5× → 5× 200. Both pools logged ``dead connection (...); retrying once`` exactly once. All 5 ``function_invocations`` rows persisted with ``status_code=200``.
- [x] Sanity: 5 more invocations on the recovered pool → 5× 200, zero retry log lines (retry only fires on real dead-conn errors).
- [x] Vitest: ``services/control-api`` test suite — 982 passing, 22 pre-existing failures (schema drift on a test DB, ai-meetings / api-keys / auth-middleware — none import either edited file). ``services/deno-runtime`` has no vitest suite that imports these files.