### PR TITLE
fix(integrations): search full Composio catalog, log fallback

### DIFF
--- a/services/control-api/src/routes/integrations.ts
+++ b/services/control-api/src/routes/integrations.ts
@@ -346,8 +346,11 @@ export async function integrationRoutes(app: FastifyInstance) {
         try {
           const result = await searchToolkits(search);
           return reply.send({ integrations: result });
-        } catch {
-          // Fall back to curated only
+        } catch (err) {
+          request.log.warn(
+            { err, search },
+            'composio catalog search failed; falling back to curated list'
+          );
         }
       }
 

--- a/services/control-api/src/services/composio-client.ts
+++ b/services/control-api/src/services/composio-client.ts
@@ -594,10 +594,14 @@ export async function searchToolkits(
   search: string,
 ): Promise<ToolkitListing[]> {
   const composio = getComposioClient();
-  // toolkits.get(params) returns a paginated list; the SDK doesn't support
-  // free-text search, so we fetch a page and filter client-side.
-  const result = await composio.toolkits.get({ limit: 100 });
-  // SDK returns an array directly (not { items: [] })
+  // The @composio/core wrapper's toolkits.get() strips next_cursor from the
+  // response, so true pagination through the wrapper isn't possible. Fetch the
+  // SDK-max page sorted by usage, so widely-used toolkits (instagram, tiktok,
+  // etc.) land in the returned set even though Composio's catalog is >1000
+  // toolkits. Long-tail toolkits may still be missed; if that becomes an issue,
+  // switch to the low-level @composio/client which supports a server-side
+  // `search` query param.
+  const result = await composio.toolkits.get({ limit: 1000, sortBy: 'usage' });
   const items: any[] = Array.isArray(result) ? result : ((result as any)?.items || []);
   const query = search.toLowerCase();
   return items


### PR DESCRIPTION
## Summary

`GET /v1/:appId/integrations/available?search=…` returned empty for common toolkits like **Instagram** and **TikTok** — even though they exist in Composio's catalog with 36 and 10 tools respectively.

### Root cause

`searchToolkits()` in `services/control-api/src/services/composio-client.ts` called `composio.toolkits.get({ limit: 100 })` and filtered client-side. Composio's catalog is >1000 toolkits, and neither instagram nor tiktok were in the first 100 the SDK returned. When `?search=instagram` came in, the filter matched nothing → response `{ integrations: [] }`.

Compounding it: when the SDK call threw, `routes/integrations.ts` caught silently and fell through to the 10-item curated list, so real API failures also looked like "no matches."

### Fix

- Bump `limit` to the SDK max (1000) and pass `sortBy: 'usage'` so widely-used toolkits (instagram, tiktok, etc.) land in the returned page. `@composio/core`'s `toolkits.get()` strips `next_cursor` from the response, so true cursor pagination through the wrapper isn't possible; comment left in place pointing at the low-level `@composio/client` (which supports server-side `search`) as the escape hatch if long-tail toolkits become an issue.
- Log the search failure via `request.log.warn` instead of a silent `catch {}`, so real Composio errors surface in ops instead of masquerading as empty results.

## Test plan

- [ ] `GET /v1/:appId/integrations/available?search=instagram` returns the Instagram toolkit
- [ ] `GET /v1/:appId/integrations/available?search=tiktok` returns the TikTok toolkit
- [ ] `GET /v1/:appId/integrations/available?search=gmail` still returns Gmail (regression check)
- [ ] `GET /v1/:appId/integrations/available` (no search) still returns the 10-item curated list
- [ ] With Composio API deliberately broken (bad key), `?search=foo` returns curated list and emits a `warn` log