### PR TITLE
fix(clone): resume mid-stage clone jobs + reaper + failure emails

### DIFF
--- a/services/control-api/src/__tests__/clone-jobs-reaper.test.ts
+++ b/services/control-api/src/__tests__/clone-jobs-reaper.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/runtime-db.js', () => ({
+  getRuntimeDbPool: vi.fn(() => ({ query: vi.fn().mockResolvedValue({ rows: [] }) })),
+}));
+
+vi.mock('../services/failure-notifications.service.js', () => ({
+  notifyCloneFailed: vi.fn().mockResolvedValue(undefined),
+  notifyCloneReaperDigest: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/audit/audit-events-service.js', () => ({
+  insertCloneAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../config.js', () => ({
+  config: { runtimeDb: {} },
+}));
+
+describe('clone-jobs-reaper: guard behavior', () => {
+  it('isTerminalCloneStatus correctly identifies terminal vs resumable statuses', async () => {
+    const { isTerminalCloneStatus } = await import('../services/clone-jobs.js');
+    expect(isTerminalCloneStatus('completed')).toBe(true);
+    expect(isTerminalCloneStatus('failed')).toBe(true);
+    expect(isTerminalCloneStatus('pending')).toBe(false);
+    expect(isTerminalCloneStatus('processing')).toBe(false);
+    expect(isTerminalCloneStatus('replaying_schema')).toBe(false);
+    expect(isTerminalCloneStatus('replaying_rls')).toBe(false);
+    expect(isTerminalCloneStatus('seeding_data')).toBe(false);
+    expect(isTerminalCloneStatus('replaying_functions')).toBe(false);
+    expect(isTerminalCloneStatus('replaying_config')).toBe(false);
+    expect(isTerminalCloneStatus('copying_repo')).toBe(false);
+  });
+});
+
+describe('clone-jobs-reaper: runOnce', () => {
+  let controlDb: { query: ReturnType<typeof vi.fn> };
+  let logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    controlDb = { query: vi.fn() };
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    vi.clearAllMocks();
+  });
+
+  it('reaps stuck jobs older than 15 minutes and returns their ids', async () => {
+    const stuckRow = {
+      id: 'cj_stuck',
+      source_app_id: 'app_src',
+      dest_app_id: 'app_dst',
+      dest_region: 'us-east-1',
+      status: 'replaying_rls',
+      requested_by_user_id: 'user_1',
+      updated_at: new Date(Date.now() - 30 * 60_000),
+      age_minutes: '30',
+    };
+    // First call: fetchCandidates. Second call: setCloneJobStatus.
+    controlDb.query
+      .mockResolvedValueOnce({ rows: [stuckRow] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const { getRuntimeDbPool } = await import('../services/runtime-db.js');
+    // No live neon_task for this job
+    (getRuntimeDbPool as any).mockReturnValue({
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    });
+
+    const { runOnce } = await import('../services/clone-jobs-reaper.js');
+    const result = await runOnce(controlDb as any, logger as any);
+
+    expect(result.reapedJobIds).toEqual(['cj_stuck']);
+    expect(result.details[0]).toMatchObject({
+      jobId: 'cj_stuck',
+      destAppId: 'app_dst',
+      stalledStage: 'replaying_rls',
+      ageMinutes: 30,
+    });
+
+    // The setCloneJobStatus call — check we asked for status='failed'
+    const updateCall = controlDb.query.mock.calls[1];
+    expect(updateCall[0]).toContain('UPDATE template_clone_jobs');
+    expect(updateCall[1]).toContain('failed');
+  });
+
+  it('leaves a stuck job alone when a live neon_task exists in its region', async () => {
+    const stuckRow = {
+      id: 'cj_still_running',
+      source_app_id: 'app_src',
+      dest_app_id: 'app_dst',
+      dest_region: 'us-east-1',
+      status: 'replaying_schema',
+      requested_by_user_id: 'user_1',
+      updated_at: new Date(Date.now() - 20 * 60_000),
+      age_minutes: '20',
+    };
+    controlDb.query.mockResolvedValueOnce({ rows: [stuckRow] });
+
+    const { getRuntimeDbPool } = await import('../services/runtime-db.js');
+    (getRuntimeDbPool as any).mockReturnValue({
+      query: vi.fn().mockResolvedValue({ rows: [{ id: 42 }] }),
+    });
+
+    const { runOnce } = await import('../services/clone-jobs-reaper.js');
+    const result = await runOnce(controlDb as any, logger as any);
+
+    expect(result.reapedJobIds).toEqual([]);
+    // fetchCandidates only, no UPDATE
+    expect(controlDb.query).toHaveBeenCalledOnce();
+  });
+
+  it('sends the digest email exactly once when at least one job was reaped', async () => {
+    controlDb.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'cj_a',
+          source_app_id: 'app_src',
+          dest_app_id: 'app_dst',
+          dest_region: 'us-east-1',
+          status: 'replaying_rls',
+          requested_by_user_id: 'user_1',
+          updated_at: new Date(Date.now() - 30 * 60_000),
+          age_minutes: '30',
+        }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const { getRuntimeDbPool } = await import('../services/runtime-db.js');
+    (getRuntimeDbPool as any).mockReturnValue({
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    });
+
+    const { notifyCloneReaperDigest } = await import('../services/failure-notifications.service.js');
+    const { runOnce } = await import('../services/clone-jobs-reaper.js');
+    await runOnce(controlDb as any, logger as any);
+    expect(notifyCloneReaperDigest).toHaveBeenCalledOnce();
+  });
+
+  it('does not send the digest email when nothing was reaped', async () => {
+    controlDb.query.mockResolvedValueOnce({ rows: [] });
+    const { notifyCloneReaperDigest } = await import('../services/failure-notifications.service.js');
+    const { runOnce } = await import('../services/clone-jobs-reaper.js');
+    await runOnce(controlDb as any, logger as any);
+    expect(notifyCloneReaperDigest).not.toHaveBeenCalled();
+  });
+
+  it('assumes live (skips reap) when the runtime lookup errors', async () => {
+    controlDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'cj_lookup_fail',
+        source_app_id: 'app_src',
+        dest_app_id: 'app_dst',
+        dest_region: 'us-east-1',
+        status: 'replaying_rls',
+        requested_by_user_id: 'user_1',
+        updated_at: new Date(Date.now() - 30 * 60_000),
+        age_minutes: '30',
+      }],
+    });
+
+    const { getRuntimeDbPool } = await import('../services/runtime-db.js');
+    (getRuntimeDbPool as any).mockReturnValue({
+      query: vi.fn().mockRejectedValue(new Error('region unreachable')),
+    });
+
+    const { runOnce } = await import('../services/clone-jobs-reaper.js');
+    const result = await runOnce(controlDb as any, logger as any);
+    expect(result.reapedJobIds).toEqual([]);
+  });
+});
+
+describe('clone-jobs-reaper: startCloneJobsReaper / stop', () => {
+  it('stop() resolves without hanging', async () => {
+    const { startCloneJobsReaper } = await import('../services/clone-jobs-reaper.js');
+    const controlDb = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const handle = startCloneJobsReaper(controlDb as any, logger as any, 50_000);
+    await handle.stop();
+  });
+});

