### PR TITLE
fix(admin): /admin/users/:id — read billing cols from organizations

### DIFF
--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -937,8 +937,11 @@ export async function adminRoutes(app: FastifyInstance) {
 
     const [userResult, suggestionsResult] = await Promise.all([
       app.controlDb.query(
-        `SELECT id, email, display_name, plan_id, account_status, stripe_customer_id, created_at
-         FROM platform_users WHERE id = $1`,
+        `SELECT pu.id, pu.email, pu.display_name, pu.created_at,
+                o.plan_id, o.account_status, o.stripe_customer_id
+         FROM platform_users pu
+         LEFT JOIN organizations o ON o.id = pu.personal_organization_id
+         WHERE pu.id = $1`,
         [id]
       ),
       app.controlDb.query(


### PR DESCRIPTION
Migration 079 dropped plan_id, account_status, stripe_customer_id from platform_users (they moved to organizations post-Plan-07). The composite /admin/users/:id SELECT still referenced the old columns and 500'd. Every other query in admin.ts already joins organizations for these — this was a single missed spot (see the '// plan_id lives on organizations post-Plan-07' comment at line 1318 acknowledging the move).

Impacts: admin dashboard UserDetail page — every click on a user in prod returns 500 without this fix.