### PR TITLE
feat(storage,mcp): expose per-app storage cap via manage_storage.update_config

### DIFF
--- a/services/control-api/src/routes/app-config.ts
+++ b/services/control-api/src/routes/app-config.ts
@@ -8,6 +8,7 @@ import { logFromRequest } from '../services/audit/with-audit.js';
 import { config } from '../config.js';
 import { resolveAppHomeRegion } from '../services/region-resolver.js';
 import { getRuntimeDbPool } from '../services/runtime-db.js';
+import { getLimitsForApp } from '../services/app-plan-resolver.js';
 
 const updateCorsSchema = z.object({
   allowed_origins: z.array(z.string().url()).min(1),
@@ -19,8 +20,12 @@ const updateJwtConfigSchema = z.object({
 });
 
 const updateStorageConfigSchema = z.object({
-  publicReadEnabled: z.boolean(),
-});
+  publicReadEnabled: z.boolean().optional(),
+  storageLimitBytes: z.number().int().positive().optional(),
+}).refine(
+  (v) => v.publicReadEnabled !== undefined || v.storageLimitBytes !== undefined,
+  { message: 'At least one of publicReadEnabled or storageLimitBytes must be provided' },
+);
 
 const updateAuthHooksSchema = z.object({
   post_auth_function: z.string().nullable(),
@@ -270,7 +275,7 @@ export async function appConfigRoutes(app: FastifyInstance) {
       return reply.code(400).send(createAgentError({
         code: VALIDATION_INVALID_SCHEMA,
         message: 'Invalid request body',
-        remediation: 'Review the validation errors in the details field. Ensure publicReadEnabled is a boolean.',
+        remediation: 'Review the validation errors in the details field. Ensure publicReadEnabled is a boolean and/or storageLimitBytes is a positive integer.',
         documentation_url: getDocUrl(VALIDATION_INVALID_SCHEMA),
         details: parseResult.error.errors
       }));
@@ -280,6 +285,34 @@ export async function appConfigRoutes(app: FastifyInstance) {
       const resolvedApp = await AppResolver.resolveApp(app.controlDb, app_id, requireUserId(request), request.auth?.organizationId ?? null);
       const region = await resolveAppHomeRegion(app.controlDb, resolvedApp.id);
       const runtimeDb = getRuntimeDbPool(config.runtimeDb, region);
+
+      // Clamp storageLimitBytes to the app's plan cap. Without this the per-app
+      // override in apps.storage_config would silently exceed what the org's
+      // plan actually allows — checkStorageQuota reads storageLimitBytes
+      // directly, so a rogue value would be honoured until the org-wide plan
+      // check catches up.
+      if (parseResult.data.storageLimitBytes !== undefined) {
+        const limits = await getLimitsForApp(app.controlDb, resolvedApp.id);
+        if (limits.maxStorageGb !== -1) {
+          const planCapBytes = limits.maxStorageGb * 1024 * 1024 * 1024;
+          if (parseResult.data.storageLimitBytes > planCapBytes) {
+            return reply.code(400).send(createAgentError({
+              code: VALIDATION_INVALID_SCHEMA,
+              message: 'storageLimitBytes exceeds the plan cap',
+              remediation:
+                `Requested ${parseResult.data.storageLimitBytes} bytes exceeds ` +
+                `the plan cap of ${planCapBytes} bytes (${limits.maxStorageGb} GB). ` +
+                `Set a value at or below the plan cap, or upgrade the plan via billing.`,
+              documentation_url: getDocUrl(VALIDATION_INVALID_SCHEMA),
+              details: {
+                requested_bytes: parseResult.data.storageLimitBytes,
+                plan_cap_bytes: planCapBytes,
+                plan_max_storage_gb: limits.maxStorageGb,
+              },
+            }));
+          }
+        }
+      }
 
       // Get current storage config
       const currentResult = await runtimeDb.query(
@@ -314,7 +347,10 @@ export async function appConfigRoutes(app: FastifyInstance) {
         action: 'update',
         resourceType: 'app_config',
         resourceId: 'storage',
-        eventData: { publicReadEnabled: newConfig.publicReadEnabled },
+        eventData: {
+          publicReadEnabled: newConfig.publicReadEnabled,
+          storageLimitBytes: newConfig.storageLimitBytes,
+        },
         success: true,
       });
 

--- a/services/mcp-server/src/tools/manage-storage.ts
+++ b/services/mcp-server/src/tools/manage-storage.ts
@@ -12,14 +12,14 @@ Actions:
   - "download_url":  Get a presigned GET URL for a stored file (expires in 1 hour)
   - "list":          List all objects in app storage with metadata
   - "delete":        Permanently delete an object from S3 + database
-  - "update_config": Update storage config (e.g., publicReadEnabled)
+  - "update_config": Update storage config (publicReadEnabled and/or per-app storage cap)
 
 Parameters by action:
   upload_url:    { app_id, action: "upload_url", filename, content_type, size_bytes, public? }
   download_url:  { app_id, action: "download_url", object_id }
   list:          { app_id, action: "list" }
   delete:        { app_id, action: "delete", object_id }
-  update_config: { app_id, action: "update_config", publicReadEnabled? }
+  update_config: { app_id, action: "update_config", publicReadEnabled?, storageLimitBytes? }
 
 object_id is the UUID returned from upload or list. Do NOT pass the s3_key / bucket path
 (e.g. app_id/user_id/uuid_file.jpg) — that is metadata only and is not a usable URL.
@@ -37,6 +37,13 @@ publicReadEnabled (update_config):
   - true:  any authenticated user can download any file (uploads/deletes still user-scoped)
   - false (default): users can only download their own files; platform auth (API key) can still access any file
 
+storageLimitBytes (update_config):
+  - Per-app total storage cap in bytes. Defaults to 1 GB (1073741824) when unset.
+  - Must be a positive integer and cannot exceed the org's plan cap
+    (rejected with VALIDATION_INVALID_SCHEMA if it does). To raise it above the
+    plan cap, upgrade the plan via manage_billing.
+  - At least one of publicReadEnabled or storageLimitBytes must be supplied.
+
 Limits & errors:
   - Files: max 10 MB each (QUOTA_FILE_SIZE_EXCEEDED)
   - QUOTA_STORAGE_EXCEEDED: delete unused files or upgrade plan
@@ -53,6 +60,7 @@ Warning: "delete" cannot be undone. Update DB references (e.g. users.avatar_id) 
       public: z.boolean().optional().describe('Optional for upload_url. Mark file as publicly downloadable. Default: false.'),
       object_id: z.string().optional().describe('Required for download_url and delete. Storage object UUID — not the s3_key path.'),
       publicReadEnabled: z.boolean().optional().describe('Optional for update_config. Enable/disable app-wide public read.'),
+      storageLimitBytes: z.number().int().positive().optional().describe('Optional for update_config. Per-app total storage cap in bytes. Cannot exceed the plan cap.'),
     },
     {
       title: 'Manage Storage',
@@ -100,9 +108,15 @@ Warning: "delete" cannot be undone. Update DB references (e.g. users.avatar_id) 
           return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
         }
         case 'update_config': {
-          const result = await apiPatch(`/v1/${app_id}/config/storage`, {
-            publicReadEnabled: args.publicReadEnabled,
-          });
+          const err = need(
+            args.publicReadEnabled !== undefined || args.storageLimitBytes !== undefined,
+            '"publicReadEnabled" or "storageLimitBytes" is required for update_config.',
+          );
+          if (err) return err;
+          const body: Record<string, unknown> = {};
+          if (args.publicReadEnabled !== undefined) body.publicReadEnabled = args.publicReadEnabled;
+          if (args.storageLimitBytes !== undefined) body.storageLimitBytes = args.storageLimitBytes;
+          const result = await apiPatch(`/v1/${app_id}/config/storage`, body);
           return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
         }
       }


### PR DESCRIPTION
## Summary

Users had no MCP path to adjust the per-app storage cap (`apps.storage_config.storageLimitBytes`). The PATCH `/v1/:app_id/config/storage` schema accepted only `publicReadEnabled`, and the `manage_storage` MCP tool's `update_config` action mirrored that. The only way to raise the cap was operator SQL or a plan upgrade.

- Extend `updateStorageConfigSchema` in `services/control-api/src/routes/app-config.ts:21` to accept an optional `storageLimitBytes` (positive int) alongside `publicReadEnabled`, with a `.refine()` requiring at least one field.
- Clamp writes to the app's plan cap: resolve limits via `getLimitsForApp()` and reject values above `maxStorageGb * 1024^3` (unless the plan is unlimited, `maxStorageGb === -1`). Without this, `checkStorageQuota()` reads `storageLimitBytes` directly and would silently honour values above the plan cap until the org-wide plan check catches up.
- Include `storageLimitBytes` in the audit event.
- Expose the new field on `manage_storage`'s `update_config` action (`services/mcp-server/src/tools/manage-storage.ts`) with matching docs and require at least one of the two fields.

## MCP invocation

```json
{
  "tool": "manage_storage",
  "app_id": "app_abc123",
  "action": "update_config",
  "storageLimitBytes": 5368709120
}
```

## Test plan

- [ ] `PATCH /v1/:app_id/config/storage` with `{storageLimitBytes: 5368709120}` writes the value to `apps.storage_config` and subsequent uploads enforce the new cap via `checkStorageQuota`
- [ ] Same PATCH with a value above the app's plan cap returns 400 `VALIDATION_INVALID_SCHEMA` with `plan_cap_bytes` in details
- [ ] Empty body `{}` returns 400 with the "at least one of" message
- [ ] `publicReadEnabled`-only PATCH still works (regression)
- [ ] MCP `manage_storage` action `update_config` with `storageLimitBytes` round-trips through the control-api