### PR TITLE
feat(admin): return signup_source + signup_referrer on /admin/users

### DIFF
--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -219,7 +219,8 @@ export async function adminRoutes(app: FastifyInstance) {
     // Fetch platform_users from controlDb (platform tier)
     const usersResult = await app.controlDb.query(
       `SELECT pu.id, pu.email, pu.display_name, o.plan_id, o.account_status,
-              o.stripe_customer_id, pu.created_at
+              o.stripe_customer_id, pu.created_at,
+              pu.signup_source, pu.signup_referrer
        FROM platform_users pu
        LEFT JOIN organizations o ON o.id = pu.personal_organization_id
        ${controlWhere}
@@ -938,6 +939,7 @@ export async function adminRoutes(app: FastifyInstance) {
     const [userResult, suggestionsResult] = await Promise.all([
       app.controlDb.query(
         `SELECT pu.id, pu.email, pu.display_name, pu.created_at,
+                pu.signup_source, pu.signup_referrer,
                 o.plan_id, o.account_status, o.stripe_customer_id
          FROM platform_users pu
          LEFT JOIN organizations o ON o.id = pu.personal_organization_id


### PR DESCRIPTION
## Summary

Surfaces first-touch signup attribution on the admin users routes so marketing can see which UTM/referrer a signup came from.

- \`GET /admin/users\`: SELECT adds \`pu.signup_source, pu.signup_referrer\`.
- \`GET /admin/users/:id\`: SELECT adds the same two columns to the user profile block.

Both columns already exist in \`platform_users\` (\`086_signup_source.sql\`, written on INSERT by the auth plugin — commit fab04ae). This is purely the read side.

Old dashboards ignoring the extra fields keep working; the new admin dashboard consumes them (butterbase-internal follow-up PR).

## Test plan

- [x] \`tsc --noEmit\` clean.
- [ ] Post-deploy: hit \`admin.butterbase.ai/users\`, confirm the new columns render on the row for yogitasen2020@gmail.com (backfilled with a demo \`utm_source=twitter\` value).