--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -73,6 +73,7 @@ import { startVideoSweeper } from './services/ai-router/video-sweeper.js';
 import { startResponsesSweeper } from './services/ai-router/responses-sweeper.js';
 import { startForkCountSweeper } from './services/fork-count-sweeper.js';
 import { startCloneJobsPruner } from './services/clone-jobs-pruner.js';
+import { startCloneJobsReaper } from './services/clone-jobs-reaper.js';
 import { startCloneWebhookSweeper } from './services/clone-webhook-sweeper.js';
 import { gatewayRoutes } from './routes/gateway.js';
 import { aiMeetingsRoutes } from './routes/ai-meetings.js';
@@ -747,6 +748,9 @@ if (process.env.NODE_ENV !== 'test') {
       if ((app as any).cloneJobsPrunerHandle) {
         await (app as any).cloneJobsPrunerHandle.stop();
       }
+      if ((app as any).cloneJobsReaperHandle) {
+        await (app as any).cloneJobsReaperHandle.stop();
+      }
       if ((app as any).cloneWebhookSweeperHandle) {
         await (app as any).cloneWebhookSweeperHandle.stop();
       }
@@ -943,6 +947,16 @@ Promise.resolve(app.ready())
       app.log.info('Clone-jobs pruner started (24h interval)');
     }
 
