### PR TITLE
fix(dashboard-proxy): forward x-signup-source and x-signup-referrer

### DIFF
--- a/services/control-api/src/plugins/dashboard-proxy.ts
+++ b/services/control-api/src/plugins/dashboard-proxy.ts
@@ -25,6 +25,14 @@ const dashboardProxyPlugin: FastifyPluginAsync = async (fastify) => {
     if (typeof orgHeader === 'string' && orgHeader) headers['x-organization-id'] = orgHeader;
     const asUser = request.headers['x-butterbase-as-user'];
     if (typeof asUser === 'string' && asUser) headers['x-butterbase-as-user'] = asUser;
+    // Forward first-touch signup attribution headers so dashboard-api's auth
+    // middleware can persist them on the platform_users INSERT. Without this
+    // pass-through the browser's captured utm_* values are dropped at the
+    // proxy boundary and every new signup gets signup_source = NULL.
+    const signupSource = request.headers['x-signup-source'];
+    if (typeof signupSource === 'string' && signupSource) headers['x-signup-source'] = signupSource;
+    const signupReferrer = request.headers['x-signup-referrer'];
+    if (typeof signupReferrer === 'string' && signupReferrer) headers['x-signup-referrer'] = signupReferrer;
 
     const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
 


### PR DESCRIPTION
## Summary

The \`/dashboard/*\` proxy in \`control-api\` explicitly opts in which headers to forward to \`dashboard-api\`. \`X-Signup-Source\` and \`X-Signup-Referrer\` weren't on that allowlist, so they were silently stripped at the proxy boundary. \`dashboard-api\`'s auth middleware then saw no headers and INSERTed every new \`platform_users\` row with \`signup_source = NULL\`.

**Net effect: signup attribution has been non-functional since fab04ae shipped.** Every signup that went through the standard \`dashboard.butterbase.ai\` flow lost its utm_* + referrer.

## Diff

Adds 2 pass-throughs, symmetric with the existing \`x-organization-id\` and \`x-butterbase-as-user\` ones — same opt-in pattern, same if-defined-forward shape. 8 lines.

## Test plan

- [x] Local docker-compose: signup click through \`docs/marketing/demo/hearth-blog.html\` → \`platform_users.signup_source = 'utm_source=hearth-blog&...'\`. Previously landed as NULL.
- [x] \`tsc --noEmit\` clean.
- [ ] Post-deploy: fresh signup on prod dashboard through a UTM'd link → check row on \`admin.butterbase.ai/attribution\`.

## Backfill note

Existing \`signup_source IS NULL\` rows in prod cannot be recovered — the header was never captured for them. Only signups after this fix deploys will have real attribution.