### PR TITLE
chore: gitignore stray pnpm-lock.yaml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 Example Code/
 stress_test_results*
 *.superpowers
+
+# Repo uses npm + package-lock.json; ignore stray pnpm lockfiles created
+# when someone runs `pnpm install` in a workspace.
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- Add `pnpm-lock.yaml` to `.gitignore`. This repo standardizes on npm + `package-lock.json`; running `pnpm install` in any workspace (e.g. `packages/cli`) drops a `pnpm-lock.yaml` that shows up dirty in `git status`.
- Surfaces in `butterbase-internal`, which consumes this repo as a submodule — any contributor with pnpm muscle memory leaves the parent repo with a dirty submodule.

## Test plan
- [ ] `git status` clean after `pnpm install` in `packages/cli`
- [ ] Parent `butterbase-internal` reports clean submodule status