### PR TITLE
fix(ai-videos): strict schema + image_url/first_frame aliases

### DIFF
--- a/services/control-api/src/routes/ai-videos.test.ts
+++ b/services/control-api/src/routes/ai-videos.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
-import { buildPublicJobResponse, handleVideoError } from './ai-videos.js';
+import { buildPublicJobResponse, handleVideoError, videoSubmitSchema } from './ai-videos.js';
 import type { VideoJobRow } from '../services/ai-router/video-jobs.js';
 import { RouterError, InsufficientCreditsError } from '../services/ai-router/router.js';
 
@@ -185,5 +185,64 @@ describe('handleVideoError', () => {
     expect(reply._sent.code).toBe(500);
     const body = reply._sent.body as Record<string, unknown>;
     expect(body).toBeDefined();
+  });
+});
+
+describe('videoSubmitSchema', () => {
+  const base = { model: 'kwaivgi/kling-v3.0', prompt: 'hi' };
+
+  it('rejects unknown fields with unrecognized_keys', () => {
+    const res = videoSubmitSchema.safeParse({ ...base, bogus_field: 'x' });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error.issues[0].code).toBe('unrecognized_keys');
+    }
+  });
+
+  it('normalizes image_url alias into input_images', () => {
+    const res = videoSubmitSchema.parse({ ...base, image_url: 'https://example.com/x.jpg' });
+    expect(res.input_images).toEqual(['https://example.com/x.jpg']);
+    expect((res as Record<string, unknown>).image_url).toBeUndefined();
+  });
+
+  it.each([
+    ['image', 'https://example.com/a.jpg'],
+    ['image_uri', 'https://example.com/b.jpg'],
+    ['first_frame', 'https://example.com/c.jpg'],
+    ['reference_image', 'https://example.com/d.jpg'],
+    ['input_image', 'https://example.com/e.jpg'],
+    ['starting_image', 'https://example.com/f.jpg'],
+  ])('normalizes %s alias into input_images', (alias, url) => {
+    const res = videoSubmitSchema.parse({ ...base, [alias]: url });
+    expect(res.input_images).toEqual([url]);
+    expect((res as Record<string, unknown>)[alias]).toBeUndefined();
+  });
+
+  it('preserves existing input_images and appends aliases', () => {
+    const res = videoSubmitSchema.parse({
+      ...base,
+      input_images: ['https://example.com/existing.jpg'],
+      image_url: 'https://example.com/alias.jpg',
+    });
+    expect(res.input_images).toEqual([
+      'https://example.com/existing.jpg',
+      'https://example.com/alias.jpg',
+    ]);
+  });
+
+  it('accepts native input_images unchanged', () => {
+    const res = videoSubmitSchema.parse({
+      ...base,
+      input_images: ['https://example.com/a.jpg', 'https://example.com/b.jpg'],
+    });
+    expect(res.input_images).toEqual([
+      'https://example.com/a.jpg',
+      'https://example.com/b.jpg',
+    ]);
+  });
+
+  it('rejects invalid (non-URL) alias value via .url() validator', () => {
+    const res = videoSubmitSchema.safeParse({ ...base, image_url: 'not-a-url' });
+    expect(res.success).toBe(false);
   });
 });

--- a/services/control-api/src/routes/ai-videos.ts
+++ b/services/control-api/src/routes/ai-videos.ts
@@ -76,7 +76,32 @@ export async function buildVideoAdapters(): Promise<Map<RouterName, RouterAdapte
   return m;
 }
 
-const videoSubmitSchema = z.object({
+const IMAGE_ALIAS_KEYS = [
+  'image',
+  'image_url',
+  'image_uri',
+  'first_frame',
+  'reference_image',
+  'input_image',
+  'starting_image',
+] as const;
+
+export const videoSubmitSchema = z.preprocess((raw) => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return raw;
+  const src = raw as Record<string, unknown>;
+  const aliased: string[] = [];
+  for (const key of IMAGE_ALIAS_KEYS) {
+    const v = src[key];
+    if (typeof v === 'string' && v.length > 0) aliased.push(v);
+    else if (Array.isArray(v)) for (const item of v) if (typeof item === 'string' && item.length > 0) aliased.push(item);
+  }
+  if (aliased.length === 0) return raw;
+  const next = { ...src };
+  for (const key of IMAGE_ALIAS_KEYS) delete next[key];
+  const existing = Array.isArray(next.input_images) ? (next.input_images as unknown[]).filter((x): x is string => typeof x === 'string') : [];
+  next.input_images = [...existing, ...aliased];
+  return next;
+}, z.object({
   model: z.string(),
   prompt: z.string(),
   duration: z.number().int().positive().optional(),
@@ -87,7 +112,7 @@ const videoSubmitSchema = z.object({
   input_images: z.array(z.string().url()).optional(),
   input_references: z.array(z.string().url()).optional(),
   provider: z.record(z.unknown()).optional(),
-});
+}).strict());
 
 export async function aiVideoRoutes(app: FastifyInstance) {
   const adapters = await buildVideoAdapters();


### PR DESCRIPTION
## Summary

`POST /v1/{appId}/videos/completions` silently accepted then dropped any field not in the zod schema. Callers passing `image_url`, `first_frame`, `reference_image`, etc. got `200 + job_id` and a credit charge, but the image never reached the upstream provider — output videos came back text-to-video only.

Two changes:

1. `.strict()` the request schema. Unknown fields now return `400 unrecognized_keys` instead of silently passing through.
2. Add a `z.preprocess` layer that normalizes seven common image aliases — `image`, `image_url`, `image_uri`, `first_frame`, `reference_image`, `input_image`, `starting_image` — into the canonical `input_images` array before strict validation. Strings and `string[]` both accepted. Existing `input_images` is preserved; aliases append.

## Test plan

- [x] `vitest run src/routes/ai-videos.test.ts` — 21/21 pass, 11 new
- [x] Live recreate against rebuilt local control-api:
  - `bogus_field` → 400 `unrecognized_keys`
  - `image_url` / `first_frame` / `reference_image` → 200 + reaches credit stage (previously silently dropped)
  - native `input_images` → 200 (no regression)
- [x] End-to-end Kling V3 image-to-video job submitted with `image_url`, reference portrait used in output (eyeball-confirmed)

## Context

Reported by customer (suggestion `49d53a61-68e0-461e-b8aa-76a95a12c8be`); ~$5 of credits were spent debugging the silent drop before the param-name mismatch was found. Companion overlay PR in `butterbase-internal` wires the now-strict `input_images` through the two adapters that were also dropping it (Kling V3, PixVerse) and fixes a related URL-extraction bug.