+    // Clone-jobs reaper: flips template_clone_jobs stuck in a mid-stage
+    // status (>15 min, no live neon_task) to 'failed' and notifies the
+    // owner + ops. Backstops the neon_tasks retry logic for scenarios
+    // where a control-api instance died mid-pipeline (runs every 5 min).
+    if (process.env.SKIP_CLONE_JOBS_REAPER !== '1') {
+      const cloneJobsReaperHandle = startCloneJobsReaper(app.controlDb, app.log);
+      (app as any).cloneJobsReaperHandle = cloneJobsReaperHandle;
+      app.log.info('Clone-jobs reaper started (5m interval)');
+    }
+
     // Clone-webhook sweeper: delivers clone_webhook_outbox rows with HMAC-SHA256
     // signing and 3-attempt exponential-backoff retry (runs every 30 s).
     if (process.env.SKIP_CLONE_WEBHOOK_SWEEPER !== '1') {
@@ -1009,6 +1023,7 @@ if (process.env.NODE_ENV !== 'test') {
       if ((app as any).forkSweeperHandle) await (app as any).forkSweeperHandle.stop().catch(() => {});
       if ((app as any).responsesSweeperHandle) await (app as any).responsesSweeperHandle.stop().catch(() => {});
       if ((app as any).cloneJobsPrunerHandle) await (app as any).cloneJobsPrunerHandle.stop().catch(() => {});
+      if ((app as any).cloneJobsReaperHandle) await (app as any).cloneJobsReaperHandle.stop().catch(() => {});
       if ((app as any).cloneWebhookSweeperHandle) await (app as any).cloneWebhookSweeperHandle.stop().catch(() => {});
 
       // Timeout: force exit if shutdown hangs

--- a/services/control-api/src/services/auth/email-service.ts
+++ b/services/control-api/src/services/auth/email-service.ts
@@ -152,6 +152,8 @@ export type BillingEmailTemplate =
   | 'hard_limit_exceeded'
   | 'deployment_failed'
   | 'provisioning_failed'
+  | 'clone_failed'
+  | 'clone_reaper_digest'
   | 'function_failed'
   | 'auth_hook_failed'
   | 'auto_refill_failed'
@@ -169,6 +171,8 @@ const BILLING_EMAIL_SUBJECTS: Record<BillingEmailTemplate, string> = {
   hard_limit_exceeded: 'Action Required: Plan Limit Reached',
   deployment_failed: 'Deployment failed',
   provisioning_failed: 'App setup failed',
+  clone_failed: 'Clone failed',
+  clone_reaper_digest: '[butterbase] Clone reaper flipped stuck jobs to failed',
   function_failed: 'A function in your app is failing',
   auth_hook_failed: 'Your auth hook is failing',
   auto_refill_failed: 'Action Required: Auto-Refill Failed',
@@ -285,6 +289,45 @@ export function buildBillingEmailBody(template: BillingEmailTemplate, data: Reco
         '',
         `View app: ${dashboardUrl}/apps/${data.appId}`,
       ].join('\n');
+
+    case 'clone_failed': {
+      const stageLine = data.stalledStage
+        ? `Stalled at stage: ${data.stalledStage}`
+        : '';
+      return [
+        `We couldn't finish cloning "${data.appName || data.appId}" from template ${data.sourceAppId}.`,
+        '',
+        `Job ID: ${data.jobId}`,
+        stageLine,
+        `Error: ${data.errorMessage || '(no message captured)'}`,
+        '',
+        'The destination app was created but the code (frontend + functions) may not be fully in place. You can:',
+        `  • Try cloning again: ${dashboardUrl}/templates`,
+        `  • Delete the partial app: ${dashboardUrl}/apps/${data.appId}`,
+        `  • Contact support if this keeps happening.`,
+      ].filter(Boolean).join('\n');
+    }
+
+    case 'clone_reaper_digest': {
+      let details: Array<{ jobId: string; destAppId: string | null; stalledStage: string; ageMinutes: number }> = [];
+      try {
+        details = JSON.parse(data.detailsJson || '[]');
+      } catch {
+        // Fall through with empty list — the reapedCount is still informative.
+      }
+      const lines: string[] = [
+        `The clone-jobs reaper marked ${data.reapedCount} stuck job(s) as failed this tick.`,
+        '',
+        'This usually means a control-api instance died mid-pipeline (deploy, OOM, or unhandled exception past the neon_tasks max_attempts).',
+        '',
+      ];
+      for (const d of details) {
+        lines.push(`• ${d.jobId} → ${d.destAppId ?? '(no dest)'} — stalled at ${d.stalledStage} (${d.ageMinutes}m)`);
+      }
+      lines.push('');
+      lines.push('Users have been notified individually via clone_failed emails.');
+      return lines.join('\n');
+    }
 
     case 'weekly_digest': {
       const items = parseDigestItems(data.itemsJson);

--- a/services/control-api/src/services/clone-jobs-reaper.ts
+++ b/services/control-api/src/services/clone-jobs-reaper.ts
@@ -1,0 +1,234 @@
+// services/control-api/src/services/clone-jobs-reaper.ts
+//
+// Safety net for template_clone_jobs stuck in a mid-stage status.
+//
+// The neon-task queue already handles retries and permanent-fail for the
+// common case (worker throws → backoff → eventual 'failed' after
+// max_attempts). But some historical failure modes bypass that path
+// entirely: a bug that returned success from executeClone without touching
+// the job status, a control-api instance killed by SIGKILL mid-transaction
+// before the queue could react, or a lost neon_tasks row. This reaper is
+// the backstop.
+//
+// Every REAPER_INTERVAL_MS it looks for template_clone_jobs whose status is
+// neither terminal nor pre-processing (i.e. one of the mid-stage statuses)
+// and whose updated_at is older than STALE_THRESHOLD_MINUTES. For each
+// candidate it checks the dest region's neon_tasks table for a live task
+// row (status pending or processing) — if one exists, the queue is still
+// working on it and we leave it alone. Otherwise we flip the job to
+// 'failed' with a diagnostic error_message, insert the audit event, and
+// notify the dest owner + ops.
+
+import type pg from 'pg';
+import { getRuntimeDbPool } from './runtime-db.js';
+import { config } from '../config.js';
+import { setCloneJobStatus, type CloneJobStatus } from './clone-jobs.js';
+import { insertCloneAuditLog } from './audit/audit-events-service.js';
+import { notifyCloneFailed, notifyCloneReaperDigest } from './failure-notifications.service.js';
+
+const STALE_THRESHOLD_MINUTES = 15;
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+const BATCH_LIMIT = 100;
+const REAP_ERROR_MESSAGE = 'Clone worker abandoned mid-stage; reaped by clone-jobs-reaper.';
+
+export interface ReaperLogger {
+  info(obj: unknown, msg?: string): void;
+  warn(obj: unknown, msg?: string): void;
+  error(obj: unknown, msg?: string): void;
+}
+
+interface Candidate {
+  id: string;
+  source_app_id: string;
+  dest_app_id: string | null;
+  dest_region: string;
+  status: CloneJobStatus;
+  requested_by_user_id: string;
+  updated_at: Date;
+  ageMinutes: number;
+}
+
+async function fetchCandidates(controlDb: Pick<pg.Pool, 'query'>): Promise<Candidate[]> {
+  const res = await controlDb.query<{
+    id: string;
+    source_app_id: string;
+    dest_app_id: string | null;
+    dest_region: string;
+    status: CloneJobStatus;
+    requested_by_user_id: string;
+    updated_at: Date;
+    age_minutes: string;
+  }>(
+    `SELECT id, source_app_id, dest_app_id, dest_region, status, requested_by_user_id, updated_at,
+            EXTRACT(EPOCH FROM (now() - updated_at)) / 60 AS age_minutes
+       FROM template_clone_jobs
+      WHERE status NOT IN ('completed', 'failed', 'pending', 'processing')
+        AND updated_at < now() - interval '${STALE_THRESHOLD_MINUTES} minutes'
+      ORDER BY updated_at ASC
+      LIMIT $1`,
+    [BATCH_LIMIT],
+  );
+  return res.rows.map((r) => ({
+    id: r.id,
+    source_app_id: r.source_app_id,
+    dest_app_id: r.dest_app_id,
+    dest_region: r.dest_region,
+    status: r.status,
+    requested_by_user_id: r.requested_by_user_id,
+    updated_at: r.updated_at,
+    ageMinutes: Math.round(Number(r.age_minutes)),
+  }));
+}
+
+/**
+ * Returns true if the region's neon_tasks table has a pending/processing
+ * clone task for this job. When true, we leave the job alone — the queue
+ * will finish or terminally fail it via the normal path.
+ */
+async function hasLiveNeonTask(
+  region: string,
+  jobId: string,
+  logger: ReaperLogger,
+): Promise<boolean> {
+  try {
+    const runtimePool = getRuntimeDbPool(config.runtimeDb, region);
+    const res = await runtimePool.query<{ id: number }>(
+      `SELECT id FROM neon_tasks
+        WHERE task_type = 'clone'
+          AND status IN ('pending', 'processing')
+          AND task_meta->>'job_id' = $1
+        LIMIT 1`,
+      [jobId],
+    );
+    return res.rows.length > 0;
+  } catch (err) {
+    // On a lookup failure, assume live to be safe — we'd rather leave a
+    // job un-reaped for another tick than falsely flip a running job to failed.
+    logger.warn({ err, region, jobId }, '[clone-jobs-reaper] neon_tasks lookup failed; assuming live');
+    return true;
+  }
+}
+
+export async function runOnce(
+  controlDb: pg.Pool,
+  logger: ReaperLogger,
+): Promise<{ reapedJobIds: string[]; details: Array<{ jobId: string; destAppId: string | null; stalledStage: string; ageMinutes: number }> }> {
+  const candidates = await fetchCandidates(controlDb);
+  const reapedJobIds: string[] = [];
+  const details: Array<{ jobId: string; destAppId: string | null; stalledStage: string; ageMinutes: number }> = [];
+
+  for (const c of candidates) {
+    if (await hasLiveNeonTask(c.dest_region, c.id, logger)) {
+      logger.info({ jobId: c.id, status: c.status, ageMinutes: c.ageMinutes }, '[clone-jobs-reaper] skipping; live neon_task exists');
+      continue;
+    }
+
+    const errorMessage = `${REAP_ERROR_MESSAGE} (stage: ${c.status}, age: ${c.ageMinutes}m)`;
+    try {
+      await setCloneJobStatus(controlDb, c.id, {
+        status: 'failed',
+        error_message: errorMessage,
+        completed_at: new Date(),
+      });
+    } catch (err) {
+      logger.error({ err, jobId: c.id }, '[clone-jobs-reaper] failed to mark job failed; skipping notifications');
+      continue;
+    }
+
+    logger.error(
+      { jobId: c.id, destAppId: c.dest_app_id, stalledStage: c.status, ageMinutes: c.ageMinutes },
+      '[clone] reaper: stalled job',
+    );
+
+    // Audit event on source app so template owners see the failure signal too.
+    insertCloneAuditLog(controlDb, {
+      appId: c.source_app_id,
+      userId: c.requested_by_user_id,
+      eventType: 'template_clone_failed',
+      metadata: {
+        job_id: c.id,
+        dest_app_id: c.dest_app_id,
+        dest_region: c.dest_region,
+        error: errorMessage,
+        reaped: true,
+        stalled_stage: c.status,
+      },
+    }).catch((auditErr) => logger.error({ auditErr, jobId: c.id }, '[clone-jobs-reaper] audit insert failed'));
+
+    // Notify the dest owner + ops. Only when a dest_app_id exists — otherwise
+    // there's no owner to look up. The ops-alert path inside notifyCloneFailed
+    // still fires via the separate dedup key.
+    if (c.dest_app_id) {
+      const destRuntimePool = getRuntimeDbPool(config.runtimeDb, c.dest_region);
+      notifyCloneFailed(
+        controlDb,
+        destRuntimePool,
+        {
+          appId: c.dest_app_id,
+          jobId: c.id,
+          sourceAppId: c.source_app_id,
+          errorMessage,
+          stalledStage: c.status,
+        },
+        logger,
+      ).catch((notifyErr) => logger.error({ notifyErr, jobId: c.id }, '[clone-jobs-reaper] notifyCloneFailed failed'));
+    }
+
+    reapedJobIds.push(c.id);
+    details.push({
+      jobId: c.id,
+      destAppId: c.dest_app_id,
+      stalledStage: c.status,
+      ageMinutes: c.ageMinutes,
+    });
+  }
+
+  if (reapedJobIds.length > 0) {
+    logger.warn(
+      { reapedCount: reapedJobIds.length, jobIds: reapedJobIds },
+      '[clone-jobs-reaper] reaped stuck jobs',
+    );
+    notifyCloneReaperDigest({ reapedJobIds, details }, logger).catch((err) =>
+      logger.error({ err }, '[clone-jobs-reaper] digest send failed'),
+    );
+  }
+
+  return { reapedJobIds, details };
+}
+
+export function startCloneJobsReaper(
+  controlDb: pg.Pool,
+  logger: ReaperLogger,
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+): { stop(): Promise<void> } {
+  let running = true;
+  let currentTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeRun: Promise<void> | null = null;
+
+  async function tick(): Promise<void> {
+    if (!running) return;
+    try {
+      await runOnce(controlDb, logger);
+    } catch (err) {
+      logger.error({ err }, '[clone-jobs-reaper] tick failed');
+    } finally {
+      if (running) {
+        currentTimer = setTimeout(() => {
+          activeRun = tick();
+        }, intervalMs);
+      }
+    }
+  }
+
+  logger.info({ intervalMs }, '[clone-jobs-reaper] started');
+  activeRun = tick();
+
+  return {
+    async stop() {
+      running = false;
+      if (currentTimer !== null) clearTimeout(currentTimer);
+      if (activeRun) await activeRun.catch(() => {});
+      logger.info({}, '[clone-jobs-reaper] stopped');
+    },
+  };
+}

--- a/services/control-api/src/services/clone-jobs.ts
+++ b/services/control-api/src/services/clone-jobs.ts
@@ -14,6 +14,19 @@ export type CloneJobStatus =
   | 'completed'
   | 'failed';
 
+/**
+ * Statuses at which the pipeline is finished for good. Any other status —
+ * including mid-flight ones like 'replaying_rls' — is resumable and must NOT
+ * short-circuit executeClone on retry (see neon-task-worker.ts). A prior
+ * version of the re-entry guard treated everything except 'pending'/'processing'
+ * as terminal, which silently orphaned jobs after their first mid-stage crash.
+ */
+export const TERMINAL_CLONE_STATUSES: ReadonlyArray<CloneJobStatus> = ['completed', 'failed'];
+
+export function isTerminalCloneStatus(status: CloneJobStatus): boolean {
+  return TERMINAL_CLONE_STATUSES.includes(status);
+}
+
 export interface CloneJob {
   id: string;
   source_app_id: string;

--- a/services/control-api/src/services/failure-notifications.service.ts
+++ b/services/control-api/src/services/failure-notifications.service.ts
@@ -92,6 +92,108 @@ export async function notifyDeploymentFailed(
 }
 
 /**
+ * Clone job failed — called from neon-task-worker.ts (terminal fail path) and
+ * from the clone-jobs reaper. Dedup key: failure_notif:clone:{jobId} — once
+ * per job attempt lifetime (a job that terminally fails via the worker and
+ * then also gets swept by the reaper produces one email, not two).
+ *
+ * Also CCs an ops-side alert to OPS_ALERT_EMAIL (defaults to ken@butterbase.ai)
+ * with a separate dedup key so operator visibility isn't gated by the user
+ * email's silence rules or dedup.
+ */
+export async function notifyCloneFailed(
+  controlPool: Pool,
+  runtimePool: Pool,
+  args: {
+    appId: string;
+    jobId: string;
+    sourceAppId: string;
+    errorMessage: string;
+    stalledStage?: string;
+  },
+  log?: { warn: (payload: Record<string, unknown>, message: string) => void }
+): Promise<void> {
+  // Ops alert: fire independently of the user email so operators still see the
+  // failure when the dest app has no owner, is deleted, or has silences on.
+  const opsRecipient = process.env.OPS_ALERT_EMAIL || 'ken@butterbase.ai';
+  const opsKey = `failure_notif:clone:ops:${args.jobId}`;
+  try {
+    const opsSet = await getRedisClient().set(opsKey, '1', 'EX', NOTIF_TTL_SECONDS, 'NX');
+    if (opsSet) {
+      await sendBillingEmail(opsRecipient, 'clone_failed', {
+        appId: args.appId,
+        appName: `(ops alert) ${args.appId}`,
+        sourceAppId: args.sourceAppId,
+        jobId: args.jobId,
+        errorMessage: args.errorMessage,
+        stalledStage: args.stalledStage || '',
+      }).catch((err) => {
+        log?.warn({ err, jobId: args.jobId }, 'failure-notifications: clone ops send failed');
+      });
+    }
+  } catch {
+    // Don't let ops-alert plumbing break the user email path below.
+  }
+
+  const key = `failure_notif:clone:${args.jobId}`;
+  try {
+    const wasSet = await getRedisClient().set(key, '1', 'EX', NOTIF_TTL_SECONDS, 'NX');
+    if (!wasSet) return;
+
+    const owner = await getOwnerEmailAndAppName(controlPool, runtimePool, args.appId);
+    if (!owner) {
+      log?.warn({ appId: args.appId, jobId: args.jobId }, 'failure-notifications: clone skipped (no owner email)');
+      await getRedisClient().del(key).catch(() => {});
+      return;
+    }
+
+    await sendBillingEmail(owner.email, 'clone_failed', {
+      appId: args.appId,
+      appName: owner.appName,
+      sourceAppId: args.sourceAppId,
+      jobId: args.jobId,
+      errorMessage: args.errorMessage,
+      stalledStage: args.stalledStage || '',
+    }, {
+      controlPool,
+      userId: owner.userId,
+      scope: { appId: args.appId },
+    }).catch((err) => {
+      log?.warn({ err, appId: args.appId, jobId: args.jobId }, 'failure-notifications: clone send failed');
+    });
+  } catch {
+    // Notifications must never block their callers.
+  }
+}
+
+/**
+ * Send an ops-only digest when the clone-jobs reaper flips one or more
+ * stuck jobs to 'failed' in a single tick. Complements the per-job
+ * notifyCloneFailed emails: if 10 jobs get reaped in one tick you want
+ * one summary in the ops inbox in addition to the 10 individual emails,
+ * because a multi-job reap points at a systemic issue (worker crash,
+ * deploy race, region outage) that the individual emails don't convey.
+ * No dedup — every non-empty reap tick sends one email.
+ */
+export async function notifyCloneReaperDigest(
+  args: { reapedJobIds: string[]; details: Array<{ jobId: string; destAppId: string | null; stalledStage: string; ageMinutes: number }> },
+  log?: { warn: (payload: Record<string, unknown>, message: string) => void }
+): Promise<void> {
+  if (args.reapedJobIds.length === 0) return;
+  const opsRecipient = process.env.OPS_ALERT_EMAIL || 'ken@butterbase.ai';
+  try {
+    await sendBillingEmail(opsRecipient, 'clone_reaper_digest', {
+      reapedCount: String(args.reapedJobIds.length),
+      detailsJson: JSON.stringify(args.details),
+    }).catch((err) => {
+      log?.warn({ err, reapedCount: args.reapedJobIds.length }, 'failure-notifications: reaper digest send failed');
+    });
+  } catch {
+    // Non-fatal
+  }
+}
+
+/**
  * App provisioning failed — synchronous, called from provisioner.ts and neon-task-worker.ts.
  * Dedup key: failure_notif:provision:{appId}:{UTC date} — once per app per day.
  */

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -7,10 +7,10 @@ import * as neonClient from './neon-client.js';
 import { getDataProjectIdForRegion } from './neon-projects.js';
 import { runMigrationsWithRetry, generateAppId, insertAppRow, provisionAppBackground } from './provisioner.js';
 import { runDataPlaneMigrations } from './migrator.js';
-import { notifyProvisioningFailed } from './failure-notifications.service.js';
+import { notifyProvisioningFailed, notifyCloneFailed } from './failure-notifications.service.js';
 import { addOrgAppIndex, removeOrgAppIndex } from './org-app-index.js';
 import { resolveOrganizationId } from './org-resolver.js';
-import { getCloneJob, setCloneJobStatus, appendCloneJobWarnings } from './clone-jobs.js';
+import { getCloneJob, setCloneJobStatus, appendCloneJobWarnings, isTerminalCloneStatus } from './clone-jobs.js';
 import {
   getManifestJson,
   putManifest,
@@ -434,10 +434,15 @@ async function executeClone(
 
   const job = await getCloneJob(controlDb, jobId);
   if (!job) throw new Error(`Clone job ${jobId} not found`);
-  if (job.status !== 'pending' && job.status !== 'processing') {
+  if (isTerminalCloneStatus(job.status)) {
     logger.info({ jobId, status: job.status }, '[clone] job in terminal status; skipping');
     return;
   }
+  // Any non-terminal status (including mid-stage: replaying_schema, replaying_rls,
+  // seeding_data, replaying_functions, replaying_config, copying_repo) is a
+  // resumable state. Each stage below is idempotent and its own guard decides
+  // whether to skip or redo the work.
+  const resumedFromStatus = job.status;
 
   await setCloneJobStatus(controlDb, jobId, { status: 'processing' });
 
@@ -456,6 +461,8 @@ async function executeClone(
     scope.setTag('clone_job_id', jobId);
     scope.setTag('source_app_id', job.source_app_id);
     scope.setTag('target_app_id', 'pending');
+    scope.setTag('resumed_from_status', resumedFromStatus);
+    scope.setTag('attempt', String(task.attempts));
 
     try {
       scope.setTag('step', 'provisioning');
@@ -1013,6 +1020,27 @@ async function executeClone(
           eventType: 'template_clone_failed',
           metadata: { job_id: jobId, dest_app_id: destAppId ?? null, dest_region: job.dest_region, error: msg },
         }).catch((auditErr) => logger.error({ auditErr }, '[clone] audit log failed event insert failed'));
+
+        // Notify the dest owner (and ops) that their clone permanently failed. The dest app
+        // exists at this point (destAppId is set once provisioning succeeds); if provisioning
+        // itself failed, notifyProvisioningFailed already fired from the same catch path via
+        // the ambient provisioning task, so we skip to avoid a duplicate email.
+        if (destAppId) {
+          const destRuntimePool = await getRuntimeDbForApp(controlDb, destAppId).catch(() => null);
+          if (destRuntimePool) {
+            notifyCloneFailed(
+              controlDb,
+              destRuntimePool,
+              {
+                appId: destAppId,
+                jobId,
+                sourceAppId: job.source_app_id,
+                errorMessage: msg,
+              },
+              logger,
+            ).catch((notifyErr) => logger.error({ notifyErr, jobId }, '[clone] notifyCloneFailed failed'));
+          }
+        }
       } else {
         // Surface the last error to the user but keep the job alive for the next attempt.
         await setCloneJobStatus(controlDb, jobId, { error_message: msg }).catch(() => {});


### PR DESCRIPTION
## Summary

Root cause of silently-orphaned clones (`cj_enduvS0kZGhzicBGLjhItAZZ` and two June-8 rows): `executeClone` treated any status !== `pending`/`processing` as terminal and returned early. On retry after a mid-stage crash (status `replaying_rls`, etc.) the guard fired, the neon_tasks queue marked the task `completed`, and the job silently stalled — no `error_message`, no email, no reaper.

This PR is the full fix: guard, resume, notify, reap.

## Changes

- **Guard fix** (`services/clone-jobs.ts`, `services/neon-task-worker.ts`): introduce `TERMINAL_CLONE_STATUSES = ['completed','failed']` + `isTerminalCloneStatus`. The re-entry guard in `executeClone` uses it so mid-stage statuses are correctly treated as resumable. Sentry scope now tags `resumed_from_status` + `attempt`.
- **Terminal-fail email hook** (`services/neon-task-worker.ts`): when `attempts >= max_attempts`, call `notifyCloneFailed` for the dest owner + ops.
- **`notifyCloneFailed`** (`services/failure-notifications.service.ts`): mirrors `notifyProvisioningFailed`. Redis dedup key `failure_notif:clone:{jobId}`. Ops-alert path CCs `OPS_ALERT_EMAIL` (default `ken@butterbase.ai`) with a separate dedup key so operator visibility isn't gated by user silences.
- **`notifyCloneReaperDigest`** (same file): one summary ops email per non-empty reap tick — a multi-job reap points at a systemic issue, not a per-user problem.
- **Email templates** (`services/auth/email-service.ts`): add `clone_failed` and `clone_reaper_digest` to the `BillingEmailTemplate` union, subject map, and text body switch. HTML variants can follow.
- **Reaper** (new — `services/clone-jobs-reaper.ts`): every 5 min, flips `template_clone_jobs` stuck in a mid-stage status (>15 min, no live `neon_task` in the dest region) to `failed`, writes a diagnostic `error_message`, inserts the `template_clone_failed` audit event, and fires `notifyCloneFailed` + digest.
- **Wiring** (`services/control-api/src/index.ts`): register `startCloneJobsReaper` alongside `startCloneJobsPruner`. Clean shutdown in both `onClose` and the signal handler. Gated by `SKIP_CLONE_JOBS_REAPER=1`.
- **Tests** (`__tests__/clone-jobs-reaper.test.ts`): 7 new unit tests covering `isTerminalCloneStatus` truth table + reaper reap / skip-when-live / digest-once / no-digest-when-empty / lookup-error-safe / start-stop.

## Backfill

None needed. The three known orphans (`cj_enduvS0kZGhzicBGLjhItAZZ` and the two June-8 rows stuck in `replaying_schema`) will be swept on the first reaper tick after deploy — all >15 min old.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm vitest run src/__tests__/clone-jobs-reaper.test.ts src/__tests__/clone-jobs-pruner.test.ts` — 10/10 pass
- [ ] Manual: after deploy, verify a summary ops email arrives at `ken@butterbase.ai` and the three orphan jobs flip to `failed` with a diagnostic `error_message`
- [ ] Manual: verify a fresh clone against the same template succeeds end-to-end