### PR TITLE
feat(init): accept organization_id on POST /init and init_app MCP tool

### DIFF
--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -8,7 +8,7 @@ import { quotaErrors } from '../utils/quota-errors.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
 import { getDataProjectIdForRegion } from '../services/neon-projects.js';
 import { addOrgAppIndex, removeOrgAppIndex, listUserApps } from '../services/org-app-index.js';
-import { resolveOrganizationId } from '../services/org-resolver.js';
+import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
 import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
 
 const initSchema = {
@@ -29,6 +29,10 @@ const initSchema = {
         pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$',
       },
       region: {
+        type: 'string',
+        minLength: 1,
+      },
+      organization_id: {
         type: 'string',
         minLength: 1,
       },
@@ -253,7 +257,22 @@ export async function initRoutes(app: FastifyInstance) {
       [subdomain, appId]
     );
 
-    const orgId = await resolveOrganizationId(app.controlDb, ownerId);
+    // Resolve target org. Precedence:
+    //   1. Explicit body.organization_id — gated by membership check.
+    //   2. Auth-bound org (bb_sk_* key's org, or JWT x-organization-id).
+    //   3. Caller's personal org.
+    // NOTE: for now we only check membership, not per-key scope — a bb_sk_*
+    // key can create an app in any org its owning user belongs to. Tighten
+    // later if we want strict per-key org locking.
+    const bodyOrgId = (request.body as { organization_id?: string }).organization_id;
+    let orgId: string;
+    if (bodyOrgId) {
+      await assertOrgMember(app.controlDb, ownerId, bodyOrgId);
+      orgId = bodyOrgId;
+    } else {
+      orgId = request.auth?.organizationId
+        ?? await resolveOrganizationId(app.controlDb, ownerId);
+    }
     await addOrgAppIndex(app.controlDb, {
       organizationId: orgId,
       appId,

--- a/services/control-api/src/services/org-resolver.ts
+++ b/services/control-api/src/services/org-resolver.ts
@@ -1,5 +1,5 @@
 import type { Pool } from 'pg';
-import { NotFoundError } from './api-errors.js';
+import { NotFoundError, AuthorizationError } from './api-errors.js';
 
 /**
  * Resolve the caller's personal organization id for org-scoped inserts.
@@ -26,4 +26,26 @@ export async function resolveOrganizationId(pool: Pool, userId: string): Promise
     throw new Error(`resolveOrganizationId: user ${userId} has no personal_organization_id`);
   }
   return orgId;
+}
+
+/**
+ * Assert that `userId` is a member of `orgId`. Throws AuthorizationError (403)
+ * otherwise. Use when a caller supplies an explicit target org (e.g. body
+ * `organization_id` on `/init`) and we need to gate the write on membership.
+ *
+ * NOTE: this only checks membership, not per-key scope. A bb_sk_* key bound
+ * to org X can currently create resources in any org its owning user belongs
+ * to. Tighten later if strict per-key scoping is required.
+ */
+export async function assertOrgMember(pool: Pool, userId: string, orgId: string): Promise<void> {
+  const result = await pool.query(
+    'SELECT 1 FROM organization_members WHERE organization_id = $1 AND user_id = $2 LIMIT 1',
+    [orgId, userId],
+  );
+  if (result.rowCount === 0) {
+    throw new AuthorizationError(
+      `user is not a member of organization ${orgId}`,
+      'AUTH_ORG_FORBIDDEN',
+    );
+  }
 }

--- a/services/mcp-server/src/tools/init-app.ts
+++ b/services/mcp-server/src/tools/init-app.ts
@@ -43,6 +43,7 @@ The response includes _meta.next_actions with recommended next steps.`,
     {
       name: z.string().min(1).max(63).describe('App name (lowercase alphanumeric, hyphens, underscores)'),
       region: z.string().min(1).optional().describe('Region to provision in (e.g. "us-east-1", "us-west-2"). Defaults to the control-api\'s home region.'),
+      organization_id: z.string().min(1).optional().describe('Organization to create the app under. Requires membership. Defaults to the API key\'s bound org, or the caller\'s personal org.'),
     },
     {
       title: 'Initialize App',
@@ -51,7 +52,7 @@ The response includes _meta.next_actions with recommended next steps.`,
       idempotentHint: false,
       openWorldHint: true,
     },
-    async ({ name, region }) => {
+    async ({ name, region, organization_id }) => {
       // Auto-slugify: "My Cool App" → "my-cool-app"
       const slug = name
         .toLowerCase()
@@ -61,8 +62,9 @@ The response includes _meta.next_actions with recommended next steps.`,
         .replace(/^[^a-z0-9]+/, '')
         .slice(0, 63);
 
-      const body: { name: string; region?: string } = { name: slug };
+      const body: { name: string; region?: string; organization_id?: string } = { name: slug };
       if (region) body.region = region;
+      if (organization_id) body.organization_id = organization_id;
       const result = await apiPost<InitResponse>('/init', body);
 
       // Poll until provisioned (max ~60s)


### PR DESCRIPTION
## Summary
- Add optional `organization_id` body param on `POST /init`, gated by an `organization_members` check via a new `assertOrgMember` helper.
- Resolution precedence: body `organization_id` (membership-checked) → `request.auth.organizationId` (bb_sk_* bound org or JWT `x-organization-id`) → caller's personal org.
- Mirror the param in the `init_app` MCP tool so agents/CLIs can create team-scoped apps directly.

## Test plan
Smoked end-to-end locally (control-api rebuilt, `/mcp` hit via curl as a real user):
- No `organization_id` → app lands in caller's personal org ✅
- `organization_id` = a team org caller is a member of → app lands in that org ✅
- `organization_id` = an org caller is NOT a member of → `AUTH_ORG_FORBIDDEN` (403) ✅

## Known gap
Membership check only — a `bb_sk_*` key bound to org X can still create an app in any other org its owning user belongs to. Documented in the handler comment; tighten later if strict per-key scoping is desired.