### PR TITLE
feat: substrate auto-mirror users + iMARouter cost integration (merge main)

### DIFF
--- a/db/runtime-plane/028_ai_usage_logs_user_id.sql
+++ b/db/runtime-plane/028_ai_usage_logs_user_id.sql
@@ -1,0 +1,32 @@
+-- @scope: runtime
+-- 028: Add user_id column to ai_usage_logs so app-less gateway calls
+-- (app_id IS NULL, since migration 011) and calls against apps the caller
+-- does not own can still be aggregated per user.
+--
+-- Pre-028, the only path from a usage row back to a billed user was
+-- ai_usage_logs.app_id → apps.owner_id. App-less calls and non-owned-app
+-- calls were silently dropped from usage_meters and the admin dashboard,
+-- even though credit_leases (keyed on user_id directly) charged them
+-- correctly. We backfill from request_metadata->>'user_id', which the
+-- writers have populated all along.
+
+BEGIN;
+
+ALTER TABLE ai_usage_logs
+  ADD COLUMN IF NOT EXISTS user_id uuid;
+
+UPDATE ai_usage_logs
+   SET user_id = (request_metadata->>'user_id')::uuid
+ WHERE user_id IS NULL
+   AND request_metadata ? 'user_id'
+   AND request_metadata->>'user_id' IS NOT NULL
+   AND request_metadata->>'user_id' <> '';
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_logs_user_created
+  ON ai_usage_logs (user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+COMMENT ON COLUMN ai_usage_logs.user_id IS
+  'Platform user the call is attributed to. Populated for every call (app-bound or app-less). Use this — not apps.owner_id — to aggregate usage per user.';
+
+COMMIT;

--- a/packages/cli/bin/butterbase.ts
+++ b/packages/cli/bin/butterbase.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path';
 import { renderError } from '../src/lib/errors.js';
 import { initCommand } from '../src/commands/init.js';
 import { loginCommand, logoutCommand, configGetCommand, configSetCommand } from '../src/commands/config.js';
-import { appsListCommand, appsCreateCommand, appsUseCommand, appsDeleteCommand, appsPauseCommand, appsResumeCommand, appsLinkSubstrateCommand, appsUnlinkSubstrateCommand } from '../src/commands/apps.js';
+import { appsListCommand, appsCreateCommand, appsUseCommand, appsDeleteCommand, appsPauseCommand, appsResumeCommand, appsLinkSubstrateCommand, appsUnlinkSubstrateCommand, appsSubstrateAutopropagateCommand } from '../src/commands/apps.js';
 import { schemaGetCommand, schemaApplyCommand } from '../src/commands/schema.js';
 import { functionsListCommand, functionsGetCommand, functionsDeployCommand, functionsLogsCommand, functionsDeleteCommand, functionsInvokeCommand, functionsEnvSetCommand, functionsEnvListCommand, functionsMetricsCommand } from '../src/commands/functions.js';
 import { storageListCommand, storageUploadCommand, storageDeleteCommand, storageConfigCommand } from '../src/commands/storage.js';
@@ -247,6 +247,12 @@ apps
   .command('unlink-substrate [app-id]')
   .description('Unlink this app from your substrate')
   .action(appsUnlinkSubstrateCommand);
+
+apps
+  .command('substrate-autopropagate <app-id>')
+  .description('Toggle per-event auto-mirroring of app activity into the linked substrate (e.g. user signups)')
+  .option('--users <bool>', 'Mirror user events (signup / email-verified / user-deleted) into the substrate', (v) => v === 'true')
+  .action(appsSubstrateAutopropagateCommand);
 
 const appsConfig = apps.command('config').description('Read or update the app\'s server-side config');
 

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import ora from 'ora';
 import prompts from 'prompts';
-import { initApp, listApps, deleteApp, pauseApp, apiPost, apiDelete } from '../lib/api-client.js';
+import { initApp, listApps, deleteApp, pauseApp, apiPost, apiDelete, apiPut } from '../lib/api-client.js';
 import { setCurrentAppId, getCurrentAppId } from '../lib/config.js';
 
 export async function appsListCommand() {
@@ -179,6 +179,40 @@ export async function appsUnlinkSubstrateCommand(appId: string) {
     spinner.succeed(`Unlinked ${appId} from substrate`);
   } catch (error) {
     spinner.fail('Failed to unlink app from substrate');
+    console.error(chalk.red((error as Error).message));
+    process.exit(1);
+  }
+}
+
+export async function appsSubstrateAutopropagateCommand(appId: string, opts: { users?: boolean }) {
+  if (!appId) appId = (await getCurrentAppId()) || '';
+  if (!appId) {
+    console.log(chalk.red('✗ App ID is required'));
+    console.log(chalk.gray('Usage: butterbase apps substrate-autopropagate <app-id> --users <true|false>'));
+    process.exit(1);
+  }
+
+  const body: { users?: boolean } = {};
+  if (opts.users !== undefined) body.users = opts.users;
+
+  if (Object.keys(body).length === 0) {
+    console.log(chalk.red('✗ At least one toggle flag must be provided.'));
+    console.log(chalk.gray('  Example: butterbase apps substrate-autopropagate <app-id> --users true'));
+    process.exit(1);
+  }
+
+  const spinner = ora(`Updating substrate autopropagate settings for ${appId}...`).start();
+  try {
+    const result: any = await apiPut(`/v1/me/apps/${appId}/substrate-autopropagate`, body);
+    spinner.succeed(`Updated substrate autopropagate settings for ${appId}`);
+    if (result && typeof result === 'object') {
+      console.log(chalk.gray('\n  Current settings:'));
+      for (const [key, value] of Object.entries(result)) {
+        console.log(chalk.gray(`    ${key}: ${value}`));
+      }
+    }
+  } catch (error) {
+    spinner.fail('Failed to update substrate autopropagate settings');
     console.error(chalk.red((error as Error).message));
     process.exit(1);
   }

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -229,17 +229,32 @@ export async function adminRoutes(app: FastifyInstance) {
     // Fetch runtime stats from every region and sum per-user. Per-region
     // rows are mutually disjoint (no app appears in two regions), so this
     // is a true cross-region aggregate.
+    // App counts come from apps.owner_id; AI usage is summed via
+    // ai_usage_logs.user_id (post-028), which captures app-less gateway
+    // calls and calls against apps the user does not own. Joining AI
+    // through apps would drop both — they are still billed via
+    // credit_leases, so the admin view would understate spend.
     const runtimeStatsRows = await fanOutQuery<{
       owner_id: string; app_count: number; ai_cost_usd: string; ai_tokens: string;
     }>(
-      `SELECT a.owner_id,
-              count(DISTINCT a.id)::int AS app_count,
-              coalesce(sum(u.cost_usd), 0)::numeric AS ai_cost_usd,
-              coalesce(sum(u.total_tokens), 0)::bigint AS ai_tokens
-       FROM apps a
-       LEFT JOIN ai_usage_logs u ON u.app_id = a.id
-       WHERE a.owner_id = ANY($1::uuid[])
-       GROUP BY a.owner_id`,
+      `SELECT coalesce(u.user_id, ac.owner_id) AS owner_id,
+              coalesce(ac.app_count, 0)::int AS app_count,
+              coalesce(u.ai_cost_usd, 0)::numeric AS ai_cost_usd,
+              coalesce(u.ai_tokens, 0)::bigint AS ai_tokens
+         FROM (
+           SELECT user_id,
+                  sum(cost_usd)     AS ai_cost_usd,
+                  sum(total_tokens) AS ai_tokens
+             FROM ai_usage_logs
+            WHERE user_id = ANY($1::uuid[])
+            GROUP BY user_id
+         ) u
+         FULL OUTER JOIN (
+           SELECT owner_id, count(DISTINCT id)::int AS app_count
+             FROM apps
+            WHERE owner_id = ANY($1::uuid[])
+            GROUP BY owner_id
+         ) ac ON ac.owner_id = u.user_id`,
       [userIds]
     );
 
@@ -463,14 +478,14 @@ export async function adminRoutes(app: FastifyInstance) {
         [days]
       ),
       fanOutQuery<{ user_id: string; requests: number; tokens: string; cost_usd: string }>(
-        `SELECT ap.owner_id AS user_id,
+        `SELECT user_id,
                 count(*)::int AS requests,
-                coalesce(sum(a.total_tokens),0)::bigint AS tokens,
-                coalesce(sum(a.cost_usd),0)::numeric AS cost_usd
-         FROM ai_usage_logs a
-         JOIN apps ap ON a.app_id = ap.id
-         WHERE a.created_at >= current_date - $1::int * interval '1 day'
-         GROUP BY ap.owner_id
+                coalesce(sum(total_tokens),0)::bigint AS tokens,
+                coalesce(sum(cost_usd),0)::numeric AS cost_usd
+         FROM ai_usage_logs
+         WHERE created_at >= current_date - $1::int * interval '1 day'
+           AND user_id IS NOT NULL
+         GROUP BY user_id
          ORDER BY cost_usd DESC
          LIMIT 50`,
         [days]
@@ -950,7 +965,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(total_tokens),0)::bigint AS tokens,
                 coalesce(sum(cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs
-         WHERE app_id IN (SELECT a.id FROM apps a WHERE a.owner_id = $1)
+         WHERE user_id = $1
          GROUP BY model
          ORDER BY cost_usd DESC`,
         [id]
@@ -961,7 +976,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(total_tokens),0)::bigint AS tokens,
                 coalesce(sum(cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs
-         WHERE app_id IN (SELECT a.id FROM apps a WHERE a.owner_id = $1)
+         WHERE user_id = $1
            AND created_at >= current_date - interval '30 days'
          GROUP BY date(created_at)
          ORDER BY date ASC`,
@@ -1296,7 +1311,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(total_tokens),0)::bigint AS tokens,
                 coalesce(sum(cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs
-         WHERE app_id IN (SELECT a.id FROM apps a WHERE a.owner_id = $1)
+         WHERE user_id = $1
          GROUP BY model, provider, router
          ORDER BY cost_usd DESC`,
         [id]
@@ -1307,7 +1322,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(total_tokens),0)::bigint AS tokens,
                 coalesce(sum(cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs
-         WHERE app_id IN (SELECT a.id FROM apps a WHERE a.owner_id = $1)
+         WHERE user_id = $1
          GROUP BY COALESCE(router, '(direct)')
          ORDER BY cost_usd DESC`,
         [id]
@@ -1319,7 +1334,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(a.cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs a
          JOIN apps ap ON a.app_id = ap.id
-         WHERE ap.owner_id = $1
+         WHERE a.user_id = $1
          GROUP BY a.app_id, ap.name
          ORDER BY cost_usd DESC`,
         [id]
@@ -1330,7 +1345,7 @@ export async function adminRoutes(app: FastifyInstance) {
                 coalesce(sum(total_tokens),0)::bigint AS tokens,
                 coalesce(sum(cost_usd),0)::numeric AS cost_usd
          FROM ai_usage_logs
-         WHERE app_id IN (SELECT a.id FROM apps a WHERE a.owner_id = $1)
+         WHERE user_id = $1
            AND created_at >= current_date - interval '30 days'
          GROUP BY date(created_at)
          ORDER BY date ASC`,

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -45,7 +45,7 @@ export async function initRoutes(app: FastifyInstance) {
     const allRows: any[] = [];
     for (const region of regions) {
       const { rows } = await app.runtimeDb(region).query(
-        'SELECT id, name, subdomain, db_name, db_provisioned, provisioning_status, region, visibility, listed, template_source_app_id, fork_count, substrate_user_id, created_at FROM apps WHERE owner_id = $1 ORDER BY created_at DESC',
+        'SELECT id, name, subdomain, db_name, db_provisioned, provisioning_status, region, visibility, listed, template_source_app_id, fork_count, substrate_user_id, substrate_autopropagate, created_at FROM apps WHERE owner_id = $1 ORDER BY created_at DESC',
         [ownerId]
       );
       allRows.push(...rows);

--- a/services/control-api/src/routes/suggestions.ts
+++ b/services/control-api/src/routes/suggestions.ts
@@ -195,7 +195,12 @@ export async function suggestionsRoutes(app: FastifyInstance) {
       });
     }
 
-    return reply.code(201).send({ suggestion: rows[0] });
+    // Do NOT echo the captured `context` back to the client. It holds up to 20
+    // recent tool calls with verbatim `parameters` (function source, html_content),
+    // which can be tens of KB and blows past MCP per-tool-result limits. The
+    // context is still persisted for the admin views (/admin/suggestions/:id).
+    const { context: _context, ...suggestion } = rows[0];
+    return reply.code(201).send({ suggestion });
   });
 
   // ---------- Admin-secret authenticated ----------

--- a/services/control-api/src/services/ai-router/adapters/types.ts
+++ b/services/control-api/src/services/ai-router/adapters/types.ts
@@ -75,6 +75,13 @@ export interface AdapterResult {
   usage: AdapterUsage | null;
   /** Provider's reported cost, in USD; null when adapter can't extract it. */
   providerCostUsd: number | null;
+  /**
+   * Optional post-hoc cost lookup. Used by streaming adapters that cannot
+   * report cost inline (e.g. iMARouter's chat stream). wrapStreamForSettlement
+   * awaits this after the upstream emits [DONE] when no in-stream cost was
+   * observed.
+   */
+  costFetcher?: () => Promise<number | null>;
 }
 
 export type AdapterErrorKind =

--- a/services/control-api/src/services/ai-router/router.streaming.test.ts
+++ b/services/control-api/src/services/ai-router/router.streaming.test.ts
@@ -2,7 +2,7 @@
  * Tests for streaming usage extraction in wrapStreamForSettlement.
  * Covers cache-token propagation for both OpenRouter and ImaRouter SSE shapes.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { wrapStreamForSettlement } from './router.js';
 
 function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -210,5 +210,46 @@ describe('wrapStreamForSettlement — split-line SSE robustness', () => {
       cacheReadInputTokens: 6003,
       promptTokens: 6803, // 800 + 6003
     });
+  });
+});
+
+describe('wrapStreamForSettlement — costFetcher hook', () => {
+  it('calls costFetcher after [DONE] when no in-stream providerCost was seen', async () => {
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      'data: {"usage":{"prompt_tokens":3,"completion_tokens":1}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+    const upstream = new ReadableStream<Uint8Array>({
+      start(c) { for (const c2 of chunks) c.enqueue(new TextEncoder().encode(c2)); c.close(); },
+    });
+    let captured: number | null = -1;
+    const costFetcher = vi.fn().mockResolvedValue(0.000077);
+    const wrapped = wrapStreamForSettlement(upstream, async (_usage, providerCost) => { captured = providerCost; }, costFetcher);
+
+    const reader = wrapped.getReader();
+    while (true) { const { done } = await reader.read(); if (done) break; }
+
+    expect(costFetcher).toHaveBeenCalledTimes(1);
+    expect(captured).toBe(0.000077);
+  });
+
+  it('skips costFetcher when an in-stream providerCost was already observed', async () => {
+    const chunks = [
+      'data: {"usage":{"prompt_tokens":3,"completion_tokens":1,"cost":0.0001}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+    const upstream = new ReadableStream<Uint8Array>({
+      start(c) { for (const c2 of chunks) c.enqueue(new TextEncoder().encode(c2)); c.close(); },
+    });
+    let captured: number | null = -1;
+    const costFetcher = vi.fn().mockResolvedValue(0.9);
+    const wrapped = wrapStreamForSettlement(upstream, async (_usage, providerCost) => { captured = providerCost; }, costFetcher);
+
+    const reader = wrapped.getReader();
+    while (true) { const { done } = await reader.read(); if (done) break; }
+
+    expect(costFetcher).not.toHaveBeenCalled();
+    expect(captured).toBe(0.0001);
   });
 });

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -271,7 +271,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
         latency_ms: t1 - t0,
         status: result.status,
       }));
-    });
+    }, result.costFetcher);
     return { status: result.status, stream: wrapped, chosen: chosenRouter };
   }
 
@@ -326,11 +326,21 @@ interface StreamUsage {
 export function wrapStreamForSettlement(
   upstream: ReadableStream<Uint8Array>,
   onComplete: (usage: StreamUsage, providerCostUsd: number | null) => Promise<void>,
+  costFetcher?: () => Promise<number | null>,
 ): ReadableStream<Uint8Array> {
   const decoder = new TextDecoder();
   let promptTokens = 0, completionTokens = 0, providerCost: number | null = null;
   let cacheReadInputTokens = 0, cacheCreationInputTokens = 0;
   let lineBuffer = '';
+
+  const settle = async () => {
+    // Only invoke costFetcher when the in-stream usage events never carried a cost.
+    if (providerCost === null && costFetcher) {
+      try { providerCost = await costFetcher(); } catch (e) { console.error('[router] costFetcher:', e); }
+    }
+    try { await onComplete({ promptTokens, completionTokens, cacheReadInputTokens, cacheCreationInputTokens }, providerCost); }
+    catch (e) { console.error('[router] stream settle:', e); }
+  };
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -338,11 +348,7 @@ export function wrapStreamForSettlement(
       try {
         while (true) {
           const { done, value } = await reader.read();
-          if (done) {
-            try { await onComplete({ promptTokens, completionTokens, cacheReadInputTokens, cacheCreationInputTokens }, providerCost); } catch (e) { console.error('[router] stream settle:', e); }
-            controller.close();
-            return;
-          }
+          if (done) { await settle(); controller.close(); return; }
           lineBuffer += decoder.decode(value, { stream: true });
           const parts = lineBuffer.split('\n');
           lineBuffer = parts.pop() ?? '';
@@ -356,9 +362,6 @@ export function wrapStreamForSettlement(
                 const u = parsed.usage;
                 const details = u.prompt_tokens_details;
                 const cacheRead = details?.cached_tokens ?? 0;
-
-                // ImaRouter shape: claude_cache_creation_*_tokens present on the usage object.
-                // ImaRouter also excludes cached tokens from prompt_tokens — add them back.
                 const hasImaRouterFields =
                   typeof u.claude_cache_creation_5_m_tokens === 'number' ||
                   typeof u.claude_cache_creation_1_h_tokens === 'number';
@@ -367,12 +370,7 @@ export function wrapStreamForSettlement(
                 const cacheCreate = hasImaRouterFields
                   ? cacheWrite5m + cacheWrite1h
                   : (details?.cache_write_tokens ?? 0);
-
                 const rawPromptTokens = u.prompt_tokens ?? 0;
-                // ImaRouter excludes cached tokens from prompt_tokens; add them back
-                // so downstream billing math (prompt_tokens - cache_read_input_tokens) is correct.
-                // Only update promptTokens when a fresh raw value is present to avoid double-adding
-                // cacheRead if a later usage event arrives without prompt_tokens.
                 if (rawPromptTokens > 0) {
                   promptTokens = hasImaRouterFields ? rawPromptTokens + cacheRead : rawPromptTokens;
                 }
@@ -388,7 +386,7 @@ export function wrapStreamForSettlement(
         }
       } catch (err) {
         controller.error(err);
-        try { await onComplete({ promptTokens, completionTokens, cacheReadInputTokens, cacheCreationInputTokens }, providerCost); } catch {}
+        await settle();
       }
     },
   });

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -238,7 +238,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
   // Streaming: wrap so we can parse usage after [DONE] and settle.
   if (result.stream) {
     const wrapped = wrapStreamForSettlement(result.stream, async (usage, providerCost) => {
-      const cost = providerCost ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cacheReadInputTokens ?? 0);
+      const cost = providerCost ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cacheReadInputTokens ?? 0, usage.cacheCreationInputTokens ?? 0);
       const chargedCredits = applyMarkup(cost, ctx.markupPct);
       await settleAfterCall(ctx.platformPool, lease, chargedCredits);
       maybeTriggerAutoRefill(
@@ -278,7 +278,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
   // Non-streaming.
   const usage: AdapterUsage = result.usage ?? { promptTokens: 0, completionTokens: 0, totalCost: null };
   const providerCost = result.providerCostUsd
-    ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cache_read_input_tokens ?? 0);
+    ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cache_read_input_tokens ?? 0, usage.cache_creation_input_tokens ?? 0);
   const chargedCredits = applyMarkup(providerCost, ctx.markupPct);
 
   await settleAfterCall(ctx.platformPool, lease, chargedCredits);
@@ -448,7 +448,7 @@ export async function routeEmbedding(ctx: RouteContext, req: EmbeddingRequest): 
 
   const usage: AdapterUsage = result.usage ?? { promptTokens: 0, completionTokens: 0, totalCost: null };
   const providerCost = result.providerCostUsd
-    ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, 0, usage.cache_read_input_tokens ?? 0);
+    ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, 0, usage.cache_read_input_tokens ?? 0, usage.cache_creation_input_tokens ?? 0);
   const chargedCredits = applyMarkup(providerCost, ctx.markupPct);
 
   await settleAfterCall(ctx.platformPool, lease, chargedCredits);

--- a/services/control-api/src/services/ai-router/select.test.ts
+++ b/services/control-api/src/services/ai-router/select.test.ts
@@ -147,6 +147,46 @@ describe('estimateWorstCaseUsd', () => {
       expect(cost).toBeCloseTo(0.06144, 6);
     });
   });
+
+  describe('cache-creation pricing (write side)', () => {
+    const prices = { promptPricePerMtok: 3, completionPricePerMtok: 15 };
+
+    it('treats missing cacheCreationInputTokens as zero (unchanged behavior)', () => {
+      const baseline = estimateWorstCaseUsd(prices, 1000, 4096, 0);
+      const withZero = estimateWorstCaseUsd(prices, 1000, 4096, 0, 0);
+      expect(withZero).toBeCloseTo(baseline, 10);
+    });
+
+    it('charges cache-creation tokens at 1.25× prompt price, added on top of input', () => {
+      // 1000 non-cached prompt at $3/Mtok = 0.003; completion 4096 at $15/Mtok = 0.06144;
+      // 800 cache-creation tokens at 3 × 1.25 = $3.75/Mtok = 0.003.
+      const cost = estimateWorstCaseUsd(prices, 1000, 4096, 0, 800);
+      expect(cost).toBeCloseTo(0.003 + 0.06144 + 0.003, 6);
+    });
+
+    it('cache creation is additive — not part of promptTokens, so not subtracted', () => {
+      // Regression for the flat-charge bug: a cache *write* must cost strictly
+      // more than the same call with no cache write.
+      const noWrite = estimateWorstCaseUsd(prices, 16, 7, 0, 0);
+      const withWrite = estimateWorstCaseUsd(prices, 16, 7, 0, 5590);
+      expect(withWrite).toBeGreaterThan(noWrite);
+      // 5590 × 3 × 1.25 / 1e6 = 0.02096... extra.
+      expect(withWrite - noWrite).toBeCloseTo((5590 * 3 * 1.25) / 1_000_000, 9);
+    });
+
+    it('prices a cache write strictly higher than the equivalent cache read', () => {
+      // The exact scenario from the prod repro: identical prompt, one writes the
+      // cache (REQ1), the next reads it (REQ2). Write must cost more than read.
+      const writeReq = estimateWorstCaseUsd(prices, 16, 7, 0, 5590);     // cache creation
+      const readReq = estimateWorstCaseUsd(prices, 5606, 7, 5590, 0);    // cache read
+      expect(writeReq).toBeGreaterThan(readReq);
+    });
+
+    it('clamps negative cacheCreationInputTokens to 0', () => {
+      const cost = estimateWorstCaseUsd(prices, 1000, 4096, 0, -100);
+      expect(cost).toBeCloseTo(0.003 + 0.06144, 6);
+    });
+  });
 });
 
 describe('rankRoutersPresenceMode', () => {

--- a/services/control-api/src/services/ai-router/select.ts
+++ b/services/control-api/src/services/ai-router/select.ts
@@ -80,20 +80,33 @@ export function rankRoutersForModel(
 }
 
 /**
+ * Anthropic prices an ephemeral 5-minute prompt-cache *write* at 1.25× the base
+ * input rate. (1-hour writes are 2×, but adapters collapse both 5m and 1h cache
+ * creation into a single `cache_creation_input_tokens` count, so we apply the
+ * 5m multiplier as a floor — a conservative under-estimate for 1h writes.)
+ */
+const CACHE_WRITE_PRICE_MULTIPLIER = 1.25;
+
+/**
  * Worst-case USD cost: prompt_tokens × prompt_price + max_tokens × completion_price.
  * Used for lease reservation; actual cost from router response settles the lease.
  *
- * Optionally cache-aware: when `cacheReadInputTokens > 0`, that portion of
- * `promptTokens` is excluded from the input-cost charge. This is used on the
- * settlement-fallback path (when the upstream's `usage.cost` is null) so we
- * don't over-bill customers for tokens the upstream served from cache.
+ * Cache-aware on the settlement-fallback path (when the upstream's `usage.cost`
+ * is null), where adapters report a token breakdown:
  *
- * We don't know each router's exact cache-read price, so cached tokens are
- * billed at $0 here — a conservative under-estimate relative to the upstream's
- * real cache-read line item, but a strict improvement over the previous
- * behavior, which ignored `cache_read_input_tokens` entirely on this path.
- * The lease-reservation call site passes no cache field (cache state is
- * unknown before the call), preserving worst-case behavior there.
+ *  - `cacheReadInputTokens`: that portion of `promptTokens` is excluded from the
+ *    input-cost charge (billed at $0). We don't know each router's exact
+ *    cache-read price, so this is a deliberate, customer-favorable under-estimate
+ *    relative to the upstream's real cache-read line item (~0.1× input).
+ *  - `cacheCreationInputTokens`: charged at `CACHE_WRITE_PRICE_MULTIPLIER × prompt
+ *    price`. Unlike cache reads, cache-creation tokens are NOT part of
+ *    `promptTokens` (adapters report them as a separate count), so they are
+ *    *added*, not subtracted. Omitting this term silently undercharged every
+ *    prompt-cache write — the expensive side of caching — by the full creation
+ *    cost (see known-bugs/2026-06-23-cache-creation-tokens-unpriced.md).
+ *
+ * The lease-reservation call site passes no cache fields (cache state is unknown
+ * before the call), preserving worst-case behavior there.
  *
  * If `cacheReadInputTokens` exceeds `promptTokens` (degenerate input), the
  * non-cached portion clamps to 0 rather than going negative.
@@ -103,11 +116,14 @@ export function estimateWorstCaseUsd(
   promptTokens: number,
   maxCompletionTokens: number,
   cacheReadInputTokens: number = 0,
+  cacheCreationInputTokens: number = 0,
 ): number {
   const nonCachedPromptTokens = Math.max(0, promptTokens - cacheReadInputTokens);
   const promptCost = (nonCachedPromptTokens / 1_000_000) * prices.promptPricePerMtok;
+  const cacheCreationCost =
+    (Math.max(0, cacheCreationInputTokens) / 1_000_000) * prices.promptPricePerMtok * CACHE_WRITE_PRICE_MULTIPLIER;
   const completionCost = (maxCompletionTokens / 1_000_000) * prices.completionPricePerMtok;
-  return promptCost + completionCost;
+  return promptCost + cacheCreationCost + completionCost;
 }
 
 /**

--- a/services/control-api/src/services/ai-router/usage-log.ts
+++ b/services/control-api/src/services/ai-router/usage-log.ts
@@ -1,5 +1,6 @@
 import type pg from 'pg';
 import type { RouterName } from './normalize.js';
+import { incrementUsage } from '../usage-metering.js';
 
 export interface AiUsageRow {
   appId: string | null;
@@ -32,13 +33,14 @@ export interface AiUsageRow {
 export async function writeAiUsageRow(runtimePool: pg.Pool, row: AiUsageRow): Promise<void> {
   await runtimePool.query(
     `INSERT INTO ai_usage_logs (
-       app_id, model, provider, prompt_tokens, completion_tokens, total_tokens,
+       app_id, user_id, model, provider, prompt_tokens, completion_tokens, total_tokens,
        cost_usd, key_type, charged_to_user, request_metadata,
        router, provider_cost_usd, charged_credits_usd, markup_pct, fallback_chain, lease_id,
        cache_read_input_tokens, cache_creation_input_tokens
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)`,
     [
       row.appId,
+      row.userId,
       row.model,
       row.router,              // provider column = router name (legacy)
       row.promptTokens,
@@ -58,4 +60,12 @@ export async function writeAiUsageRow(runtimePool: pg.Pool, row: AiUsageRow): Pr
       row.cacheCreationInputTokens ?? 0,
     ]
   );
+
+  // Fan the call into usage_meters via the Redis hot path. Meter against
+  // the caller (row.userId), not apps.owner_id — that join misses app-less
+  // gateway calls (app_id = NULL) and calls against apps the caller does
+  // not own, both of which are still billed via credit_leases.
+  if (row.chargedToUser && row.userId) {
+    void incrementUsage(row.userId, 'ai_tokens', row.totalTokens, row.appId ?? undefined);
+  }
 }

--- a/services/control-api/src/services/ai-usage-logger.ts
+++ b/services/control-api/src/services/ai-usage-logger.ts
@@ -30,10 +30,11 @@ export async function logAiUsage(db: Pool, log: AiUsageLog): Promise<void> {
 
     // Insert into ai_usage_logs table (runtime-tier)
     await runtimePool.query(
-      `INSERT INTO ai_usage_logs (app_id, model, provider, prompt_tokens, completion_tokens, total_tokens, cost_usd, key_type, charged_to_user, request_metadata)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      `INSERT INTO ai_usage_logs (app_id, user_id, model, provider, prompt_tokens, completion_tokens, total_tokens, cost_usd, key_type, charged_to_user, request_metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
       [
         log.appId,
+        log.userId,
         log.model,
         log.provider,
         log.promptTokens,
@@ -46,19 +47,11 @@ export async function logAiUsage(db: Pool, log: AiUsageLog): Promise<void> {
       ]
     );
 
-    // Get app owner for usage metering (apps is runtime-tier)
-    const ownerResult = await runtimePool.query(
-      'SELECT owner_id FROM apps WHERE id = $1',
-      [log.appId]
-    );
-
-    if (ownerResult.rows.length > 0) {
-      const ownerId = ownerResult.rows[0].owner_id;
-
-      // Only increment usage meter if charged to user (platform key)
-      if (log.chargedToUser) {
-        await incrementUsage(ownerId, 'ai_tokens', log.totalTokens, log.appId);
-      }
+    // Meter against the caller (log.userId), not the app owner. Pre-028 this
+    // resolved owner_id via apps and silently skipped null-app-id rows; now
+    // app-less / non-owned-app calls also land in usage_meters.
+    if (log.chargedToUser && log.userId) {
+      await incrementUsage(log.userId, 'ai_tokens', log.totalTokens, log.appId ?? undefined);
     }
   } catch (error) {
     // Don't throw - logging should never block the response

--- a/services/control-api/src/services/usage-metering.ts
+++ b/services/control-api/src/services/usage-metering.ts
@@ -236,11 +236,13 @@ async function reconcileUsageInRegion(runtimePool: Pool, userId: string, periodS
       );
     }
 
-    // Reconcile AI tokens
+    // Reconcile AI tokens — key on user_id (post-028), since app_id is
+    // nullable and the caller can also hit AI on apps they don't own.
+    // Both cases were silently dropped under the old apps.owner_id join.
     const aiResult = await runtimePool.query(
       `SELECT app_id, COALESCE(SUM(total_tokens), 0) as total
        FROM ai_usage_logs
-       WHERE app_id IN (SELECT id FROM apps WHERE owner_id = $1)
+       WHERE user_id = $1
          AND DATE(created_at) >= $2
        GROUP BY app_id`,
       [userId, periodStart]

--- a/services/deno-runtime/worker-executor.ts
+++ b/services/deno-runtime/worker-executor.ts
@@ -944,6 +944,40 @@ function buildWorkerCode(
         if (!res.ok) throw new Error('substrate.listMemory failed: ' + res.status);
         return (await res.json()).results;
       },
+      async listSourceArtifacts(opts) {
+        const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/source-artifacts:list', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-butterbase-internal-secret': ${JSON.stringify(Deno.env.get("BUTTERBASE_INTERNAL_SECRET") || '')} },
+          body: JSON.stringify({ kind: opts?.kind, q: opts?.q, limit: opts?.limit, count: opts?.count }),
+        });
+        if (!res.ok) throw new Error('substrate.listSourceArtifacts failed: ' + res.status);
+        return (await res.json()).source_artifacts;
+      },
+      async getSourceArtifact(id) {
+        const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/source-artifacts/' + encodeURIComponent(id), {
+          headers: { 'x-butterbase-internal-secret': ${JSON.stringify(Deno.env.get("BUTTERBASE_INTERNAL_SECRET") || '')} },
+        });
+        if (res.status === 404) return null;
+        if (!res.ok) throw new Error('substrate.getSourceArtifact failed: ' + res.status);
+        return await res.json();
+      },
+      async listActions(opts) {
+        const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/actions:list', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-butterbase-internal-secret': ${JSON.stringify(Deno.env.get("BUTTERBASE_INTERNAL_SECRET") || '')} },
+          body: JSON.stringify({ status: opts?.status, capability: opts?.capability, source_app_id: opts?.source_app_id, source_rule_id: opts?.source_rule_id, before: opts?.before, limit: opts?.limit }),
+        });
+        if (!res.ok) throw new Error('substrate.listActions failed: ' + res.status);
+        return (await res.json()).actions;
+      },
+      async getAction(id) {
+        const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/actions/' + encodeURIComponent(id), {
+          headers: { 'x-butterbase-internal-secret': ${JSON.stringify(Deno.env.get("BUTTERBASE_INTERNAL_SECRET") || '')} },
+        });
+        if (res.status === 404) return null;
+        if (!res.ok) throw new Error('substrate.getAction failed: ' + res.status);
+        return await res.json();
+      },
       async upsertEntity(payload) {
         return await this.propose('upsert_entity', payload);
       },

--- a/services/mcp-server/src/__tests__/tools.test.ts
+++ b/services/mcp-server/src/__tests__/tools.test.ts
@@ -106,7 +106,7 @@ describe('MCP Server Tools', () => {
     const actions = (tool!.inputSchema as unknown as { properties: { action: { enum: string[] } } })
       .properties.action.enum;
     expect(actions.sort()).toEqual([
-      'clone', 'delete', 'find_templates', 'get_clone_job', 'get_config', 'link_substrate', 'list', 'move', 'move_status', 'pause', 'preview_clone_env_vars', 'secure', 'set_clone_webhook', 'set_visibility', 'teardown_source_replica', 'unlink_substrate', 'update_access_mode', 'update_cors',
+      'clone', 'delete', 'find_templates', 'get_clone_job', 'get_config', 'link_substrate', 'list', 'move', 'move_status', 'pause', 'preview_clone_env_vars', 'secure', 'set_clone_webhook', 'set_substrate_autopropagate', 'set_visibility', 'teardown_source_replica', 'unlink_substrate', 'update_access_mode', 'update_cors',
     ]);
     const names = result.tools.map((t) => t.name);
     for (const removed of [
@@ -124,7 +124,7 @@ describe('MCP Server Tools', () => {
     expect(tool).toBeDefined();
     const actions = ((tool!.inputSchema as unknown) as { properties: { action: { enum: string[] } } })
       .properties.action.enum;
-    expect(actions.sort()).toEqual(['delete', 'get', 'get_logs', 'list', 'update_env']);
+    expect(actions.sort()).toEqual(['delete', 'get', 'get_logs', 'list', 'update_env', 'update_settings']);
     const names = result.tools.map((t) => t.name);
     for (const removed of ['list_functions', 'delete_function', 'get_function_logs', 'update_function_env']) {
       expect(names).not.toContain(removed);

--- a/services/mcp-server/src/docs/user-documentation.ts
+++ b/services/mcp-server/src/docs/user-documentation.ts
@@ -3742,9 +3742,16 @@ export async function handler(req, ctx) {
   });
   const people = await ctx.substrate.findEntities({ type: 'person', limit: 10 });
   const one = await ctx.substrate.getEntity('ent_…');
-  return Response.json({ verdict, prior, browse, people, one });
+  // Source artifacts (meeting transcripts, email threads, documents) and the action ledger:
+  const artifacts = await ctx.substrate.listSourceArtifacts({ q: 'onboarding', kind: 'meeting_transcript', limit: 10 });
+  const artifact = await ctx.substrate.getSourceArtifact('art_…'); // null if not found
+  const actions = await ctx.substrate.listActions({ status: 'executed', limit: 25 });
+  const action = await ctx.substrate.getAction('act_…');           // null if not found
+  return Response.json({ verdict, prior, browse, people, one, artifacts, action });
 }
 \`\`\`
+
+Every read method (\`searchMemory\`, \`listMemory\`, \`listSourceArtifacts\`, \`listActions\`) returns an array (empty when there are no matches — never an error). The \`get*\` methods return the row or \`null\` when the id is unknown.
 
 Agent-proposed side-effecting actions (e.g. \`send_email_draft\`) always require human approval even if the user has \`yolo_mode\` on. Memory writes (\`record_decision\`, etc.) auto-execute.
 
@@ -4059,12 +4066,56 @@ export function getUserDocumentation(topic: DocTopic): string {
       SECTIONS.rag,
       SECTIONS.billing,
       SECTIONS.platform,
+      SECTIONS.regions,
       SECTIONS.schema,
       SECTIONS.sdk,
       SECTIONS.cli,
+      SECTIONS.realtime,
       SECTIONS.integrations,
       SECTIONS.substrate,
     ].join('\n\n');
   }
   return SECTIONS[topic];
+}
+
+export interface DocSearchHit {
+  topic: Exclude<DocTopic, 'all'>;
+  /** Number of query-term occurrences across the section. */
+  score: number;
+  /** A short excerpt around the first match, for the result index. */
+  snippet: string;
+}
+
+/**
+ * Substring search across every documentation section. Splits the query into
+ * whitespace-delimited terms, counts case-insensitive occurrences per section,
+ * and returns the highest-scoring sections. No external index — the corpus is
+ * already in memory.
+ */
+export function searchUserDocumentation(query: string, maxHits = 5): DocSearchHit[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
+
+  const hits: DocSearchHit[] = [];
+  for (const [topic, text] of Object.entries(SECTIONS) as [Exclude<DocTopic, 'all'>, string][]) {
+    const lower = text.toLowerCase();
+    let score = 0;
+    let firstPos = Infinity;
+    for (const term of terms) {
+      let idx = lower.indexOf(term);
+      if (idx !== -1 && idx < firstPos) firstPos = idx;
+      while (idx !== -1) {
+        score++;
+        idx = lower.indexOf(term, idx + term.length);
+      }
+    }
+    if (score > 0) {
+      const start = Math.max(0, firstPos - 80);
+      const snippet = text.slice(start, start + 240).replace(/\s+/g, ' ').trim();
+      hits.push({ topic, score, snippet });
+    }
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, maxHits);
 }

--- a/services/mcp-server/src/tools/docs.ts
+++ b/services/mcp-server/src/tools/docs.ts
@@ -1,6 +1,11 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { DOC_TOPICS, getUserDocumentation, type DocTopic } from '../docs/user-documentation.js';
+import {
+  DOC_TOPICS,
+  getUserDocumentation,
+  searchUserDocumentation,
+  type DocTopic,
+} from '../docs/user-documentation.js';
 
 export function registerDocs(server: McpServer) {
   server.tool(
@@ -31,6 +36,11 @@ Example:
   Input: { topic: "auth" }
   Output: Full authentication documentation with OAuth setup, JWT handling, etc.
 
+Don't know the topic slug? Pass a freeform { query: "..." } instead and the tool
+returns the best-matching section plus an index of related topics:
+  Input: { query: "how do I send email" }
+  Output: Ranked topic index + the full text of the top-matching section.
+
 Use this to:
   - Learn Butterbase features and APIs
   - Get code examples for common tasks
@@ -46,7 +56,13 @@ Idempotency: Safe to call anytime (read-only operation).`,
         .enum(DOC_TOPICS)
         .optional()
         .describe(
-          'Section to return: all (default), overview, mcp, rest, auth, storage, functions, frontend, ai, billing, platform, regions, schema, sdk, cli, realtime, rag, integrations, substrate.'
+          'Section to return: all (default), overview, mcp, rest, auth, storage, functions, frontend, ai, meetings, billing, platform, regions, schema, sdk, cli, realtime, rag, integrations, substrate.'
+        ),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          'Freeform search across all docs. When provided (and no topic is given), returns the best-matching section plus a ranked index of related topics. Use when you do not know the exact topic slug.'
         ),
     },
     {
@@ -56,7 +72,34 @@ Idempotency: Safe to call anytime (read-only operation).`,
       idempotentHint: true,
       openWorldHint: false,
     },
-    async ({ topic }) => {
+    async ({ topic, query }) => {
+      // Freeform search path: only when a query is given and no explicit topic.
+      // (topic always wins so callers can pin an exact section.)
+      if (query && query.trim() && !topic) {
+        const hits = searchUserDocumentation(query);
+        const browsable = DOC_TOPICS.filter((t) => t !== 'all').join(', ');
+        if (hits.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `No documentation section matched "${query}".\n\nValid topics: ${browsable}.\nCall butterbase_docs again with one of these as { topic }.`,
+              },
+            ],
+          };
+        }
+        const index = hits
+          .map((h) => `- ${h.topic} (${h.score} hit${h.score === 1 ? '' : 's'}): ${h.snippet.slice(0, 160)}…`)
+          .join('\n');
+        const best = getUserDocumentation(hits[0].topic);
+        const text =
+          `# Search results for "${query}"\n\n` +
+          `Top matching topics:\n${index}\n\n` +
+          `Showing the full "${hits[0].topic}" section below (the best match). ` +
+          `Call butterbase_docs with { topic: "<name>" } for any other.\n\n---\n\n${best}`;
+        return { content: [{ type: 'text' as const, text }] };
+      }
+
       const t = (topic ?? 'all') as DocTopic;
       const text = getUserDocumentation(t);
       return {

--- a/services/mcp-server/src/tools/manage-app.ts
+++ b/services/mcp-server/src/tools/manage-app.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiDelete, apiPatch, apiPost } from '../api-client.js';
+import { apiGet, apiDelete, apiPatch, apiPost, apiPut } from '../api-client.js';
 
 export function registerManageApp(server: McpServer) {
   server.tool(
@@ -21,8 +21,9 @@ Actions:
   - "get_clone_job":           Look up the status of a previously-started clone job. Returns { status, dest_app_id?, error_message? }.
   - "find_templates":          Search public templates by name, region, sort order, and pagination. Returns paginated list of public app templates.
   - "set_clone_webhook":       Set or clear a webhook that fires when someone clones this app. Pass webhook_url + webhook_secret to configure, or clear_webhook: true to remove.
-  - "link_substrate":          Link this app to the caller's substrate. Once linked, the app's deployed functions receive ctx.substrate and its actions/entities flow into the caller's substrate ledger.
-  - "unlink_substrate":        Unlink this app from substrate. ctx.substrate stops being injected; in-flight actions are unaffected.
+  - "link_substrate":              Link this app to the caller's substrate. Once linked, the app's deployed functions receive ctx.substrate and its actions/entities flow into the caller's substrate ledger.
+  - "unlink_substrate":            Unlink this app from substrate. ctx.substrate stops being injected; in-flight actions are unaffected.
+  - "set_substrate_autopropagate": Toggle per-event auto-mirroring of app activity into the linked owner's substrate. Currently supports 'users' (signup / email-verified / user-deleted). Requires the app to already be linked via 'link_substrate'.
   - "move":                    Migrate an app to a different region. Returns migration_id + initial status "queued".
   - "move_status":             Get the current status of an in-progress migration.
   - "teardown_source_replica": After a completed move, decommission the retained source-region replica.
@@ -41,8 +42,9 @@ Parameters by action:
   get_clone_job:           { action: "get_clone_job", job_id }
   find_templates:          { action: "find_templates", q?, region?, sort?, limit?, offset? }
   set_clone_webhook:       { action: "set_clone_webhook", app_id, webhook_url, webhook_secret } or { action: "set_clone_webhook", app_id, clear_webhook: true }
-  link_substrate:          { action: "link_substrate", app_id }
-  unlink_substrate:        { action: "unlink_substrate", app_id }
+  link_substrate:              { action: "link_substrate", app_id }
+  unlink_substrate:            { action: "unlink_substrate", app_id }
+  set_substrate_autopropagate: { action: "set_substrate_autopropagate", app_id, users? }
   move:                    { action: "move", app_id, dest_region }
   move_status:             { action: "move_status", app_id, migration_id }
   teardown_source_replica: { action: "teardown_source_replica", migration_id }
@@ -51,7 +53,7 @@ Common errors:
   - RESOURCE_NOT_FOUND: App doesn't exist, verify app_id with action: "list"
   - AUTH_INVALID_API_KEY: Check your API key is set correctly`,
     {
-      action: z.enum(['list', 'delete', 'pause', 'get_config', 'update_access_mode', 'secure', 'update_cors', 'set_visibility', 'preview_clone_env_vars', 'clone', 'get_clone_job', 'find_templates', 'set_clone_webhook', 'link_substrate', 'unlink_substrate', 'move', 'move_status', 'teardown_source_replica'])
+      action: z.enum(['list', 'delete', 'pause', 'get_config', 'update_access_mode', 'secure', 'update_cors', 'set_visibility', 'preview_clone_env_vars', 'clone', 'get_clone_job', 'find_templates', 'set_clone_webhook', 'link_substrate', 'unlink_substrate', 'set_substrate_autopropagate', 'move', 'move_status', 'teardown_source_replica'])
         .describe('The action to perform'),
       app_id: z.string().optional().describe('The app ID (e.g. app_abc123def456). Required for all actions except "list".'),
       // pause params
@@ -91,6 +93,8 @@ Common errors:
       sort: z.enum(['recent', 'popular']).optional().describe('Optional for "find_templates". Sort order: "recent" or "popular". Defaults to "recent".'),
       limit: z.number().int().optional().describe('Optional for "find_templates". Max results per page (default 20).'),
       offset: z.number().int().optional().describe('Optional for "find_templates". Pagination offset (default 0).'),
+      // set_substrate_autopropagate params
+      users: z.boolean().optional().describe('Optional for "set_substrate_autopropagate". true to mirror user signup / email-verified / user-deleted events into the substrate; false to disable. At least one toggle key must be provided.'),
       // move / move_status / teardown_source_replica params
       dest_region: z.string().optional().describe('Required for "move". Target region slug (e.g. "us-west-2").'),
       migration_id: z.string().optional().describe('Required for "move_status" and "teardown_source_replica". The migration ID returned by action: "move".'),
@@ -246,6 +250,24 @@ Common errors:
           const err = need(args.app_id, '"app_id" is required for this action.');
           if (err) return err;
           const result = await apiDelete(`/v1/me/apps/${args.app_id}/substrate-link`);
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        }
+        case 'set_substrate_autopropagate': {
+          const err = need(args.app_id, '"app_id" is required for this action.');
+          if (err) return err;
+          // Build body from only the keys the caller explicitly provided.
+          const body: { users?: boolean } = {};
+          if (args.users !== undefined) body.users = args.users;
+          if (Object.keys(body).length === 0) {
+            return {
+              content: [{
+                type: 'text' as const,
+                text: 'Error: At least one toggle key must be provided (e.g. users: true). Shape: { users?: boolean }',
+              }],
+              isError: true as const,
+            };
+          }
+          const result = await apiPut(`/v1/me/apps/${args.app_id}/substrate-autopropagate`, body);
           return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
         }
         case 'set_clone_webhook': {


### PR DESCRIPTION
Substrate auto-propagation work + AI router cost lookup via iMARouter. Includes a merge of main (OAuth onboarding via PR #55).

Substrate runtime surfaces, listSourceArtifacts FTS, dashboard UI toggle for per-event auto-propagation, internal-bridge list endpoints, AI router cost lookup via iMARouter /api/log/token (both stream and non-stream chat paths).

Tests: run before merge.