### PR TITLE
chore(dispatch-worker): set CONTROL_API_URL for visit beacon

### DIFF
--- a/dispatch-worker/wrangler.json
+++ b/dispatch-worker/wrangler.json
@@ -10,7 +10,7 @@
   ],
   "vars": {
     "BUTTERBASE_REGION": "us-east-1",
-    "CONTROL_API_URL": ""
+    "CONTROL_API_URL": "https://api.butterbase.ai"
   },
   "kv_namespaces": [
     {


### PR DESCRIPTION
Populates the vars slot introduced with the visit beacon. The beacon fetch silently no-ops when this is empty, so this is required to actually start recording frontend_visit_daily rows in prod.