### PR TITLE
fix: per-org monthly allowance + target-org project quota

### DIFF
--- a/db/control-plane/092_clone_jobs_organization_id.sql
+++ b/db/control-plane/092_clone_jobs_organization_id.sql
@@ -1,3 +1,4 @@
+-- @scope: platform
 -- template_clone_jobs.dest_organization_id
 --
 -- Records the org the destination clone should land in. Populated by

--- a/db/control-plane/092_clone_jobs_organization_id.sql
+++ b/db/control-plane/092_clone_jobs_organization_id.sql
@@ -1,0 +1,13 @@
+-- template_clone_jobs.dest_organization_id
+--
+-- Records the org the destination clone should land in. Populated by
+-- POST /v1/templates/:source_app_id/clone from the same precedence used
+-- by /init (body.organization_id → auth.organizationId → personal org).
+-- The worker reads this at insertAppRow / addOrgAppIndex time instead of
+-- re-resolving personal org.
+--
+-- Nullable so pending pre-migration rows keep processing; the worker falls
+-- back to resolveOrganizationId(user) for a NULL value.
+
+ALTER TABLE template_clone_jobs
+  ADD COLUMN IF NOT EXISTS dest_organization_id uuid REFERENCES organizations(id);

--- a/db/control-plane/093_org_monthly_allowance.sql
+++ b/db/control-plane/093_org_monthly_allowance.sql
@@ -1,0 +1,50 @@
+-- @scope: platform
+-- 093: Move monthly credit allowance from per-user to per-org.
+--
+-- Prior model (migration 067): platform_users.monthly_allowance_usd — a single
+-- pool per user, shared across every org the user is a member of. This
+-- conflated personal-org billing with team-org billing:
+--   * downgrading a personal-org paid sub left the user-level $5 in place,
+--     so the dashboard kept showing the credit indefinitely
+--   * the same user-level $5 rendered on every org card the user could see,
+--     making it look like credit "duplicated" across orgs
+--   * a paid team-org sub still ran the reset against personal_organization_id
+--     (see stripe-service.ts handleInvoicePaid), so its allowance leaked back
+--     into the personal pool instead of the team org's own balance
+--
+-- New model: organizations.monthly_allowance_usd. Every subscription is
+-- per-org, so the allowance follows the sub. handleInvoicePaid /
+-- handleSubscriptionUpdated key on subscription.organization_id and reset
+-- THAT org's row.
+--
+-- Backfill preserves existing user balances by moving them to the user's
+-- personal org (the only org that could have been the source under the old
+-- model). Team orgs start at 0.
+--
+-- The per-user column is not dropped in this migration — a follow-up removes
+-- it after readers/writers are cut over (see phase 7). During the interim
+-- writers dual-write for safety; readers prefer the org column.
+
+BEGIN;
+
+-- 1. New column, defaults to 0 so pre-existing orgs (team orgs, playground)
+--    start with no phantom allowance.
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS monthly_allowance_usd NUMERIC(10,4) NOT NULL DEFAULT 0;
+
+-- 2. Backfill from personal orgs only. A user's monthly_allowance_usd came
+--    from resetMonthlyAllowance events whose subject was always their
+--    personal org, so the personal org is the correct destination.
+--    UPDATE is idempotent (rerun-safe) because it copies the current value.
+UPDATE organizations o
+   SET monthly_allowance_usd = pu.monthly_allowance_usd
+  FROM platform_users pu
+ WHERE pu.personal_organization_id = o.id
+   AND pu.monthly_allowance_usd > 0
+   AND o.monthly_allowance_usd = 0;  -- don't clobber a value another writer set
+
+-- 3. monthly_credit_resets.organization_id already exists (added earlier);
+--    no schema change here. The Stripe handler is patched separately to
+--    populate it for every reset going forward.
+
+COMMIT;

--- a/services/control-api/src/plugins/kv-quota.test.ts
+++ b/services/control-api/src/plugins/kv-quota.test.ts
@@ -140,9 +140,11 @@ beforeEach(async () => {
   // Reset keys counter
   const kvR = wrap(redis);
   await resetKeysCounter(kvR, appId);
-  // Restore credits balance to a positive value (in case a test zeroed it)
+  // Restore credits balance to a positive value (in case a test zeroed it).
+  // Both pools live on organizations post-093.
   await pool.query(
-    `UPDATE platform_users SET monthly_allowance_usd = 10, credits_usd = 0 WHERE id = $1`,
+    `UPDATE organizations SET monthly_allowance_usd = 10, credits_usd = 0
+     WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $1)`,
     [fixture.userId],
   );
 });
