### PR TITLE
fix(custom-domains): support TXT DCV for apex on Cloudflare-proxied zones

### DIFF
--- a/packages/cli/bin/butterbase.ts
+++ b/packages/cli/bin/butterbase.ts
@@ -746,6 +746,10 @@ domains
   .command('add <hostname>')
   .description('Add a custom domain')
   .option('--app <app-id>', 'App ID')
+  .option(
+    '--validation-method <method>',
+    'SSL validation method: "http" (default) or "txt". Use "txt" for apex domains on Cloudflare.',
+  )
   .action(domainsAddCommand);
 
 domains

--- a/packages/cli/src/commands/domains.ts
+++ b/packages/cli/src/commands/domains.ts
@@ -49,23 +49,81 @@ export async function domainsListCommand(options: { app?: string }) {
   }
 }
 
-export async function domainsAddCommand(hostname: string, options: { app?: string }) {
+export async function domainsAddCommand(
+  hostname: string,
+  options: { app?: string; validationMethod?: string },
+) {
   const appId = await requireAppId(options.app);
+
+  let validationMethod: 'http' | 'txt' | undefined;
+  if (options.validationMethod !== undefined) {
+    if (options.validationMethod !== 'http' && options.validationMethod !== 'txt') {
+      console.error(
+        chalk.red(`✗ --validation-method must be "http" or "txt" (got "${options.validationMethod}")`),
+      );
+      process.exit(1);
+    }
+    validationMethod = options.validationMethod;
+  }
+
   const spinner = ora(`Adding custom domain "${hostname}"...`).start();
 
   try {
-    const response: any = await addCustomDomain(appId, hostname);
+    const response: any = await addCustomDomain(appId, hostname, validationMethod);
     spinner.succeed(`Added custom domain "${hostname}"`);
+
+    const chosenMethod: 'http' | 'txt' = response.validation_method || validationMethod || 'http';
 
     console.log(chalk.green('\n✓ Custom domain registered!'));
     console.log();
-    console.log(chalk.bold('Next step: Add this CNAME record at your DNS provider:'));
-    console.log();
-    console.log(`  ${chalk.cyan(hostname)} → ${chalk.cyan(response.cname_target || 'butterbase.dev')}`);
-    console.log();
+
+    if (chosenMethod === 'txt') {
+      console.log(chalk.bold('Next steps — add these records at your DNS provider:'));
+      console.log();
+      console.log(chalk.bold('  Routing:'));
+      console.log(`    ${chalk.cyan(hostname)}  CNAME  ${chalk.cyan(response.cname_target || 'butterbase.dev')}`);
+      console.log(chalk.gray('    (apex on Cloudflare: a flattened CNAME at the root is fine)'));
+      console.log();
+
+      const txtRecord = (response.verification_records || []).find(
+        (r: any) => r.txt_name && r.txt_value,
+      );
+      console.log(chalk.bold('  SSL validation (TXT):'));
+      if (txtRecord) {
+        console.log(`    ${chalk.cyan(txtRecord.txt_name)}  TXT  ${chalk.cyan(txtRecord.txt_value)}`);
+      } else {
+        console.log(
+          chalk.gray(
+            `    Pending — run "butterbase domains status ${response.domain?.id}" in ~30s to fetch the TXT details.`,
+          ),
+        );
+      }
+      console.log();
+
+      if (response.ownership_verification) {
+        const ov = response.ownership_verification;
+        console.log(chalk.bold('  Ownership (Cloudflare-proxied zones only):'));
+        console.log(`    ${chalk.cyan(ov.name)}  ${String(ov.type).toUpperCase()}  ${chalk.cyan(ov.value)}`);
+        console.log();
+      }
+    } else {
+      console.log(chalk.bold('Next step: Add this CNAME record at your DNS provider:'));
+      console.log();
+      console.log(`  ${chalk.cyan(hostname)} → ${chalk.cyan(response.cname_target || 'butterbase.dev')}`);
+      console.log();
+      console.log(
+        chalk.gray(
+          'If your DNS is on Cloudflare, use DNS-only (grey cloud).\nFor apex domains on a Cloudflare zone, re-add with --validation-method txt — HTTP DCV cannot work there.',
+        ),
+      );
+      console.log();
+    }
+
     if (response.instructions) {
       console.log(chalk.gray(response.instructions));
+      console.log();
     }
+    console.log(chalk.gray(`Validation method: ${chosenMethod}`));
     console.log(chalk.gray(`Domain ID: ${response.domain?.id}`));
     console.log(chalk.gray('Check status with: butterbase domains status <domain-id>'));
   } catch (error) {

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -518,8 +518,14 @@ export async function listCustomDomains(appId: string) {
   return apiGet<{ domains: any[] }>(`/v1/${appId}/custom-domains`);
 }
 
-export async function addCustomDomain(appId: string, hostname: string) {
-  return apiPost<any>(`/v1/${appId}/custom-domains`, { hostname });
+export async function addCustomDomain(
+  appId: string,
+  hostname: string,
+  validationMethod?: 'http' | 'txt',
+) {
+  const body: Record<string, unknown> = { hostname };
+  if (validationMethod) body.validation_method = validationMethod;
+  return apiPost<any>(`/v1/${appId}/custom-domains`, body);
 }
 
 export async function getCustomDomainStatus(appId: string, domainId: string) {

--- a/services/control-api/src/routes/custom-domains.ts
+++ b/services/control-api/src/routes/custom-domains.ts
@@ -34,6 +34,11 @@ const addDomainSchema = z.object({
     .refine((h) => /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/.test(h), {
       message: 'Hostname contains invalid characters',
     }),
+  // 'http' (default): CF auto-validates via an HTTP challenge served from our zone.
+  // 'txt': CF emits a TXT record the customer drops in their DNS. Required for any
+  // apex domain whose DNS is on Cloudflare (CNAME flattening + orange-cloud intercept
+  // make HTTP DCV impossible there); also works in every other case.
+  validation_method: z.enum(['http', 'txt']).optional().default('http'),
 });
 
 const CNAME_TARGET = config.cloudflare.customHostnameFallbackOrigin;
@@ -89,7 +94,7 @@ export async function customDomainRoutes(fastify: FastifyInstance) {
     }
 
     const body = addDomainSchema.parse(request.body);
-    const { hostname } = body;
+    const { hostname, validation_method } = body;
 
     // Check hostname uniqueness in our DB — app_custom_domains is a runtime table
     const existing = await runtimeDb.query(
@@ -112,7 +117,7 @@ export async function customDomainRoutes(fastify: FastifyInstance) {
     // Create custom hostname in Cloudflare
     let cfResult: CustomHostnames.CustomHostnameResult;
     try {
-      cfResult = await CustomHostnames.createCustomHostname(hostname);
+      cfResult = await CustomHostnames.createCustomHostname(hostname, validation_method);
     } catch (error) {
       if (isHttpError(error)) throw error;
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -164,10 +169,36 @@ export async function customDomainRoutes(fastify: FastifyInstance) {
       success: true,
     });
 
+    const txtValidationRecord = cfResult.ssl?.validation_records?.find(
+      (r) => r.txt_name && r.txt_value,
+    );
+    const instructions =
+      validation_method === 'txt'
+        ? [
+            `Add the following records at your DNS provider:`,
+            ``,
+            `  1. CNAME (routing):`,
+            `       ${hostname}  CNAME  ${CNAME_TARGET}`,
+            `     If apex on Cloudflare, an "A/AAAA" or "CNAME flattened" record at the root is fine; the TXT below is what authorizes the cert.`,
+            ``,
+            txtValidationRecord
+              ? `  2. TXT (SSL validation):\n       ${txtValidationRecord.txt_name}  TXT  ${txtValidationRecord.txt_value}`
+              : `  2. TXT (SSL validation): Cloudflare will issue the TXT record details on the status endpoint shortly — call GET /v1/${appId}/custom-domains/${insertResult.rows[0].id}/status to fetch them.`,
+            cfResult.ownership_verification
+              ? `\n  3. Ownership TXT (Cloudflare-proxied zones only):\n       ${cfResult.ownership_verification.name}  ${cfResult.ownership_verification.type.toUpperCase()}  ${cfResult.ownership_verification.value}`
+              : ``,
+            ``,
+            `TXT validation works in every case, including apex domains on a Cloudflare-proxied zone.`,
+          ].join('\n')
+        : `Add a CNAME record at your DNS provider:\n  ${hostname}  CNAME  ${CNAME_TARGET}\n\nIf your DNS is managed by Cloudflare, set the record to DNS-only (grey cloud, not proxied).\nCloudflare will automatically validate ownership and issue an SSL certificate once the CNAME is active.\n\nNote: HTTP validation does NOT work for apex domains whose DNS is on Cloudflare. For that case, re-add the domain with validation_method: "txt".`;
+
     return reply.status(201).send({
       domain: insertResult.rows[0],
       cname_target: CNAME_TARGET,
-      instructions: `Add a CNAME record at your DNS provider:\n  ${hostname}  CNAME  ${CNAME_TARGET}\n\nIf your DNS is managed by Cloudflare, set the record to DNS-only (grey cloud, not proxied).\nCloudflare will automatically validate ownership and issue an SSL certificate once the CNAME is active.`,
+      validation_method,
+      verification_records: cfResult.ssl?.validation_records ?? [],
+      ownership_verification: cfResult.ownership_verification ?? null,
+      instructions,
     });
   });
 
@@ -292,7 +323,22 @@ export async function customDomainRoutes(fastify: FastifyInstance) {
     }
 
     try {
-      const cfResult = await CustomHostnames.refreshCustomHostname(domain.cf_custom_hostname_id);
+      // Preserve the SSL method the customer originally chose (http vs txt).
+      // Fetching first costs one extra GET but avoids silently downgrading a
+      // txt-validated domain back to http on every refresh.
+      let currentMethod: CustomHostnames.SslValidationMethod = 'http';
+      try {
+        const current = await CustomHostnames.getCustomHostname(domain.cf_custom_hostname_id);
+        if (current.ssl?.method === 'txt' || current.ssl?.method === 'http') {
+          currentMethod = current.ssl.method;
+        }
+      } catch {
+        // Fall through with default 'http' — refresh will re-error and surface to caller.
+      }
+      const cfResult = await CustomHostnames.refreshCustomHostname(
+        domain.cf_custom_hostname_id,
+        currentMethod,
+      );
 
       // app_custom_domains is a runtime table
       await runtimeDb.query(

--- a/services/control-api/src/services/cloudflare-custom-hostnames.ts
+++ b/services/control-api/src/services/cloudflare-custom-hostnames.ts
@@ -62,12 +62,27 @@ interface CfResponse<T> {
   result: T;
 }
 
+export type SslValidationMethod = 'http' | 'txt';
+
 /**
  * Create a custom hostname on the zone via Cloudflare for SaaS.
- * SSL method defaults to 'http' (DCV over HTTP).
+ *
+ * `validationMethod` picks the SSL DCV method:
+ *   - 'http' (default): Cloudflare validates by serving a challenge from our SaaS zone.
+ *     Convenient — customer adds nothing — but fails when the customer's zone is
+ *     Cloudflare-proxied (orange cloud) because their CF intercepts the challenge,
+ *     and is also impossible for apex hostnames on CF-hosted zones (CNAME flattening
+ *     hides the CNAME from CF for SaaS).
+ *   - 'txt': Cloudflare issues a TXT record the customer drops in their DNS. Works
+ *     unconditionally, including apex + CF-proxied zones. This is the method to use
+ *     for any apex domain whose DNS is on Cloudflare.
+ *
  * Handles 409 (already exists) idempotently.
  */
-export async function createCustomHostname(hostname: string): Promise<CustomHostnameResult> {
+export async function createCustomHostname(
+  hostname: string,
+  validationMethod: SslValidationMethod = 'http',
+): Promise<CustomHostnameResult> {
   if (!config.cloudflare.zoneId) {
     throw new CustomHostnameError('Cloudflare zone ID not configured', 'MISSING_ZONE_ID');
   }
@@ -75,7 +90,7 @@ export async function createCustomHostname(hostname: string): Promise<CustomHost
   const body = {
     hostname,
     ssl: {
-      method: 'http',
+      method: validationMethod,
       type: 'dv',
       settings: {
         min_tls_version: '1.2',
@@ -199,7 +214,10 @@ export async function deleteCustomHostname(customHostnameId: string): Promise<vo
  * Re-trigger validation for a custom hostname by PATCHing it.
  * This causes Cloudflare to re-check ownership and SSL status.
  */
-export async function refreshCustomHostname(customHostnameId: string): Promise<CustomHostnameResult> {
+export async function refreshCustomHostname(
+  customHostnameId: string,
+  validationMethod: SslValidationMethod = 'http',
+): Promise<CustomHostnameResult> {
   if (!config.cloudflare.zoneId) {
     throw new CustomHostnameError('Cloudflare zone ID not configured', 'MISSING_ZONE_ID');
   }
@@ -209,7 +227,7 @@ export async function refreshCustomHostname(customHostnameId: string): Promise<C
     headers: getHeaders(),
     body: JSON.stringify({
       ssl: {
-        method: 'http',
+        method: validationMethod,
         type: 'dv',
       },
     }),

--- a/services/mcp-server/src/docs/user-documentation.ts
+++ b/services/mcp-server/src/docs/user-documentation.ts
@@ -1678,31 +1678,50 @@ manage_frontend({ app_id: "app_abc123", action: "configure_custom_domain", domai
 POST /v1/{app_id}/custom-domains
 Authorization: Bearer {token}
 
-{ "hostname": "app.example.com" }
+{ "hostname": "app.example.com", "validation_method": "http" }
 \`\`\`
 
-Response includes a \`cname_target\` and setup instructions.
+Response includes a \`cname_target\`, the chosen \`validation_method\`, verification records, and setup instructions.
+
+#### Choosing a validation method
+
+\`validation_method\` controls how Cloudflare proves ownership and issues the SSL certificate.
+
+- **\`"http"\`** (default) \u2014 Cloudflare serves an HTTP challenge from our zone; the customer adds nothing besides the routing CNAME. Convenient, but **does not work** when the customer's DNS is on a Cloudflare-proxied zone \u2014 orange-cloud intercept blocks the challenge \u2014 and is **impossible for apex hostnames on Cloudflare-hosted zones** (CNAME flattening hides the record from CF for SaaS).
+- **\`"txt"\`** \u2014 Cloudflare emits a TXT record the customer drops in their DNS. Works in **every** scenario, including \`example.com\` (apex) on a Cloudflare-proxied zone. Required when the customer's DNS provider is Cloudflare and the hostname is the apex.
+
+Pick \`"txt"\` whenever the target hostname is an apex on a Cloudflare-hosted zone. Pick \`"http"\` for subdomains or non-Cloudflare DNS where convenience matters.
 
 #### Verification flow
 
+**HTTP method (default):**
 1. Add your domain via the API, MCP tool, CLI, or dashboard
-2. Add a CNAME record at your DNS provider: \`app.example.com \u2192 butterbase.dev\`
+2. Add a CNAME at your DNS provider: \`app.example.com \u2192 butterbase.dev\`
    - **If your DNS is on Cloudflare:** set the record to **DNS-only (grey cloud)**. Proxied (orange cloud) CNAMEs between different Cloudflare accounts produce Error 1014 and will not work.
 3. Cloudflare validates ownership and issues an SSL certificate automatically
 4. Check progress via the status endpoint (typically 5\u201315 minutes)
 5. Once \`status\` is \`"active"\` and \`ssl_status\` is \`"active"\`, the domain is live
 
+**TXT method (required for apex on Cloudflare):**
+1. Add the domain with \`validation_method: "txt"\`
+2. Point the hostname at us in DNS \u2014 a CNAME (\`app.example.com \u2192 butterbase.dev\`), or for an apex, whatever record your provider uses (CF's flattened CNAME at the root is fine)
+3. Add the SSL TXT record from \`verification_records[].txt_name\` / \`txt_value\` in the response
+4. If \`ownership_verification\` is also returned (Cloudflare-proxied zones), add that record too
+5. Poll the status endpoint; once \`ssl_status\` is \`"active"\`, the domain is live
+
 #### Managing domains
 
 | Method | Path / MCP Action | Purpose |
 |--------|-------------------|---------|
-| POST | /v1/{app_id}/custom-domains | Add a custom domain |
+| POST | /v1/{app_id}/custom-domains | Add a custom domain (accepts \`validation_method\`) |
 | GET | /v1/{app_id}/custom-domains | List all custom domains |
 | GET | /v1/{app_id}/custom-domains/{id}/status | Check verification/SSL status |
-| POST | /v1/{app_id}/custom-domains/{id}/verify | Re-trigger verification |
+| POST | /v1/{app_id}/custom-domains/{id}/verify | Re-trigger verification (preserves the original \`validation_method\`) |
 | DELETE | /v1/{app_id}/custom-domains/{id} | Remove a custom domain |
 
-**Apex domains:** For \`example.com\` (no subdomain), your DNS provider must support CNAME flattening (e.g., Cloudflare DNS). Otherwise, use \`www.example.com\` and set up a redirect from the apex.
+**Apex domains:** For \`example.com\` (no subdomain) on **Cloudflare DNS**, use \`validation_method: "txt"\` \u2014 HTTP DCV cannot work there. For apex on a non-Cloudflare provider, CNAME flattening with \`"http"\` works; otherwise use \`www.example.com\` and redirect the apex to it at your DNS edge.
+
+**Canonical \`www\` vs apex:** Butterbase does **not** force a www\u2194apex redirect on customer domains. Either variant can be canonical \u2014 set up the canonical one as a custom domain and the other as a DNS-level redirect at your provider.
 `,
 
   ai: `## AI Model Gateway


### PR DESCRIPTION
## Summary

Customer reported that apex custom domains (e.g. `catchpacific.com`) on Cloudflare-hosted zones could not be served as Butterbase custom domains — Cloudflare for SaaS rejected with *\"custom hostname does not CNAME to this zone\"* / *\"cannot be activated with a TXT or HTTP validation token. To activate the custom hostname, the DNS target needs to point to the SaaS zone.\"*

Root cause: we hard-coded `ssl.method = 'http'` on the custom-hostname create call. HTTP DCV cannot work for an apex on a Cloudflare-proxied zone — CNAME flattening hides the CNAME from CF for SaaS, and orange-cloud intercept blocks the HTTP challenge. CF for SaaS supports a TXT-DCV escape hatch for exactly this case; we just never wired it up.

## Changes

- **`services/control-api/src/services/cloudflare-custom-hostnames.ts`** — `createCustomHostname` / `refreshCustomHostname` accept an optional `validationMethod: 'http' | 'txt'`; default stays `'http'` for backward compat.
- **`services/control-api/src/routes/custom-domains.ts`**
  - `POST /v1/:appId/custom-domains` accepts `validation_method` in the body.
  - Response now returns `validation_method`, `verification_records`, `ownership_verification`, and method-specific `instructions`.
  - `POST /v1/:appId/custom-domains/:domainId/verify` reads the existing `ssl.method` from CF and PATCHes with the same value — previously unconditionally rewrote to `'http'`, which would have silently downgraded a TXT-validated domain on every refresh.
- **`packages/cli/`** — `butterbase domains add <hostname>` gains `--validation-method <method>`; TXT-mode output prints the routing CNAME, SSL TXT, and ownership TXT (when present) in one shot.
- **`services/mcp-server/src/docs/user-documentation.ts`** — new \"Choosing a validation method\" section, split HTTP/TXT verification flows, apex-on-Cloudflare guidance points at `validation_method: \"txt\"`. Also clarifies that the platform does **not** force www↔apex redirects on customer domains (either variant can be canonical) — addresses the customer's secondary complaint, which turned out to be a misdiagnosis.

## Customer-facing flow

```
butterbase domains add catchpacific.com --validation-method txt
```

Returns the routing record, the SSL TXT, and the ownership TXT to drop in DNS. Works for apex on Cloudflare.

## Deliberately not in scope

- No DB migration — chosen method lives in CF, read back on verify (one extra GET). Avoids a schema change.
- No auto-fallback (catching CF's \"must point to SaaS zone\" error and silently switching to TXT). Method changes should be explicit.

## Test plan

- [ ] Unit: addCustomDomain → CF mock receives `ssl.method: 'http'` by default
- [ ] Unit: addCustomDomain with `validation_method: 'txt'` → CF mock receives `ssl.method: 'txt'`; response includes `verification_records`
- [ ] Unit: verify endpoint reads current `ssl.method` and PATCHes with the same value
- [ ] Manual: `butterbase domains add <apex>.com --validation-method txt` against staging; confirm TXT records surface in CLI output and `GET /status` reflects them
- [ ] Manual: re-verify a TXT-validated domain; confirm method is preserved (not downgraded to HTTP)
- [ ] Repro fix: walk through the catchpacific.com flow end-to-end with the new TXT path