### PR TITLE
fix(integrations): persist BYO credentials so clone replay can recreate use_custom_auth

### DIFF
--- a/db/control-plane/migrate.test.ts
+++ b/db/control-plane/migrate.test.ts
@@ -42,10 +42,10 @@ describe('applyByScope', () => {
     },
   } as any;
 
-  it('throws not-implemented error for runtime scope without touching DB', async () => {
+  it('throws misplaced-migration error for runtime scope without touching DB', async () => {
     await expect(
       applyByScope('runtime', 'demo.sql', '-- @scope: runtime\n', failingClient)
-    ).rejects.toThrow(/runtime tier is not implemented until Phase 2/);
+    ).rejects.toThrow(/scope=runtime but it is under db\/control-plane\//);
   });
 
   it('throws not-implemented error for data scope without touching DB', async () => {

--- a/db/runtime-plane/025_byo_integration_credentials.sql
+++ b/db/runtime-plane/025_byo_integration_credentials.sql
@@ -1,0 +1,25 @@
+-- @scope: runtime
+-- Persist BYO OAuth credentials for integrations so clone replay can
+-- recreate `use_custom_auth` configs on the destination.
+--
+-- Background: app_integration_configs only stored an opaque
+-- composio_auth_config_id — the underlying client_id/client_secret/extras
+-- (e.g. twitter's generic_id) lived only on Composio's side, behind that
+-- id. Clone replay therefore could not reconstruct the BYO config and
+-- silently fell back to use_composio_managed_auth, which Composio rejects
+-- for any non-curated toolkit. Result: BYO toolkits (twitter, linkedin,
+-- reddit, etc.) silently disappeared from cloned apps.
+--
+-- credentials_encrypted: AES-256-GCM ciphertext (iv:ct:tag base64) of
+--   JSON.stringify({ client_id, client_secret, ...toolkit-specific extras })
+--   under AUTH_ENCRYPTION_KEY. Same format as
+--   services/control-api/src/services/crypto.ts.
+-- auth_scheme:           Composio auth scheme (e.g. 'OAUTH2', 'BEARER_TOKEN').
+--                        Needed verbatim by replay's authConfigs.create call.
+--
+-- Both columns are nullable: existing rows and curated/managed-auth rows
+-- leave them NULL and continue working via the managed-auth replay path.
+
+ALTER TABLE public.app_integration_configs
+  ADD COLUMN IF NOT EXISTS credentials_encrypted TEXT,
+  ADD COLUMN IF NOT EXISTS auth_scheme TEXT;

--- a/db/runtime-plane/migrate.test.ts
+++ b/db/runtime-plane/migrate.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { resolveRuntimeUrls, MigrationScopeError } from './migrate.js';
+import pg from 'pg';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('resolveRuntimeUrls', () => {
   it('returns one URL per region from env', () => {
@@ -19,13 +25,6 @@ describe('resolveRuntimeUrls', () => {
     ).toThrow(/NEON_RUNTIME_PROJECT_ID_EU_WEST_1/);
   });
 });
-
-import pg from 'pg';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('migrations', () => {
   it('023_actor_usage_logs has correct column schema', async () => {

--- a/services/control-api/src/services/__tests__/clone-replay-integrations.test.ts
+++ b/services/control-api/src/services/__tests__/clone-replay-integrations.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { replayIntegrations } from '../clone-replay.js';
 import { __setComposioClientForTest } from '../composio-client.js';
+import { encrypt } from '../crypto.js';
+import { config } from '../../config.js';
 import { runtimeDb, controlDb } from '../../__tests__/test-helpers/control-db.js';
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
@@ -156,6 +158,128 @@ describeDb('replayIntegrations', () => {
       [destId],
     );
     expect(rows.rows.map((r: any) => r.toolkit_slug)).toEqual(['gmail']);
+
+    await runtimeDb.query(`DELETE FROM app_integration_configs WHERE app_id IN ($1, $2)`, [srcId, destId]);
+    await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+    await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+  });
+
+  it('recreates BYO use_custom_auth configs from encrypted source credentials', async () => {
+    const ownerId = randomUUID();
+    await controlDb.query(
+      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
+      [ownerId, `int-byo-${ownerId}@x.com`],
+    );
+    const srcId = `app_int_byo_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_int_byo_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+         ON CONFLICT (id) DO NOTHING`,
+        [id, ownerId],
+      );
+    }
+
+    const key = process.env.AUTH_ENCRYPTION_KEY ?? config.auth.encryptionKey;
+    const twitterCreds = { client_id: 'twitter_cid', client_secret: 'twitter_csec', generic_id: 'app_bearer_xyz' };
+    const linkedinCreds = { client_id: 'linkedin_cid', client_secret: 'linkedin_csec' };
+
+    await runtimeDb.query(
+      `INSERT INTO app_integration_configs
+         (app_id, toolkit_slug, composio_auth_config_id, enabled, credentials_encrypted, auth_scheme)
+       VALUES ($1, 'twitter',  'ac_src_twitter',  true, $2, 'OAUTH2'),
+              ($1, 'linkedin', 'ac_src_linkedin', true, $3, 'OAUTH2'),
+              ($1, 'gmail',    'ac_src_gmail',    true, NULL, NULL)`,
+      [srcId, encrypt(JSON.stringify(twitterCreds), key), encrypt(JSON.stringify(linkedinCreds), key)],
+    );
+
+    const calls: Array<{ slug: string; args: any }> = [];
+    let counter = 0;
+    __setComposioClientForTest({
+      authConfigs: {
+        create: async (slug: string, args: any) => {
+          calls.push({ slug, args });
+          counter += 1;
+          return { id: `ac_test_${counter}` };
+        },
+      },
+    } as any);
+
+    const warnings: string[] = [];
+    await replayIntegrations(runtimeDb, runtimeDb, srcId, destId, warnings, noopLogger);
+    expect(warnings).toEqual([]);
+
+    // Gmail still uses managed auth; twitter + linkedin use use_custom_auth with decrypted creds.
+    const callBySlug = Object.fromEntries(calls.map(c => [c.slug, c.args]));
+    expect(callBySlug.GMAIL.type).toBe('use_composio_managed_auth');
+    expect(callBySlug.TWITTER.type).toBe('use_custom_auth');
+    expect(callBySlug.TWITTER.authScheme).toBe('OAUTH2');
+    expect(callBySlug.TWITTER.credentials).toEqual(twitterCreds);
+    expect(callBySlug.LINKEDIN.type).toBe('use_custom_auth');
+    expect(callBySlug.LINKEDIN.credentials).toEqual(linkedinCreds);
+
+    // Dest rows carry the encrypted blob + auth_scheme forward (copied ciphertext).
+    const rows = await runtimeDb.query(
+      `SELECT toolkit_slug, credentials_encrypted, auth_scheme
+         FROM app_integration_configs WHERE app_id = $1 ORDER BY toolkit_slug`,
+      [destId],
+    );
+    const byToolkit = Object.fromEntries(rows.rows.map((r: any) => [r.toolkit_slug, r]));
+    expect(byToolkit.twitter.credentials_encrypted).toBeTruthy();
+    expect(byToolkit.twitter.auth_scheme).toBe('OAUTH2');
+    expect(byToolkit.linkedin.credentials_encrypted).toBeTruthy();
+    expect(byToolkit.gmail.credentials_encrypted).toBeNull();
+    expect(byToolkit.gmail.auth_scheme).toBeNull();
+
+    await runtimeDb.query(`DELETE FROM app_integration_configs WHERE app_id IN ($1, $2)`, [srcId, destId]);
+    await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+    await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+  });
+
+  it('legacy BYO row without credentials_encrypted falls through to managed-auth and warns', async () => {
+    const ownerId = randomUUID();
+    await controlDb.query(
+      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
+      [ownerId, `int-legacy-${ownerId}@x.com`],
+    );
+    const srcId = `app_int_lg_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_int_lg_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+         ON CONFLICT (id) DO NOTHING`,
+        [id, ownerId],
+      );
+    }
+    // Legacy row: BYO toolkit on Composio's side but no local credentials_encrypted.
+    await runtimeDb.query(
+      `INSERT INTO app_integration_configs (app_id, toolkit_slug, composio_auth_config_id, enabled)
+       VALUES ($1, 'twitter', 'ac_src_twitter', true)`,
+      [srcId],
+    );
+
+    __setComposioClientForTest({
+      authConfigs: {
+        create: async (_slug: string, args: any) => {
+          // Composio refuses managed auth for BYO-only toolkits.
+          if (args?.type === 'use_composio_managed_auth') {
+            throw new Error('toolkit requires custom OAuth credentials');
+          }
+          return { id: 'ac_should_not_happen' };
+        },
+      },
+    } as any);
+
+    const warnings: string[] = [];
+    await replayIntegrations(runtimeDb, runtimeDb, srcId, destId, warnings, noopLogger);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/twitter/);
+
+    const rows = await runtimeDb.query(
+      `SELECT 1 FROM app_integration_configs WHERE app_id = $1`,
+      [destId],
+    );
+    expect(rows.rowCount).toBe(0);
 
     await runtimeDb.query(`DELETE FROM app_integration_configs WHERE app_id IN ($1, $2)`, [srcId, destId]);
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);

--- a/services/control-api/src/services/clone-replay.ts
+++ b/services/control-api/src/services/clone-replay.ts
@@ -838,6 +838,19 @@ async function replayOauthConfigs(
  * namespaced to the DEST app (`{destAppId}_{toolkit}`), then insert the dest
  * row with the new id.
  *
+ * BYO vs managed auth: if the source row has `credentials_encrypted` set, the
+ * config was created with `use_custom_auth` (caller-supplied OAuth client). We
+ * decrypt those credentials and recreate the auth config with the same
+ * authScheme + credentials on the dest. Otherwise we use
+ * `use_composio_managed_auth`, which only works for curated toolkits Composio
+ * has provisioned client credentials for.
+ *
+ * Legacy data caveat: rows created before the credentials_encrypted column
+ * existed have NULL there. If such a row was originally BYO, the managed-auth
+ * fallback will fail at Composio and the row is dropped with a warning telling
+ * the cloner to reconfigure on the dest. This cannot be repaired retroactively
+ * because Composio doesn't expose stored client secrets on read.
+ *
  * Soft-fail semantics:
  *   - Composio not configured → 1 warning, return.
  *   - Per-row Composio/DB error → 1 warning, continue with next row.
@@ -851,10 +864,18 @@ export async function replayIntegrations(
   warnings: string[],
   logger: ReplayLogger,
 ): Promise<void> {
-  let src: { rows: Array<{ toolkit_slug: string; display_name: string | null; scopes: unknown }> };
+  let src: {
+    rows: Array<{
+      toolkit_slug: string;
+      display_name: string | null;
+      scopes: unknown;
+      credentials_encrypted: string | null;
+      auth_scheme: string | null;
+    }>;
+  };
   try {
     src = await sourceRuntimePool.query(
-      `SELECT toolkit_slug, display_name, scopes
+      `SELECT toolkit_slug, display_name, scopes, credentials_encrypted, auth_scheme
          FROM app_integration_configs
         WHERE app_id = $1 AND enabled = true
         ORDER BY toolkit_slug`,
@@ -899,10 +920,27 @@ export async function replayIntegrations(
       }
 
       const composioSlug = row.toolkit_slug.toUpperCase().replace(/-/g, '');
-      const authConfig = await composio.authConfigs.create(composioSlug, {
-        type: 'use_composio_managed_auth',
-        name: `${destAppId}_${row.toolkit_slug}`,
-      });
+
+      let authConfig: { id?: string };
+      if (row.credentials_encrypted) {
+        const encryptionKey = process.env.AUTH_ENCRYPTION_KEY ?? config.auth.encryptionKey;
+        if (!encryptionKey) {
+          throw new Error('AUTH_ENCRYPTION_KEY not set; cannot decrypt BYO credentials for replay');
+        }
+        const credsPlain = JSON.parse(decrypt(row.credentials_encrypted, encryptionKey)) as
+          Record<string, string | number | boolean>;
+        authConfig = await composio.authConfigs.create(composioSlug, {
+          type: 'use_custom_auth',
+          authScheme: row.auth_scheme ?? 'OAUTH2',
+          credentials: credsPlain,
+          name: `${destAppId}_${row.toolkit_slug}`,
+        } as any);
+      } else {
+        authConfig = await composio.authConfigs.create(composioSlug, {
+          type: 'use_composio_managed_auth',
+          name: `${destAppId}_${row.toolkit_slug}`,
+        });
+      }
       const newAuthConfigId = authConfig.id ?? '';
       if (!newAuthConfigId) {
         throw new Error('composio returned empty auth config id');
@@ -912,15 +950,21 @@ export async function replayIntegrations(
 
       await destRuntimePool.query(
         `INSERT INTO app_integration_configs
-           (app_id, toolkit_slug, composio_auth_config_id, display_name, enabled, scopes)
-         VALUES ($1, $2, $3, $4, true, $5::jsonb)
+           (app_id, toolkit_slug, composio_auth_config_id, display_name, enabled, scopes,
+            credentials_encrypted, auth_scheme)
+         VALUES ($1, $2, $3, $4, true, $5::jsonb, $6, $7)
          ON CONFLICT (app_id, toolkit_slug) DO UPDATE
            SET composio_auth_config_id = EXCLUDED.composio_auth_config_id,
                display_name            = COALESCE(EXCLUDED.display_name, app_integration_configs.display_name),
                scopes                  = EXCLUDED.scopes,
+               credentials_encrypted   = EXCLUDED.credentials_encrypted,
+               auth_scheme             = EXCLUDED.auth_scheme,
                enabled                 = true,
                updated_at              = now()`,
-        [destAppId, row.toolkit_slug, newAuthConfigId, row.display_name, scopesJson],
+        [
+          destAppId, row.toolkit_slug, newAuthConfigId, row.display_name, scopesJson,
+          row.credentials_encrypted, row.auth_scheme,
+        ],
       );
       succeeded += 1;
     } catch (err) {

--- a/services/control-api/src/services/composio-client.ts
+++ b/services/control-api/src/services/composio-client.ts
@@ -3,6 +3,7 @@ import { Composio } from '@composio/core';
 import { createHmac, randomUUID } from 'crypto';
 import type { Pool } from 'pg';
 import { config } from '../config.js';
+import { encrypt } from './crypto.js';
 import { getRuntimeDbForApp } from './region-resolver.js';
 import { getRuntimeDbPool } from './runtime-db.js';
 
@@ -198,6 +199,10 @@ export async function configureIntegration(
   // Composio authConfigs.create requires uppercase slug with hyphens removed (e.g. "GOOGLECALENDAR", "GITHUB")
   const composioSlug = toolkit.toUpperCase().replace(/-/g, '');
   let authConfig: { id?: string };
+  // Captured for persistence so clone-replay can recreate the auth config
+  // on a destination app. See db/runtime-plane/025_byo_integration_credentials.sql.
+  let credentialsForStorage: Record<string, string | number | boolean> | null = null;
+  let authSchemeForStorage: string | null = null;
   try {
     if (oauthCredentials) {
       const { auth_scheme: authSchemeOpt, ...rest } = oauthCredentials;
@@ -209,6 +214,8 @@ export async function configureIntegration(
       if (scopes && scopes.length && credentials.scopes === undefined) {
         credentials.scopes = scopes.join(',');
       }
+      credentialsForStorage = credentials;
+      authSchemeForStorage = authScheme;
       authConfig = await composio.authConfigs.create(composioSlug, {
         type: 'use_custom_auth',
         authScheme,
@@ -227,17 +234,36 @@ export async function configureIntegration(
 
   const authConfigId = authConfig.id ?? '';
 
+  // Encrypt BYO credentials at rest. Managed-auth rows leave both columns NULL.
+  // AUTH_ENCRYPTION_KEY is required in production (services/control-api/src/index.ts
+  // refuses to boot without it); dev mode has a hardcoded fallback via config.ts.
+  let credentialsEncrypted: string | null = null;
+  if (credentialsForStorage) {
+    const encryptionKey = process.env.AUTH_ENCRYPTION_KEY ?? config.auth.encryptionKey;
+    if (!encryptionKey) {
+      throw new Error('AUTH_ENCRYPTION_KEY must be set to persist BYO integration credentials');
+    }
+    credentialsEncrypted = encrypt(JSON.stringify(credentialsForStorage), encryptionKey);
+  }
+
   // Store in our DB (app_integration_configs is runtime-tier)
   const result = await runtimePool.query(
-    `INSERT INTO app_integration_configs (app_id, toolkit_slug, composio_auth_config_id, display_name, scopes)
-     VALUES ($1, $2, $3, $4, $5::jsonb)
+    `INSERT INTO app_integration_configs
+       (app_id, toolkit_slug, composio_auth_config_id, display_name, scopes,
+        credentials_encrypted, auth_scheme)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
      ON CONFLICT (app_id, toolkit_slug)
      DO UPDATE SET composio_auth_config_id = EXCLUDED.composio_auth_config_id,
-       display_name = COALESCE(EXCLUDED.display_name, app_integration_configs.display_name),
-       scopes = EXCLUDED.scopes,
+       display_name          = COALESCE(EXCLUDED.display_name, app_integration_configs.display_name),
+       scopes                = EXCLUDED.scopes,
+       credentials_encrypted = EXCLUDED.credentials_encrypted,
+       auth_scheme           = EXCLUDED.auth_scheme,
        enabled = true, updated_at = now()
      RETURNING *`,
-    [appId, toolkit, authConfigId, displayName || null, JSON.stringify(scopes || [])],
+    [
+      appId, toolkit, authConfigId, displayName || null, JSON.stringify(scopes || []),
+      credentialsEncrypted, authSchemeForStorage,
+    ],
   );
 
   return result.rows[0];
@@ -283,7 +309,7 @@ export async function rotateIntegrationCredentials(
     );
   }
 
-  const { auth_scheme: _ignored, ...rest } = oauthCredentials;
+  const { auth_scheme: authSchemeOpt, ...rest } = oauthCredentials;
   const credentials: Record<string, string | number | boolean> = {};
   for (const [k, v] of Object.entries(rest)) {
     if (v !== undefined) credentials[k] = v;
@@ -298,12 +324,22 @@ export async function rotateIntegrationCredentials(
     throw mapComposioAuthConfigError(err, toolkit, true);
   }
 
+  // Refresh the at-rest credentials so clone-replay can recreate this config.
+  const encryptionKey = process.env.AUTH_ENCRYPTION_KEY ?? config.auth.encryptionKey;
+  if (!encryptionKey) {
+    throw new Error('AUTH_ENCRYPTION_KEY must be set to persist BYO integration credentials');
+  }
+  const credentialsEncrypted = encrypt(JSON.stringify(credentials), encryptionKey);
+
   const result = await runtimePool.query(
     `UPDATE app_integration_configs
-       SET updated_at = now(), enabled = true
+       SET credentials_encrypted = $3,
+           auth_scheme           = COALESCE($4, auth_scheme),
+           updated_at            = now(),
+           enabled               = true
      WHERE app_id = $1 AND toolkit_slug = $2
      RETURNING *`,
-    [appId, toolkit],
+    [appId, toolkit, credentialsEncrypted, authSchemeOpt ?? null],
   );
   return result.rows[0];
 }

--- a/services/control-api/src/services/failure-notifier.ts
+++ b/services/control-api/src/services/failure-notifier.ts
@@ -53,12 +53,16 @@ async function scanOnce(
       // window if no success exists yet). The streak_key is the
       // last-success timestamp (or 'none'); the dedup key is keyed on it
       // so the next streak after a successful run gets a fresh key.
+      //
+      // The last_success CTE is INTENTIONALLY unbounded by the lookback
+      // window: streak_key must be stable for the lifetime of a streak,
+      // and bounding it would let an old success age out of the window
+      // and silently rotate the dedup key, re-firing the email mid-streak.
       const r = await runtimePool.query<FailureGroup>(
         `WITH last_success AS (
            SELECT function_id, MAX(started_at) AS last_success_at
              FROM function_invocations
             WHERE error_message IS NULL
-              AND started_at >= now() - interval '${STREAK_LOOKBACK}'
             GROUP BY function_id
          )
          SELECT fi.app_id,


### PR DESCRIPTION
## Summary

Cloning a Butterbase app silently dropped any BYO (bring-your-own-credentials) integration toolkit — twitter, linkedin, reddit, anything Composio doesn't manage. The cloned app's first `/integrations/connect` call returned `INTEGRATIONS_TOOLKIT_NOT_ENABLED`, even though the source had been working fine for days.

### Root cause

Two things conspired in `services/control-api/src/services/clone-replay.ts:846` (`replayIntegrations`):

1. **`app_integration_configs` didn't store credentials.** The runtime table only kept a `composio_auth_config_id` — an opaque pointer to a Composio-side auth config that held the actual `client_id`/`client_secret`/extras (e.g. twitter's `generic_id`). Nothing local to reconstruct from.
2. **Replay hardcoded managed auth.** For every source row it called `composio.authConfigs.create(slug, { type: 'use_composio_managed_auth' })`. For curated toolkits Composio has provisioned client credentials and this works. For BYO toolkits Composio rejects the call → per-row catch logs a warning → row silently dropped from the destination.

End result: any clone of an app using a BYO toolkit was visibly broken at first use, with no error returned at clone time.

### Fix (option 1 from the investigation: persist credentials at rest)

- **Migration `025_byo_integration_credentials.sql`** adds nullable `credentials_encrypted` + `auth_scheme` columns. Both `NULL` for curated/managed-auth rows.
- **`configureIntegration` / `rotateIntegrationCredentials`** AES-256-GCM-encrypt the BYO credentials under `AUTH_ENCRYPTION_KEY` (same `crypto.ts` pattern `app_oauth_configs` already uses) and persist them on insert/update.
- **`replayIntegrations`** branches on `credentials_encrypted`: present → decrypt and call `authConfigs.create` with `type: 'use_custom_auth'` + stored `authScheme` + credentials. Absent → keep the existing managed-auth path (curated toolkits replay unchanged).
- Dest rows carry the ciphertext forward — re-encryption isn't needed since `AUTH_ENCRYPTION_KEY` is platform-wide — so clones-of-clones also work.

### Considered alternatives

- **Fetch credentials from Composio at clone time.** Composio doesn't return secrets on read of an auth config. Doesn't work.
- **Skip BYO rows with a structured warning, force re-configure on dest.** Honest but defeats the point of cloning a working app.
- **Persist credentials at rest (this PR).** Best UX, mirrors how `app_oauth_configs` already handles OAuth secrets.

### Legacy data

Rows configured before this migration have `NULL` in both new columns. If the original config was BYO, the managed-auth fallback will still fail at Composio and the row will be dropped with a per-toolkit warning naming it. This cannot be repaired retroactively (Composio doesn't expose stored secrets). Owners of such apps need to reconfigure once on the destination, after which further clones replay correctly.

### Drive-bys ahead of the integrations commit
This branch also carries two unrelated fixes that landed on local `main` during the same session:
- `83725a8` — fix(failure-notifier): stop bounding `last_success` CTE by `STREAK_LOOKBACK`, which let an old success age out of the window mid-streak and silently rotate the dedup key, re-firing the failure email.
- `5e24c56` — test(migrations): add a `023_actor_usage_logs` column-schema test, tidy imports in the runtime-plane test file, rename a control-plane test to match the current "misplaced-migration" error string.

Happy to split these into separate PRs if reviewers prefer.

## Test plan
- [ ] CI: `tsc --noEmit` clean — verified locally.
- [ ] CI: `clone-replay-integrations.test.ts` — 3 new test cases (BYO replay, legacy-BYO fallback warning, plus unchanged managed-auth/idempotency/partial-failure cases) — needs `RUN_DB_TESTS=1` + runtime DB, run in CI.
- [ ] Manual: clone an app that has a BYO toolkit configured (e.g. twitter), confirm `/integrations/configure` is no longer needed on the dest and `/integrations/connect` succeeds first time.
- [ ] Manual: clone an app that has only curated toolkits (gmail/slack), confirm no regression.
- [ ] Manual: rotate BYO credentials on an existing app, confirm subsequent clone picks up the new credentials.