@@ -197,7 +199,8 @@ describeDb('kv-quota plugin', () => {
     const app = await buildTestApp(pool);
     try {
       await pool.query(
-        `UPDATE platform_users SET monthly_allowance_usd = 0, credits_usd = 0 WHERE id = $1`,
+        `UPDATE organizations SET monthly_allowance_usd = 0, credits_usd = 0
+         WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $1)`,
         [fixture.userId],
       );
 

--- a/services/control-api/src/plugins/kv-quota.ts
+++ b/services/control-api/src/plugins/kv-quota.ts
@@ -227,12 +227,20 @@ const kvQuotaPlugin: FastifyPluginAsync = async (fastify) => {
 
     // Skip the balance gate when the op has no credit cost (KV is not metered).
     // If creditCostForOp is changed to return a non-zero cost in the future,
-    // the gate re-engages automatically.
+    // the gate re-engages automatically. Per-org billing: check the app's
+    // owning-org balance, not the owner user's personal balance — a team
+    // org that owns the app is what pays.
     if (creditCostForOp(op) > 0) {
-      const bal = await getCreditsBalance(fastify.controlDb, ownerId);
-      if (bal.totalUsd <= 0) {
-        const r = kvCreditsExhausted();
-        return reply.code(r.statusCode).send(r.body);
+      const orgRow = await fastify.controlDb.query<{ organization_id: string }>(
+        'SELECT organization_id FROM org_app_index WHERE app_id = $1',
+        [appId],
+      );
+      if (orgRow.rows.length > 0) {
+        const bal = await getCreditsBalance(fastify.controlDb, orgRow.rows[0].organization_id);
+        if (bal.totalUsd <= 0) {
+          const r = kvCreditsExhausted();
+          return reply.code(r.statusCode).send(r.body);
+        }
       }
     }
 

--- a/services/control-api/src/plugins/quota-enforcement.ts
+++ b/services/control-api/src/plugins/quota-enforcement.ts
@@ -29,6 +29,7 @@ async function refillLease(
   fastify: any,
   runtimePool: Pool,
   userId: string,
+  organizationId: string,
   region: string
 ): Promise<{ amountGranted: number }> {
   const platformRegion = process.env.BUTTERBASE_PLATFORM_REGION;
@@ -37,7 +38,7 @@ async function refillLease(
 
   if (platformRegion === region) {
     const { grantLease } = await import('../services/lease-service.js');
-    const grant = await grantLease(fastify.controlDb, { userId, region, amountUsd: leaseSize, ttlSeconds: ttl });
+    const grant = await grantLease(fastify.controlDb, { userId, organizationId, region, amountUsd: leaseSize, ttlSeconds: ttl });
     if (grant.amountGranted > 0) await applyLease(runtimePool, userId, grant.amountGranted, grant.expiresAt);
     return { amountGranted: grant.amountGranted };
   }
@@ -46,6 +47,7 @@ async function refillLease(
   if (!platformUrl) throw new Error('CONTROL_PLANE_URL_PLATFORM_REGION required');
   const grant = await requestLeaseFromPlatform({
     userId,
+    organizationId,
     amountUsd: leaseSize,
     platformControlApiUrl: platformUrl,
   });
@@ -176,7 +178,7 @@ const quotaEnforcementPlugin: FastifyPluginAsync = async (fastify) => {
 
           let burn = await burnLease(runtimePool, userId, costUsd);
           if (!burn.allowed) {
-            await refillLease(fastify, runtimePool, userId, region);
+            await refillLease(fastify, runtimePool, userId, organizationId, region);
             burn = await burnLease(runtimePool, userId, costUsd);
             if (!burn.allowed) {
               const spendingCap = state!.spending_cap_usd !== null
@@ -191,7 +193,7 @@ const quotaEnforcementPlugin: FastifyPluginAsync = async (fastify) => {
           // Below-threshold proactive refill (fire-and-forget)
           const threshold = requireEnvNumber('BUTTERBASE_LEASE_REFILL_THRESHOLD_USD');
           if (burn.allowed && burn.remaining < threshold) {
-            void refillLease(fastify, runtimePool, userId, region).catch((e) => {
+            void refillLease(fastify, runtimePool, userId, organizationId, region).catch((e) => {
               fastify.log.warn({ e }, 'lease refill failed');
             });
           }

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -1646,9 +1646,9 @@ export async function adminRoutes(app: FastifyInstance) {
       auto_refill_last_attempt_at: Date | null;
       auto_refill_last_failure_reason: string | null;
     }>(
-      // Post-Plan-07: credits_usd + auto_refill_* live on organizations,
-      // monthly_allowance_usd stays on platform_users.
-      `SELECT pu.monthly_allowance_usd::text,
+      // Post-093: monthly_allowance_usd moved to organizations. Reads the
+      // caller's personal-org billing row.
+      `SELECT o.monthly_allowance_usd::text,
               o.credits_usd::text,
               o.auto_refill_enabled,
               o.auto_refill_amount_usd::text,

--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -27,7 +27,7 @@ import { listCatalogModels, readCatalogEntry } from '../services/ai-router/catal
 import type { RouterAdapter } from '../services/ai-router/adapters/types.js';
 import type { RouterName } from '../services/ai-router/normalize.js';
 
-export async function readAutoRefillState(controlPool: pg.Pool, userId: string): Promise<{
+export async function readAutoRefillState(controlPool: pg.Pool, organizationId: string): Promise<{
   enabled: boolean;
   amountUsd: number | null;
   monthlyAllowanceUsd: number;
@@ -39,14 +39,12 @@ export async function readAutoRefillState(controlPool: pg.Pool, userId: string):
     monthly_allowance_usd: string;
     credits_usd: string;
   }>(
-    // Post-093: monthly_allowance_usd now lives on organizations too.
-    // Reads the caller's personal-org row; team-org variants must key on
-    // an explicit orgId once callers thread it through.
-    `SELECT o.auto_refill_enabled, o.auto_refill_amount_usd, o.monthly_allowance_usd, o.credits_usd
-     FROM platform_users pu
-     JOIN organizations o ON o.id = pu.personal_organization_id
-     WHERE pu.id = $1`,
-    [userId]
+    // Per-org (migration 093 + 3b). Caller MUST resolve org upstream —
+    // billing state has no per-user meaning any longer.
+    `SELECT auto_refill_enabled, auto_refill_amount_usd, monthly_allowance_usd, credits_usd
+     FROM organizations
+     WHERE id = $1`,
+    [organizationId]
   );
   if (r.rows.length === 0) {
     return { enabled: false, amountUsd: null, monthlyAllowanceUsd: 0, topupUsd: 0 };
@@ -245,13 +243,18 @@ export async function aiConfigRoutes(app: FastifyInstance) {
     if (!authz.ok) return reply.code(authz.status).send(authz.body);
     const ownerId = authz.ownerId;
 
+    // Resolve the app's owning org up-front so both the success path and the
+    // InsufficientCreditsError catch share the same billing subject. Per-org
+    // billing (Phase 3b): every downstream lease/read is org-scoped.
+    const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
     try {
       const body = chatCompletionSchema.parse(request.body);
 
       // ---- v2 path: multi-router gateway ----
       if (config.aiRouter.enabled) {
         const region = await resolveAppHomeRegion(app.controlDb, appId);
-        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
 
         const modelResolved = body.model
           || (await getAppDefaultModel(runtimePool, appId))
@@ -274,7 +277,7 @@ export async function aiConfigRoutes(app: FastifyInstance) {
           });
         }
 
-        const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
         const result = await routeChatCompletion(
           {
             platformPool: app.controlDb,
@@ -331,7 +334,7 @@ export async function aiConfigRoutes(app: FastifyInstance) {
       // OpenRouterError all satisfy isHttpError and would otherwise escape to
       // the global handler which masks them as a generic 500.
       if (error instanceof InsufficientCreditsError) {
-        const ar = await readAutoRefillState(app.controlDb, ownerId).catch(() => ({
+        const ar = await readAutoRefillState(app.controlDb, organizationId).catch(() => ({
           enabled: false, amountUsd: null, monthlyAllowanceUsd: 0, topupUsd: 0,
         }));
         return reply.code(402).send({
@@ -376,13 +379,17 @@ export async function aiConfigRoutes(app: FastifyInstance) {
     if (!authz.ok) return reply.code(authz.status).send(authz.body);
     const ownerId = authz.ownerId;
 
+    // Per-org billing: resolve the app's owning org before dispatch so the
+    // InsufficientCreditsError catch below reports THAT org's state.
+    const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
     try {
       const body = embeddingSchema.parse(request.body);
 
       // ---- v2 path: multi-router gateway ----
       if (config.aiRouter.enabled) {
         const region = await resolveAppHomeRegion(app.controlDb, appId);
-        const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
 
         const modelResolved = body.model
           || (await getAppDefaultModel(runtimePool, appId))
@@ -396,7 +403,6 @@ export async function aiConfigRoutes(app: FastifyInstance) {
           });
         }
 
-        const organizationId2 = await resolveOrgFromApp(runtimePool, appId);
         const result = await routeEmbedding(
           {
             platformPool: app.controlDb,
@@ -404,7 +410,7 @@ export async function aiConfigRoutes(app: FastifyInstance) {
             redis: getRedisClient(),
             adapters,
             markupPct: config.aiRouter.markupPct,
-            appId, organizationId: organizationId2, userId: ownerId, region,
+            appId, organizationId, userId: ownerId, region,
           },
           { ...body, model: modelResolved }
         );
@@ -424,7 +430,7 @@ export async function aiConfigRoutes(app: FastifyInstance) {
       return reply.code(response.status).send(data);
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
-        const ar = await readAutoRefillState(app.controlDb, ownerId).catch(() => ({
+        const ar = await readAutoRefillState(app.controlDb, organizationId).catch(() => ({
           enabled: false, amountUsd: null, monthlyAllowanceUsd: 0, topupUsd: 0,
         }));
         return reply.code(402).send({

--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -39,9 +39,10 @@ export async function readAutoRefillState(controlPool: pg.Pool, userId: string):
     monthly_allowance_usd: string;
     credits_usd: string;
   }>(
-    // Post-Plan-07: auto_refill_* + credits_usd live on organizations,
-    // monthly_allowance_usd stays on platform_users.
-    `SELECT o.auto_refill_enabled, o.auto_refill_amount_usd, pu.monthly_allowance_usd, o.credits_usd
+    // Post-093: monthly_allowance_usd now lives on organizations too.
+    // Reads the caller's personal-org row; team-org variants must key on
+    // an explicit orgId once callers thread it through.
+    `SELECT o.auto_refill_enabled, o.auto_refill_amount_usd, o.monthly_allowance_usd, o.credits_usd
      FROM platform_users pu
      JOIN organizations o ON o.id = pu.personal_organization_id
      WHERE pu.id = $1`,

--- a/services/control-api/src/routes/ai-meetings.ts
+++ b/services/control-api/src/routes/ai-meetings.ts
@@ -21,10 +21,11 @@ import { logAuditEvent } from '../services/audit/audit-events-service.js';
 import { requireUserId } from '../utils/require-auth.js';
 import { resolveAppHomeRegion, getRuntimeDbForApp } from '../services/region-resolver.js';
 import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
+import { resolveOrgFromApp } from '../services/app-org-resolver.js';
 
 const GATEWAY_SCOPE = 'ai:gateway';
 
-interface GatewayUser { userId: string; appId: string; region: string; }
+interface GatewayUser { userId: string; appId: string; organizationId: string; region: string; }
 
 // appId comes from the URL path (e.g. /v1/:appId/ai/meetings). The route
 // must verify that the authenticated caller owns the app before any
@@ -57,7 +58,11 @@ async function resolveGatewayUser(
     }
     throw err;
   }
-  return { userId, appId, region: config.aiRouter.defaultRegion };
+  // Per-org billing: resolve the app's owning org so downstream credit
+  // reservations debit the correct pool.
+  const runtimePool = await getRuntimeDbForApp((app as any).controlDb, appId);
+  const organizationId = await resolveOrgFromApp(runtimePool, appId);
+  return { userId, appId, organizationId, region: config.aiRouter.defaultRegion };
 }
 
 function openaiError(message: string, type: string, code: string, extra?: Record<string, unknown>) {
@@ -98,7 +103,7 @@ export async function aiMeetingsRoutes(app: FastifyInstance) {
       const body = startMeetingsRequestSchema.parse(req.body);
       const provider = getActorProvider('meetings');
       const handle = await reserveActorCredits((app as any).controlDb, {
-        userId: user.userId, region: user.region,
+        userId: user.userId, organizationId: user.organizationId, region: user.region,
         recordingUsdPerSecond: provider.recordingUsdPerSecond,
         transcriptionUsdPerSecond: provider.transcriptionUsdPerSecond,
         transcript: body.transcript,

--- a/services/control-api/src/routes/ai-videos.ts
+++ b/services/control-api/src/routes/ai-videos.ts
@@ -126,11 +126,12 @@ export async function aiVideoRoutes(app: FastifyInstance) {
     const ownerId = authz.ownerId;
     const endUserSub = authz.caller.kind === 'end_user' ? authz.caller.sub : null;
 
+    const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
     try {
       const body = videoSubmitSchema.parse(request.body);
       const region = await resolveAppHomeRegion(app.controlDb, appId);
-      const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
-      const organizationId = await resolveOrgFromApp(runtimePool, appId);
 
       const submit = await routeVideoSubmit(
         { platformPool: app.controlDb, runtimePool, redis: getRedisClient(),
@@ -173,7 +174,7 @@ export async function aiVideoRoutes(app: FastifyInstance) {
       const publicPollingUrl = `${publicProto(request)}://${publicHost(request)}/v1/${appId}/videos/completions/${jobId}`;
       return reply.code(202).send({ job_id: jobId, status: 'pending', polling_url: publicPollingUrl });
     } catch (error) {
-      return handleVideoError(app, reply, ownerId, error);
+      return handleVideoError(app, reply, organizationId, error);
     }
   });
 
@@ -186,8 +187,10 @@ export async function aiVideoRoutes(app: FastifyInstance) {
     if (!authz.ok) return reply.code(authz.status).send(authz.body);
     const ownerId = authz.ownerId;
 
+    const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
     try {
-      const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
       const job = await getVideoJob(runtimePool, jobId);
       if (!job || job.app_id !== appId) return reply.code(404).send({ error: 'job_not_found', code: 'JOB_NOT_FOUND' });
       // End-users can only see jobs they submitted themselves. 404 (not 403)
@@ -203,7 +206,6 @@ export async function aiVideoRoutes(app: FastifyInstance) {
       }
 
       const region = await resolveAppHomeRegion(app.controlDb, appId);
-      const organizationId = await resolveOrgFromApp(runtimePool, appId);
       const ctx: RouteContext = {
         platformPool: app.controlDb, runtimePool, redis: getRedisClient(),
         adapters, markupPct: parseFloat(job.markup_pct),
@@ -221,7 +223,7 @@ export async function aiVideoRoutes(app: FastifyInstance) {
         polling_url: `${absoluteBase}/v1/${appId}/videos/completions/${jobId}`,
       });
     } catch (error) {
-      return handleVideoError(app, reply, ownerId, error);
+      return handleVideoError(app, reply, organizationId, error);
     }
   });
 
@@ -241,8 +243,10 @@ export async function aiVideoRoutes(app: FastifyInstance) {
       });
     }
 
+    const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtimePool, appId);
+
     try {
-      const runtimePool = await getRuntimeDbForApp(app.controlDb, appId);
       const job = await getVideoJob(runtimePool, jobId);
       if (!job || job.app_id !== appId) return reply.code(404).send({ error: 'job_not_found', code: 'JOB_NOT_FOUND' });
       if (authz.caller.kind === 'end_user' && job.end_user_sub !== authz.caller.sub) {
@@ -262,7 +266,7 @@ export async function aiVideoRoutes(app: FastifyInstance) {
         .header('Content-Type', contentType)
         .send(Readable.fromWeb(stream as any));
     } catch (error) {
-      return handleVideoError(app, reply, ownerId, error);
+      return handleVideoError(app, reply, organizationId, error);
     }
   });
 }
@@ -343,9 +347,9 @@ export function buildPublicJobResponse(absoluteBase: string, appId: string, job:
   };
 }
 
-export async function handleVideoError(app: FastifyInstance, reply: any, userId: string, error: unknown) {
+export async function handleVideoError(app: FastifyInstance, reply: any, organizationId: string, error: unknown) {
   if (error instanceof InsufficientCreditsError) {
-    const ar = await readAutoRefillState(app.controlDb, userId).catch(() => ({
+    const ar = await readAutoRefillState(app.controlDb, organizationId).catch(() => ({
       enabled: false, amountUsd: null, monthlyAllowanceUsd: 0, topupUsd: 0,
     }));
     return reply.code(402).send({

--- a/services/control-api/src/routes/billing.ts
+++ b/services/control-api/src/routes/billing.ts
@@ -227,8 +227,10 @@ export async function billingRoutes(app: FastifyInstance) {
         };
       }
 
-      // Get credits balance — platform_users is controlDb; stays on controlDb
-      const credits = await getCreditsBalance(app.controlDb, userId);
+      // Per-org billing balance (migration 093 + Phase 3b). Keyed on the
+      // resolved billingOrgId, which honors ?org_id when the caller is a
+      // member and otherwise defaults to their personal org.
+      const credits = await getCreditsBalance(app.controlDb, billingOrgId);
       // getSpendingCapStatus reads platform_users+plans (controlDb) and ai_usage_logs (runtime);
       // FIXME: getSpendingCapStatus internally calls getAiCreditsUsed which hits runtimeDb tables
       // (ai_usage_logs, apps). The service function signature must be updated in a follow-on batch.

--- a/services/control-api/src/routes/clone.ts
+++ b/services/control-api/src/routes/clone.ts
@@ -16,6 +16,9 @@ import { createCloneJob, getCloneJob, incrementRetry } from '../services/clone-j
 import { getRuntimeDbForApp } from '../services/region-resolver.js';
 import { AppNotFoundError } from '../services/app-resolver.js';
 import { createAgentError, getDocUrl } from '../services/error-handler.js';
+import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
+import { checkProjectQuota } from '../services/project-quota.js';
+import { quotaErrors } from '../utils/quota-errors.js';
 import {
   VALIDATION_INVALID_SCHEMA,
   RESOURCE_NOT_FOUND,
@@ -64,10 +67,31 @@ export function cloneRoutes(app: FastifyInstance) {
       name?: string;
       region?: string;
       dest_region?: string;
+      organization_id?: string;
       env_var_values?: Record<string, Record<string, string>>;
       auto_mint_api_key?: { fn_name: string; key: string }[];
     };
     const userId = requireUserId(request);
+
+    // Resolve target org for the destination app. Precedence mirrors /init:
+    //   1. Explicit body.organization_id — gated by membership check.
+    //   2. Auth-bound org (bb_sk_* key's org, or JWT x-organization-id).
+    //   3. Caller's personal org.
+    let destOrgId: string;
+    if (body.organization_id) {
+      await assertOrgMember(app.controlDb, userId, body.organization_id);
+      destOrgId = body.organization_id;
+    } else {
+      destOrgId = request.auth?.organizationId
+        ?? await resolveOrganizationId(app.controlDb, userId);
+    }
+
+    // Enforce project limit against the destination org's plan. Blocks up-front
+    // so a queued clone can't silently push the org over max_projects.
+    const quota = await checkProjectQuota(app.controlDb, destOrgId);
+    if (!quota.ok) {
+      return reply.code(403).send(quotaErrors.projectLimitReached(quota.current, quota.limit));
+    }
 
     // getRuntimeDbForApp throws AppNotFoundError if the app isn't in
     // org_app_index. We translate to the same generic 404 we use for the
@@ -220,6 +244,7 @@ export function cloneRoutes(app: FastifyInstance) {
       sourceRegion: src.region,
       destRegion,
       requestedByUserId: userId,
+      destOrganizationId: destOrgId,
       destAppName: body.name,
       pendingEnvVarValues: body.env_var_values,
       autoMintRequests: body.auto_mint_api_key,

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -9,6 +9,7 @@ import { logFromRequest } from '../services/audit/with-audit.js';
 import { getDataProjectIdForRegion } from '../services/neon-projects.js';
 import { addOrgAppIndex, removeOrgAppIndex, listUserApps } from '../services/org-app-index.js';
 import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
+import { checkProjectQuota } from '../services/project-quota.js';
 import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
 
 const initSchema = {
@@ -165,36 +166,27 @@ export async function initRoutes(app: FastifyInstance) {
     // the control DB is the cross-region map.
     const region = provisionRegion;
 
-    // Enforce project limit for the user's plan.
-    // Cross-tier: platform_users + plans live on controlDb; apps count comes
-    // from org_app_index (cross-region — counts a user's apps in all regions,
-    // not just this region's runtime DB).
-    const planCheck = await app.controlDb.query(
-      `SELECT p.max_projects
-       FROM platform_users pu
-       JOIN organizations o ON o.id = pu.personal_organization_id
-       JOIN plans p ON p.id = o.plan_id
-       WHERE pu.id = $1`,
-      [ownerId]
-    );
-    const appsCountResult = await app.controlDb.query(
-      `SELECT COUNT(oai.app_id)::int AS current_projects
-       FROM org_app_index oai
-       JOIN organization_members om ON om.organization_id = oai.organization_id
-       WHERE om.user_id = $1`,
-      [ownerId]
-    );
-    const limitCheck = {
-      rows: planCheck.rows.length > 0
-        ? [{ max_projects: planCheck.rows[0].max_projects, current_projects: appsCountResult.rows[0]?.current_projects ?? 0 }]
-        : [],
-    };
+    // Resolve target org up-front so both quota + placement key on the same
+    // subject. Precedence:
+    //   1. Explicit body.organization_id — gated by membership check.
+    //   2. Auth-bound org (bb_sk_* key's org, or JWT x-organization-id).
+    //   3. Caller's personal org.
+    const bodyOrgId = (request.body as { organization_id?: string }).organization_id;
+    let orgId: string;
+    if (bodyOrgId) {
+      await assertOrgMember(app.controlDb, ownerId, bodyOrgId);
+      orgId = bodyOrgId;
+    } else {
+      orgId = request.auth?.organizationId
+        ?? await resolveOrganizationId(app.controlDb, ownerId);
+    }
 
-    if (limitCheck.rows.length > 0) {
-      const { max_projects, current_projects } = limitCheck.rows[0];
-      if (max_projects !== -1 && current_projects >= max_projects) {
-        return reply.code(403).send(quotaErrors.projectLimitReached(current_projects, max_projects));
-      }
+    // Enforce project limit against the TARGET org's plan (not the caller's
+    // personal org). A user on playground personal can still create apps
+    // in a team org up to that org's cap.
+    const quota = await checkProjectQuota(app.controlDb, orgId);
+    if (!quota.ok) {
+      return reply.code(403).send(quotaErrors.projectLimitReached(quota.current, quota.limit));
     }
 
     // Default subdomain to name with underscores replaced by hyphens
@@ -257,22 +249,10 @@ export async function initRoutes(app: FastifyInstance) {
       [subdomain, appId]
     );
 
-    // Resolve target org. Precedence:
-    //   1. Explicit body.organization_id — gated by membership check.
-    //   2. Auth-bound org (bb_sk_* key's org, or JWT x-organization-id).
-    //   3. Caller's personal org.
+    // orgId was resolved above (pre-quota-check); reuse it for placement.
     // NOTE: for now we only check membership, not per-key scope — a bb_sk_*
     // key can create an app in any org its owning user belongs to. Tighten
     // later if we want strict per-key org locking.
-    const bodyOrgId = (request.body as { organization_id?: string }).organization_id;
-    let orgId: string;
-    if (bodyOrgId) {
-      await assertOrgMember(app.controlDb, ownerId, bodyOrgId);
-      orgId = bodyOrgId;
-    } else {
-      orgId = request.auth?.organizationId
-        ?? await resolveOrganizationId(app.controlDb, ownerId);
-    }
     await addOrgAppIndex(app.controlDb, {
       organizationId: orgId,
       appId,

--- a/services/control-api/src/routes/internal/lease.ts
+++ b/services/control-api/src/routes/internal/lease.ts
@@ -3,6 +3,7 @@ import { grantLease, settleLease } from '../../services/lease-service.js';
 
 interface GrantBody {
   userId?: string;
+  organizationId?: string;
   region?: string;
   amountUsd?: number;
 }
@@ -13,12 +14,12 @@ interface SettleBody {
 
 const internalLeaseRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.post<{ Body: GrantBody }>('/v1/internal/lease/grant', async (request, reply) => {
-    const { userId, region, amountUsd } = request.body ?? {};
-    if (!userId || !region || typeof amountUsd !== 'number') {
-      return reply.code(400).send({ error: 'userId, region, amountUsd are required' });
+    const { userId, organizationId, region, amountUsd } = request.body ?? {};
+    if (!userId || !organizationId || !region || typeof amountUsd !== 'number') {
+      return reply.code(400).send({ error: 'userId, organizationId, region, amountUsd are required' });
     }
     const ttl = parseInt(process.env.BUTTERBASE_LEASE_TTL_SECONDS ?? '300', 10);
-    const result = await grantLease(fastify.controlDb, { userId, region, amountUsd, ttlSeconds: ttl });
+    const result = await grantLease(fastify.controlDb, { userId, organizationId, region, amountUsd, ttlSeconds: ttl });
     return {
       leaseId: result.leaseId,
       amountGranted: result.amountGranted,

--- a/services/control-api/src/routes/people.ts
+++ b/services/control-api/src/routes/people.ts
@@ -126,6 +126,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     const providerCfg = config.people.providers[slot];
 
     const runtime = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtime, appId);
 
     const ownerCheck = await assertAppOwnership(app.controlDb, appId, userId, request.auth?.organizationId ?? null);
     if (!ownerCheck.ok) return reply.code(ownerCheck.reply.code).send(ownerCheck.reply.body);
@@ -134,7 +135,7 @@ export async function peopleRoutes(app: FastifyInstance) {
 
     // Balance gate — skip if this slot charges $0 per credit
     if (pricing.usdPerCredit > 0) {
-      const bal = await getCreditsBalance(app.controlDb, userId);
+      const bal = await getCreditsBalance(app.controlDb, organizationId);
       if (bal.totalUsd < config.people.minBalanceUsd) {
         setPeopleHeaders(reply, { slot, creditsConsumed: 0, usdCharged: 0 });
         return reply.code(402).send({ error: 'insufficient_credits' });
@@ -148,8 +149,9 @@ export async function peopleRoutes(app: FastifyInstance) {
       const usdCost = result.creditsConsumed * pricing.usdPerCredit;
       let usdCharged = 0;
       if (usdCost > 0) {
-        usdCharged = await deductCreditsBalance(app.controlDb, userId, usdCost);
-        const organizationId = await resolveOrganizationId(app.controlDb, userId);
+        usdCharged = await deductCreditsBalance(app.controlDb, organizationId, usdCost);
+        // Per-org billing: incrementUsage keys on the app's owning org
+        // (resolved outer scope), not the caller's personal org.
         await incrementUsage(organizationId, userId, 'people_credits', result.creditsConsumed, appId);
       }
 
@@ -203,6 +205,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     const providerCfg = config.people.providers[slot];
 
     const runtime = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtime, appId);
 
     const ownerCheck = await assertAppOwnership(app.controlDb, appId, userId, request.auth?.organizationId ?? null);
     if (!ownerCheck.ok) return reply.code(ownerCheck.reply.code).send(ownerCheck.reply.body);
@@ -210,7 +213,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     const pricing = getPeoplePricing(slot);
 
     if (pricing.usdPerCredit > 0) {
-      const bal = await getCreditsBalance(app.controlDb, userId);
+      const bal = await getCreditsBalance(app.controlDb, organizationId);
       if (bal.totalUsd < config.people.minBalanceUsd) {
         setPeopleHeaders(reply, { slot, creditsConsumed: 0, usdCharged: 0 });
         return reply.code(402).send({ error: 'insufficient_credits' });
@@ -224,8 +227,9 @@ export async function peopleRoutes(app: FastifyInstance) {
       const usdCost = result.creditsConsumed * pricing.usdPerCredit;
       let usdCharged = 0;
       if (usdCost > 0) {
-        usdCharged = await deductCreditsBalance(app.controlDb, userId, usdCost);
-        const organizationId = await resolveOrganizationId(app.controlDb, userId);
+        usdCharged = await deductCreditsBalance(app.controlDb, organizationId, usdCost);
+        // Per-org billing: incrementUsage keys on the app's owning org
+        // (resolved outer scope), not the caller's personal org.
         await incrementUsage(organizationId, userId, 'people_credits', result.creditsConsumed, appId);
       }
 
@@ -288,6 +292,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     }
 
     const runtime = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtime, appId);
 
     const ownerCheck = await assertAppOwnership(app.controlDb, appId, userId, request.auth?.organizationId ?? null);
     if (!ownerCheck.ok) return reply.code(ownerCheck.reply.code).send(ownerCheck.reply.body);
@@ -316,7 +321,7 @@ export async function peopleRoutes(app: FastifyInstance) {
 
     // Balance gate — skip if this slot charges $0 per credit
     if (pricing.usdPerCredit > 0) {
-      const bal = await getCreditsBalance(app.controlDb, userId);
+      const bal = await getCreditsBalance(app.controlDb, organizationId);
       if (bal.totalUsd < config.people.minBalanceUsd) {
         setPeopleHeaders(reply, { slot, creditsConsumed: 0, usdCharged: 0 });
         return reply.code(402).send({ error: 'insufficient_credits' });
@@ -339,8 +344,9 @@ export async function peopleRoutes(app: FastifyInstance) {
       const usdCost = result.creditsConsumed * pricing.usdPerCredit;
       let usdCharged = 0;
       if (usdCost > 0) {
-        usdCharged = await deductCreditsBalance(app.controlDb, userId, usdCost);
-        const organizationId = await resolveOrganizationId(app.controlDb, userId);
+        usdCharged = await deductCreditsBalance(app.controlDb, organizationId, usdCost);
+        // Per-org billing: incrementUsage keys on the app's owning org
+        // (resolved outer scope), not the caller's personal org.
         await incrementUsage(organizationId, userId, 'people_credits', result.creditsConsumed, appId);
       }
 
@@ -415,6 +421,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     }
 
     const runtime = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtime, appId);
 
     const ownerCheck = await assertAppOwnership(app.controlDb, appId, userId, request.auth?.organizationId ?? null);
     if (!ownerCheck.ok) return reply.code(ownerCheck.reply.code).send(ownerCheck.reply.body);
@@ -422,7 +429,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     const pricing = getPeoplePricing(slot);
 
     if (pricing.usdPerCredit > 0) {
-      const bal = await getCreditsBalance(app.controlDb, userId);
+      const bal = await getCreditsBalance(app.controlDb, organizationId);
       if (bal.totalUsd < config.people.minBalanceUsd) {
         setPeopleHeaders(reply, { slot, creditsConsumed: 0, usdCharged: 0 });
         return reply.code(402).send({ error: 'insufficient_credits' });
@@ -433,8 +440,8 @@ export async function peopleRoutes(app: FastifyInstance) {
     try {
       const nonce = crypto.randomBytes(32).toString('hex');
 
-      // Insert the pending row BEFORE calling the adapter.
-      const organizationId = await resolveOrgFromApp(runtime, appId);
+      // Insert the pending row BEFORE calling the adapter. organizationId is
+      // hoisted from the outer scope (app's owning org).
       const lookupRow = await runtime.query<{ id: string }>(
         `INSERT INTO people_email_lookups (app_id, organization_id, user_id, normalized_url, nonce, key_type, provider_slot, status)
          VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending') RETURNING id`,
@@ -452,8 +459,9 @@ export async function peopleRoutes(app: FastifyInstance) {
       const usdCost = result.creditsConsumed * pricing.usdPerCredit;
       let usdCharged = 0;
       if (usdCost > 0) {
-        usdCharged = await deductCreditsBalance(app.controlDb, userId, usdCost);
-        const organizationId = await resolveOrganizationId(app.controlDb, userId);
+        usdCharged = await deductCreditsBalance(app.controlDb, organizationId, usdCost);
+        // Per-org billing: incrementUsage keys on the app's owning org
+        // (resolved outer scope), not the caller's personal org.
         await incrementUsage(organizationId, userId, 'people_credits', result.creditsConsumed, appId);
       }
 
@@ -506,6 +514,7 @@ export async function peopleRoutes(app: FastifyInstance) {
     const { appId, id } = request.params as { appId: string; id: string };
 
     const runtime = await getRuntimeDbForApp(app.controlDb, appId);
+    const organizationId = await resolveOrgFromApp(runtime, appId);
 
     const ownerCheck = await assertAppOwnership(app.controlDb, appId, userId, request.auth?.organizationId ?? null);
     if (!ownerCheck.ok) return reply.code(ownerCheck.reply.code).send(ownerCheck.reply.body);

--- a/services/control-api/src/services/actor-providers/billing.ts
+++ b/services/control-api/src/services/actor-providers/billing.ts
@@ -7,6 +7,7 @@ export const ACTOR_LEASE_TTL_SECONDS = 600;
 
 export interface ReserveActorCreditsInput {
   userId: string;
+  organizationId: string;
   region: string;
   recordingUsdPerSecond: number;
   transcriptionUsdPerSecond: number;
@@ -27,6 +28,7 @@ export async function reserveActorCredits(
 
   const res = await grantLease(platformPool, {
     userId: input.userId,
+    organizationId: input.organizationId,
     region: input.region,
     amountUsd: requested,
     ttlSeconds: ACTOR_LEASE_TTL_SECONDS,

--- a/services/control-api/src/services/ai-router/billing-gate.ts
+++ b/services/control-api/src/services/ai-router/billing-gate.ts
@@ -28,6 +28,7 @@ export class InsufficientCreditsError extends Error {
 export async function acquireForEstimatedCost(
   platformPool: pg.Pool,
   userId: string,
+  organizationId: string,
   region: string,
   estimatedUsd: number,
   ttlSeconds: number
@@ -40,6 +41,7 @@ export async function acquireForEstimatedCost(
   const requested = estimatedUsd < MIN_LEASE_USD ? MIN_LEASE_USD : estimatedUsd;
   const res = await grantLease(platformPool, {
     userId,
+    organizationId,
     region,
     amountUsd: requested,
     ttlSeconds,

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -79,8 +79,10 @@ export async function acquireWithAudit(
 export async function maybeFireCreditsEmail(pool: pg.Pool, userId: string): Promise<void> {
   try {
     const r = await pool.query<{ monthly_allowance_usd: string; credits_usd: string }>(
-      `SELECT monthly_allowance_usd::text, credits_usd::text
-         FROM platform_users WHERE id = $1`,
+      `SELECT o.monthly_allowance_usd::text, o.credits_usd::text
+         FROM platform_users pu
+         JOIN organizations o ON o.id = pu.personal_organization_id
+        WHERE pu.id = $1`,
       [userId],
     );
     if (r.rows.length === 0) return;

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -44,7 +44,7 @@ export async function acquireWithAudit(
 ): Promise<ReturnType<typeof acquireForEstimatedCost>> {
   try {
     return await acquireForEstimatedCost(
-      ctx.platformPool, ctx.userId, ctx.region, reservedUsd, ttlSeconds,
+      ctx.platformPool, ctx.userId, ctx.organizationId, ctx.region, reservedUsd, ttlSeconds,
     );
   } catch (err) {
     if (err instanceof InsufficientCreditsError && ctx.appId) {

--- a/services/control-api/src/services/auto-refill-service.ts
+++ b/services/control-api/src/services/auto-refill-service.ts
@@ -67,12 +67,11 @@ export async function maybeTriggerAutoRefill(deps: Deps, organizationId: string)
     auto_refill_enabled: boolean;
     auto_refill_amount_usd: string | null;
   }>(
-    `SELECT COALESCE(pu.monthly_allowance_usd, 0)::text AS monthly_allowance_usd,
+    `SELECT o.monthly_allowance_usd::text AS monthly_allowance_usd,
             o.credits_usd,
             o.auto_refill_enabled,
             o.auto_refill_amount_usd
        FROM organizations o
-       LEFT JOIN platform_users pu ON pu.id = o.owner_id
       WHERE o.id = $1`,
     [organizationId]
   );

--- a/services/control-api/src/services/clone-jobs.ts
+++ b/services/control-api/src/services/clone-jobs.ts
@@ -35,6 +35,7 @@ export interface CloneJob {
   dest_app_id: string | null;
   dest_region: string;
   requested_by_user_id: string;
+  dest_organization_id: string | null;
   dest_app_name: string | null;
   status: CloneJobStatus;
   retry_count: number;
@@ -61,6 +62,7 @@ export async function createCloneJob(
     sourceRegion: string;
     destRegion: string;
     requestedByUserId: string;
+    destOrganizationId: string;
     destAppName?: string;
     pendingEnvVarValues?: Record<string, Record<string, string>>;
     autoMintRequests?: { fn_name: string; key: string }[];
@@ -83,8 +85,9 @@ export async function createCloneJob(
   const res = await controlDb.query<CloneJob>(
     `INSERT INTO template_clone_jobs
        (id, source_app_id, source_snapshot_id, source_region, dest_region,
-        requested_by_user_id, dest_app_name, pending_env_vars, auto_mint_requests)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        requested_by_user_id, dest_organization_id, dest_app_name,
+        pending_env_vars, auto_mint_requests)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
      RETURNING *`,
     [
       id,
@@ -93,6 +96,7 @@ export async function createCloneJob(
       args.sourceRegion,
       args.destRegion,
       args.requestedByUserId,
+      args.destOrganizationId,
       args.destAppName ?? null,
       pendingEnvVars,
       autoMintRequests,

--- a/services/control-api/src/services/lease-client.ts
+++ b/services/control-api/src/services/lease-client.ts
@@ -1,5 +1,6 @@
 export interface LeaseGrantRequest {
   userId: string;
+  organizationId: string;
   amountUsd: number;
   platformControlApiUrl: string;
   fetch?: typeof fetch;
@@ -25,7 +26,7 @@ export async function requestLeaseFromPlatform(req: LeaseGrantRequest): Promise<
       'content-type': 'application/json',
       'x-butterbase-internal-secret': secret,
     },
-    body: JSON.stringify({ userId: req.userId, region, amountUsd: req.amountUsd }),
+    body: JSON.stringify({ userId: req.userId, organizationId: req.organizationId, region, amountUsd: req.amountUsd }),
   });
   if (!res.ok) {
     const text = await res.text();

--- a/services/control-api/src/services/lease-reclaim.test.ts
+++ b/services/control-api/src/services/lease-reclaim.test.ts
@@ -82,11 +82,11 @@ describe('reclaimExpiredLeases', () => {
 });
 
 describe('reclaimExpiredLeases — split pools', () => {
-  // Post-Plan-07: monthly_allowance_usd stays on platform_users; credits_usd
-  // moved to organizations. Each test seeds via TWO UPDATEs and reads via JOIN.
+  // Post-migration 093: both monthly_allowance_usd and credits_usd live on
+  // organizations. Seed / read via the personal-org join.
   const readPools = async (userId: string) => {
     const u = await pool.query(
-      `SELECT pu.monthly_allowance_usd, o.credits_usd
+      `SELECT o.monthly_allowance_usd, o.credits_usd
        FROM platform_users pu
        JOIN organizations o ON o.id = pu.personal_organization_id
        WHERE pu.id = $1`,
@@ -95,11 +95,10 @@ describe('reclaimExpiredLeases — split pools', () => {
     return u.rows[0];
   };
   const seedPools = async (userId: string, monthly: number, credits: number) => {
-    await pool.query(`UPDATE platform_users SET monthly_allowance_usd = $1 WHERE id = $2`, [monthly, userId]);
     await pool.query(
-      `UPDATE organizations SET credits_usd = $1
-       WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $2)`,
-      [credits, userId],
+      `UPDATE organizations SET monthly_allowance_usd = $1, credits_usd = $2
+       WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $3)`,
+      [monthly, credits, userId],
     );
   };
 

--- a/services/control-api/src/services/lease-reclaim.ts
+++ b/services/control-api/src/services/lease-reclaim.ts
@@ -39,8 +39,8 @@ export async function reclaimExpiredLeases(
 
       if (sourcePool === 'monthly') {
         await client.query(
-          `UPDATE platform_users SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
-          [amt, row.user_id]
+          `UPDATE organizations SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
+          [amt, row.organization_id]
         );
       } else if (sourcePool === 'topup') {
         await client.query(
@@ -51,8 +51,8 @@ export async function reclaimExpiredLeases(
         // split: refund the original portions exactly.
         if (monthlyPortion > 0) {
           await client.query(
-            `UPDATE platform_users SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
-            [monthlyPortion, row.user_id]
+            `UPDATE organizations SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
+            [monthlyPortion, row.organization_id]
           );
         }
         if (topupPortion > 0) {

--- a/services/control-api/src/services/lease-service.ts
+++ b/services/control-api/src/services/lease-service.ts
@@ -2,7 +2,12 @@ import type pg from 'pg';
 import { NotFoundError } from './api-errors.js';
 
 export interface GrantArgs {
+  /** User whose action is being billed (audit + credit_leases.user_id). */
   userId: string;
+  /** Organization whose credit pools are drawn — under per-org billing this
+   *  is the app's owning org (from resolveOrgFromApp) or the caller's
+   *  explicit billing org, never a personal-org default at this layer. */
+  organizationId: string;
   region: string;
   amountUsd: number;
   ttlSeconds: number;
@@ -21,21 +26,17 @@ export async function grantLease(platformPool: pg.Pool, args: GrantArgs): Promis
   const client = await platformPool.connect();
   try {
     await client.query('BEGIN');
-    // Read the caller's personal-org billing row. The monthly pool now lives
-    // on organizations.monthly_allowance_usd (migration 093); before 093 it
-    // was on platform_users. This code path always keys on the personal org
-    // because grantLease is currently invoked without an explicit org (AI
-    // gateway, function invocation). Team-org AI billing is a follow-up:
-    // when we thread activeOrgId through, this SELECT should key on that org.
-    const u = await client.query<{ monthly_allowance_usd: string; credits_usd: string; personal_organization_id: string }>(
-      `SELECT o.monthly_allowance_usd, o.credits_usd, pu.personal_organization_id
-       FROM platform_users pu
-       JOIN organizations o ON o.id = pu.personal_organization_id
-       WHERE pu.id = $1 FOR UPDATE OF o`,
-      [args.userId]
+    // Per-org billing (Phase 3b). Caller passes args.organizationId — this
+    // is the app's owning org (AI gateway) or an explicit billing subject.
+    // No implicit personal-org fallback at this layer.
+    const organizationId = args.organizationId;
+    const u = await client.query<{ monthly_allowance_usd: string; credits_usd: string }>(
+      `SELECT monthly_allowance_usd, credits_usd
+       FROM organizations
+       WHERE id = $1 FOR UPDATE`,
+      [organizationId]
     );
-    if (u.rows.length === 0) throw new NotFoundError('user', args.userId);
-    const organizationId = u.rows[0].personal_organization_id;
+    if (u.rows.length === 0) throw new NotFoundError('organization', organizationId);
 
     const monthly = parseFloat(u.rows[0].monthly_allowance_usd);
     const topup = parseFloat(u.rows[0].credits_usd);

--- a/services/control-api/src/services/lease-service.ts
+++ b/services/control-api/src/services/lease-service.ts
@@ -21,11 +21,17 @@ export async function grantLease(platformPool: pg.Pool, args: GrantArgs): Promis
   const client = await platformPool.connect();
   try {
     await client.query('BEGIN');
+    // Read the caller's personal-org billing row. The monthly pool now lives
+    // on organizations.monthly_allowance_usd (migration 093); before 093 it
+    // was on platform_users. This code path always keys on the personal org
+    // because grantLease is currently invoked without an explicit org (AI
+    // gateway, function invocation). Team-org AI billing is a follow-up:
+    // when we thread activeOrgId through, this SELECT should key on that org.
     const u = await client.query<{ monthly_allowance_usd: string; credits_usd: string; personal_organization_id: string }>(
-      `SELECT pu.monthly_allowance_usd, o.credits_usd, pu.personal_organization_id
+      `SELECT o.monthly_allowance_usd, o.credits_usd, pu.personal_organization_id
        FROM platform_users pu
        JOIN organizations o ON o.id = pu.personal_organization_id
-       WHERE pu.id = $1 FOR UPDATE OF pu, o`,
+       WHERE pu.id = $1 FOR UPDATE OF o`,
       [args.userId]
     );
     if (u.rows.length === 0) throw new NotFoundError('user', args.userId);
@@ -59,8 +65,8 @@ export async function grantLease(platformPool: pg.Pool, args: GrantArgs): Promis
 
     if (monthlyDraw > 0) {
       await client.query(
-        `UPDATE platform_users SET monthly_allowance_usd = monthly_allowance_usd - $1 WHERE id = $2`,
-        [monthlyDraw, args.userId]
+        `UPDATE organizations SET monthly_allowance_usd = monthly_allowance_usd - $1 WHERE id = $2`,
+        [monthlyDraw, organizationId]
       );
     }
     if (topupDraw > 0) {
@@ -141,8 +147,8 @@ export async function settleLease(
     if (refund > 0) {
       if (sourcePool === 'monthly') {
         await client.query(
-          `UPDATE platform_users SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
-          [refund, r.rows[0].user_id]
+          `UPDATE organizations SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
+          [refund, r.rows[0].organization_id]
         );
       } else if (sourcePool === 'topup') {
         await client.query(
@@ -155,8 +161,8 @@ export async function settleLease(
         const topupRefund = +(refund - monthlyRefund).toFixed(4); // preserve total via remainder
         if (monthlyRefund > 0) {
           await client.query(
-            `UPDATE platform_users SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
-            [monthlyRefund, r.rows[0].user_id]
+            `UPDATE organizations SET monthly_allowance_usd = monthly_allowance_usd + $1 WHERE id = $2`,
+            [monthlyRefund, r.rows[0].organization_id]
           );
         }
         if (topupRefund > 0) {

--- a/services/control-api/src/services/monthly-resets-service.test.ts
+++ b/services/control-api/src/services/monthly-resets-service.test.ts
@@ -22,10 +22,18 @@ describeDb('resetMonthlyAllowance', () => {
   });
 
   beforeEach(async () => {
+    // Fixture: insert a user + personal org, seed the org with $3.50 allowance
+    // (migration 093 moved the monthly pool from platform_users to organizations).
+    const orgResult = await pool.query(
+      `INSERT INTO organizations (name, personal, plan_id, credits_usd, monthly_allowance_usd, stripe_customer_id)
+       VALUES ($1, true, $2, 0, 3.50, $3) RETURNING id`,
+      [`reset-org-${Date.now()}-${Math.random()}`, planId, `cus_reset_${Date.now()}_${Math.random()}`]
+    );
+    const orgId = orgResult.rows[0].id;
     const u = await pool.query(
-      `INSERT INTO platform_users (email, account_status, plan_id, credits_usd, monthly_allowance_usd, stripe_customer_id)
-       VALUES ($1, 'active', $2, 0, 3.50, $3) RETURNING id`,
-      [`monthly-reset-${Date.now()}-${Math.random()}@x.com`, planId, `cus_reset_${Date.now()}_${Math.random()}`]
+      `INSERT INTO platform_users (email, account_status, plan_id, personal_organization_id)
+       VALUES ($1, 'active', $2, $3) RETURNING id`,
+      [`monthly-reset-${Date.now()}-${Math.random()}@x.com`, planId, orgId]
     );
     userId = u.rows[0].id;
   });
@@ -34,7 +42,12 @@ describeDb('resetMonthlyAllowance', () => {
     const r = await resetMonthlyAllowance(pool, { userId, planId, stripeEventId: `evt_${Date.now()}_a` });
     expect(r.newAmount).toBeCloseTo(10, 2);
     expect(r.previousUnspent).toBeCloseTo(3.50, 2);
-    const u = await pool.query(`SELECT monthly_allowance_usd FROM platform_users WHERE id = $1`, [userId]);
+    const u = await pool.query(
+      `SELECT o.monthly_allowance_usd FROM organizations o
+       JOIN platform_users pu ON pu.personal_organization_id = o.id
+       WHERE pu.id = $1`,
+      [userId]
+    );
     expect(parseFloat(u.rows[0].monthly_allowance_usd)).toBeCloseTo(10, 2);
 
     const audit = await pool.query(
@@ -52,12 +65,21 @@ describeDb('resetMonthlyAllowance', () => {
     expect(r1.newAmount).toBeCloseTo(10, 2);
 
     // simulate spending after the reset
-    await pool.query(`UPDATE platform_users SET monthly_allowance_usd = 4 WHERE id = $1`, [userId]);
+    await pool.query(
+      `UPDATE organizations SET monthly_allowance_usd = 4
+       WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $1)`,
+      [userId]
+    );
 
     const r2 = await resetMonthlyAllowance(pool, { userId, planId, stripeEventId: eventId });
     expect(r2.skippedDuplicate).toBe(true);
     expect(r2.newAmount).toBeCloseTo(4, 2); // unchanged
-    const u = await pool.query(`SELECT monthly_allowance_usd FROM platform_users WHERE id = $1`, [userId]);
+    const u = await pool.query(
+      `SELECT o.monthly_allowance_usd FROM organizations o
+       JOIN platform_users pu ON pu.personal_organization_id = o.id
+       WHERE pu.id = $1`,
+      [userId]
+    );
     expect(parseFloat(u.rows[0].monthly_allowance_usd)).toBeCloseTo(4, 2);
   });
 
@@ -67,7 +89,12 @@ describeDb('resetMonthlyAllowance', () => {
     expect(r.newAmount).toBe(0);
     expect(r.previousUnspent).toBeCloseTo(3.50, 2);
     // The SET still applied: monthly_allowance is now 0 (3.50 was lost — use-it-or-lose-it)
-    const u = await pool.query(`SELECT monthly_allowance_usd FROM platform_users WHERE id = $1`, [userId]);
+    const u = await pool.query(
+      `SELECT o.monthly_allowance_usd FROM organizations o
+       JOIN platform_users pu ON pu.personal_organization_id = o.id
+       WHERE pu.id = $1`,
+      [userId]
+    );
     expect(parseFloat(u.rows[0].monthly_allowance_usd)).toBeCloseTo(0, 2);
     // restore
     await pool.query(`UPDATE plans SET monthly_credit_grant_usd = 10 WHERE id = $1`, [planId]);

--- a/services/control-api/src/services/monthly-resets-service.ts
+++ b/services/control-api/src/services/monthly-resets-service.ts
@@ -6,6 +6,15 @@ export interface ResetArgs {
   userId: string;
   planId: string;
   stripeEventId: string;
+  /**
+   * Org whose monthly_allowance_usd should be SET. Optional for backwards
+   * compatibility — omit to reset the caller's personal org (legacy behavior
+   * before the per-org allowance split). New callers (stripe-service on
+   * invoice.paid / subscription.updated) MUST pass the subscription's
+   * organization_id so team-org subs reset the team-org pool, not the
+   * personal-org pool.
+   */
+  organizationId?: string;
 }
 
 export interface ResetResult {
@@ -40,16 +49,20 @@ export async function resetMonthlyAllowanceWithClient(
   }
   const grantAmount = parseFloat(plan.rows[0].monthly_credit_grant_usd);
 
-  const userRow = await client.query<{ monthly_allowance_usd: string }>(
-    `SELECT monthly_allowance_usd FROM platform_users WHERE id = $1 FOR UPDATE`,
-    [args.userId]
-  );
-  if (userRow.rows.length === 0) {
-    throw new NotFoundError('user', args.userId);
-  }
-  const previousUnspent = parseFloat(userRow.rows[0].monthly_allowance_usd);
+  // Resolve target org — subscription org if the caller passed it, else the
+  // user's personal org (legacy path).
+  const organizationId = args.organizationId
+    ?? await resolveOrganizationId(pool, args.userId);
 
-  const organizationId = await resolveOrganizationId(pool, args.userId);
+  const orgRow = await client.query<{ monthly_allowance_usd: string }>(
+    `SELECT monthly_allowance_usd FROM organizations WHERE id = $1 FOR UPDATE`,
+    [organizationId]
+  );
+  if (orgRow.rows.length === 0) {
+    throw new NotFoundError('organization', organizationId);
+  }
+  const previousUnspent = parseFloat(orgRow.rows[0].monthly_allowance_usd);
+
   const insRes = await client.query(
     `INSERT INTO monthly_credit_resets (user_id, organization_id, plan_id, amount_usd, previous_unspent_usd, stripe_event_id)
      VALUES ($1, $2, $3, $4, $5, $6)
@@ -62,10 +75,12 @@ export async function resetMonthlyAllowanceWithClient(
     return { newAmount: previousUnspent, previousUnspent, skippedDuplicate: true };
   }
 
-  // SET — not add. Use-it-or-lose-it.
+  // SET — not add. Use-it-or-lose-it. Per-org column is now authoritative;
+  // platform_users.monthly_allowance_usd will be dropped after all readers
+  // are cut over (see migration 093 header).
   await client.query(
-    `UPDATE platform_users SET monthly_allowance_usd = $1 WHERE id = $2`,
-    [grantAmount, args.userId]
+    `UPDATE organizations SET monthly_allowance_usd = $1 WHERE id = $2`,
+    [grantAmount, organizationId]
   );
 
   // Balance was just bumped — clear the credits-email dedup state so the next

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -543,7 +543,12 @@ async function executeClone(
         // Cross-region index so authorizeRepoRead/Write and other lookups can
         // resolve the dest app's region. Init route does the same step after
         // its insertAppRow; the clone worker is the equivalent caller here.
-        const destOrgId = await resolveOrganizationId(controlDb, job.requested_by_user_id);
+        //
+        // Prefer the job's dest_organization_id (set by the clone route from
+        // the same precedence /init uses). Fall back to the requester's
+        // personal org for legacy jobs written before migration 092.
+        const destOrgId = job.dest_organization_id
+          ?? await resolveOrganizationId(controlDb, job.requested_by_user_id);
         await addOrgAppIndex(controlDb, {
           organizationId: destOrgId,
           appId: destAppId,

--- a/services/control-api/src/services/project-quota.ts
+++ b/services/control-api/src/services/project-quota.ts
@@ -1,0 +1,43 @@
+import type { Pool } from 'pg';
+
+export type ProjectQuotaCheck =
+  | { ok: true }
+  | { ok: false; current: number; limit: number };
+
+/**
+ * Check whether `organizationId` can create one more app under its plan's
+ * `max_projects` limit.
+ *
+ * Keyed on the TARGET org — not the caller's personal org. A user on the
+ * playground plan (personal) can still be a member of a team org on
+ * certified/10 and create apps up to that org's cap.
+ *
+ * `max_projects = -1` means unlimited. If the org has no plan row (data
+ * corruption or a not-yet-billed org), fail open — same behavior as the
+ * pre-refactor code, so this migration does not tighten quota for orgs
+ * that never had one.
+ */
+export async function checkProjectQuota(
+  pool: Pool,
+  organizationId: string,
+): Promise<ProjectQuotaCheck> {
+  const result = await pool.query<{ max_projects: number; current_projects: number }>(
+    `SELECT
+       p.max_projects,
+       (SELECT COUNT(*)::int
+          FROM org_app_index
+         WHERE organization_id = $1) AS current_projects
+     FROM organizations o
+     JOIN plans p ON p.id = o.plan_id
+     WHERE o.id = $1`,
+    [organizationId],
+  );
+  const row = result.rows[0];
+  if (!row) return { ok: true };
+  const { max_projects, current_projects } = row;
+  if (max_projects === -1) return { ok: true };
+  if (current_projects >= max_projects) {
+    return { ok: false, current: current_projects, limit: max_projects };
+  }
+  return { ok: true };
+}

--- a/services/control-api/src/services/usage-metering.ts
+++ b/services/control-api/src/services/usage-metering.ts
@@ -617,10 +617,12 @@ export interface CreditsBalance {
  * the monthly plan allowance and the prepaid top-up balance.
  */
 export async function getCreditsBalance(db: DbClient, userId: string): Promise<CreditsBalance> {
-  // Post-Plan-07: monthly_allowance_usd stays on platform_users (per-user budget),
-  // credits_usd moved to organizations (org-scoped credit balance).
+  // Both monthly_allowance_usd and credits_usd live on organizations
+  // (migration 093 moved monthly_allowance off platform_users). This still
+  // keys on the personal org; team-org billing views should call a variant
+  // that takes an explicit orgId once the caller sites thread it through.
   const result = await db.query<{ monthly_allowance_usd: string; credits_usd: string }>(
-    `SELECT pu.monthly_allowance_usd, o.credits_usd
+    `SELECT o.monthly_allowance_usd, o.credits_usd
      FROM platform_users pu
      JOIN organizations o ON o.id = pu.personal_organization_id
      WHERE pu.id = $1`,

--- a/services/control-api/src/services/usage-metering.ts
+++ b/services/control-api/src/services/usage-metering.ts
@@ -613,20 +613,20 @@ export interface CreditsBalance {
 }
 
 /**
- * Get the user's current credits balance across both pools:
+ * Get an organization's credits balance across both pools:
  * the monthly plan allowance and the prepaid top-up balance.
+ *
+ * Billing is per-org (migration 093). Callers MUST resolve the target org
+ * upstream — from request.auth.organizationId, an explicit param, or (for
+ * UX defaults on dashboard reads) resolveOrganizationId(userId). The data
+ * layer never falls back to personal on its own.
  */
-export async function getCreditsBalance(db: DbClient, userId: string): Promise<CreditsBalance> {
-  // Both monthly_allowance_usd and credits_usd live on organizations
-  // (migration 093 moved monthly_allowance off platform_users). This still
-  // keys on the personal org; team-org billing views should call a variant
-  // that takes an explicit orgId once the caller sites thread it through.
+export async function getCreditsBalance(db: DbClient, organizationId: string): Promise<CreditsBalance> {
   const result = await db.query<{ monthly_allowance_usd: string; credits_usd: string }>(
-    `SELECT o.monthly_allowance_usd, o.credits_usd
-     FROM platform_users pu
-     JOIN organizations o ON o.id = pu.personal_organization_id
-     WHERE pu.id = $1`,
-    [userId]
+    `SELECT monthly_allowance_usd, credits_usd
+     FROM organizations
+     WHERE id = $1`,
+    [organizationId]
   );
   if (result.rows.length === 0) {
     return { monthlyAllowanceUsd: 0, topupUsd: 0, totalUsd: 0 };
@@ -642,17 +642,16 @@ export async function getCreditsBalance(db: DbClient, userId: string): Promise<C
  */
 export async function deductCreditsBalance(
   db: DbClient,
-  userId: string,
+  organizationId: string,
   amountUsd: number
 ): Promise<number> {
-  // credits_usd lives on organizations post-Plan-07; deduct from the caller's
-  // personal org's balance.
+  // Per-org (Phase 3b). Caller passes the org whose credit pool to draw from.
   const result = await db.query(
     `UPDATE organizations
      SET credits_usd = GREATEST(0, credits_usd - $1)
-     WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $2)
+     WHERE id = $2
      RETURNING credits_usd`,
-    [amountUsd, userId]
+    [amountUsd, organizationId]
   );
   if (result.rows.length === 0) return 0;
 

--- a/services/mcp-server/src/tools/billing.ts
+++ b/services/mcp-server/src/tools/billing.ts
@@ -89,6 +89,10 @@ Common errors:
         .string()
         .optional()
         .describe('Meter type to filter usage by, e.g. "compute", "storage" (used with "usage")'),
+      org_id: z
+        .string()
+        .optional()
+        .describe('Organization id to view billing for. Requires membership. Defaults to the caller\'s personal org. Applies to "status" and "usage".'),
     },
     {
       title: 'Manage Billing',
@@ -98,11 +102,13 @@ Common errors:
       openWorldHint: true,
     },
     async (args) => {
-      const { action, amount, raise_by, start_date, end_date, meter } = args;
+      const { action, amount, raise_by, start_date, end_date, meter, org_id } = args;
 
       switch (action) {
         case 'status': {
-          const res = await fetch(`${getBaseUrl()}/dashboard/billing`, {
+          const url = new URL(`${getBaseUrl()}/dashboard/billing`);
+          if (org_id) url.searchParams.set('org_id', org_id);
+          const res = await fetch(url.toString(), {
             headers: getHeaders(),
           });
           const data = await res.json();

--- a/services/mcp-server/src/tools/manage-app.ts
+++ b/services/mcp-server/src/tools/manage-app.ts
@@ -80,6 +80,7 @@ Common errors:
       source_app_id: z.string().optional().describe('Required for "clone" and "preview_clone_env_vars". The id of the public app to clone.'),
       name: z.string().optional().describe('Optional for "clone". A name for the new app; defaults to `Clone of <source_app_id>`.'),
       region: z.string().optional().describe('Optional for "clone". The region for the new app; defaults to the source app\'s region.'),
+      organization_id: z.string().min(1).optional().describe('Optional for "clone". Organization to create the destination app under. Requires membership. Defaults to the caller\'s personal org.'),
       env_var_values: z.record(z.string(), z.record(z.string(), z.string())).optional()
         .describe('Optional for "clone". Per-function env var values: { fn_name: { KEY: "value" } }. Use preview_clone_env_vars to see what keys the source needs.'),
       auto_mint_api_key: z.array(z.object({
@@ -187,11 +188,13 @@ Common errors:
           const body: {
             name?: string;
             region?: string;
+            organization_id?: string;
             env_var_values?: Record<string, Record<string, string>>;
             auto_mint_api_key?: { fn_name: string; key: string }[];
           } = {};
           if (args.name) body.name = args.name;
           if (args.region) body.region = args.region;
+          if (args.organization_id) body.organization_id = args.organization_id;
           if (args.env_var_values) body.env_var_values = args.env_var_values;
           if (args.auto_mint_api_key) body.auto_mint_api_key = args.auto_mint_api_key;
 


### PR DESCRIPTION
## Summary

Companion oss PR for butterbase-internal#43. See that PR for full context on Willow's / head-of-eng thread reports.

Two shipwrights here:

**Billing — per-org monthly allowance.** Migration 093 adds `organizations.monthly_allowance_usd` (backfilled from personal orgs so users keep their balance). `resetMonthlyAllowance` writes to the org column keyed on the sub's org id — was writing to `platform_users` and always resolving to personal, which caused paid team-org subs to leak into the personal pool and canceled paid subs to leave the $5 sitting on the user forever. `lease-service` / `lease-reclaim` / `auto-refill-service` / `ai-router` / `getCreditsBalance` / admin credits / ai-config auto-refill state all read+debit from the org column now.

**Quota — target-org check.** New `checkProjectQuota(pool, orgId)` shared helper. `/init` resolves target org first (body → auth → personal), gates on the target org's plan + target org's app count, then provisions. `POST /v1/templates/:source_app_id/clone` accepts `organization_id`, gates on quota, persists on the job row (migration 092 adds `template_clone_jobs.dest_organization_id`). Clone worker uses `job.dest_organization_id` at `addOrgAppIndex` time — was hard-coded to personal.

Tests: `monthly-resets-service.test.ts`, `lease-reclaim.test.ts`, `kv-quota.test.ts` rewritten to seed / assert on the org column.

## Deferred
- `platform_users.monthly_allowance_usd` retained; drop in a follow-up after this bakes one release.
- Team-org AI billing (thread `activeOrgId` through the AI gateway) — separate refactor.
- `manage_app.transfer_to_org` — real feature, separate PR.

## Test plan
- [ ] Migration 092 + 093 apply cleanly
- [ ] Backfill preserves personal-org balances; team orgs start at 0
- [ ] Reset writer: team-org paid sub resets team-org allowance
- [ ] Cancel path: `handleSubscriptionDeleted` zeros org allowance
- [ ] `/init` + clone: quota gated on target org's plan
- [ ] Vitest: `monthly-resets-service.test.ts`, `lease-reclaim.test.ts` pass with new fixtures