### PR TITLE
fix(clone): fall back to BUTTERBASE_DEFAULT_REGION before source region

### DIFF
--- a/services/control-api/src/routes/clone.ts
+++ b/services/control-api/src/routes/clone.ts
@@ -212,8 +212,15 @@ export function cloneRoutes(app: FastifyInstance) {
       }
     }
 
-    // Accept dest_region (preferred) or the legacy region alias.
-    const destRegion = body.dest_region ?? body.region ?? src.region;
+    // Accept dest_region (preferred) or the legacy region alias. When neither
+    // is provided, fall back to the operator-configured default before the
+    // source region — the source may be at capacity while the default has
+    // headroom (Neon's 500-databases-per-branch limit).
+    const destRegion =
+      body.dest_region ??
+      body.region ??
+      process.env.BUTTERBASE_DEFAULT_REGION ??
+      src.region;
     const job = await createCloneJob(app.controlDb, {
       sourceAppId: source_app_id,
       sourceSnapshotId: src.repo_latest_snapshot,


### PR DESCRIPTION
## Summary
- Clones currently default to the source app's region, which fails when that region has hit Neon's databases-per-branch cap (500).
- Insert `BUTTERBASE_DEFAULT_REGION` into the fallback chain so operators can divert new clones to a region with headroom without editing every caller.
- No change for callers that pass an explicit `dest_region` / `region`.

## Context
us-east-1 hit `DATABASES_LIMIT_EXCEEDED` earlier today (2026-07-07), blocking clones. With a hackathon starting tomorrow, we need clones of us-east-1 templates to land in us-west-2 (which has ~417 slots free) without asking every user to pass `dest_region`. `/init` already reads `BUTTERBASE_DEFAULT_REGION`; this brings the clone route in line.

## Test plan
- [ ] Deploy with `BUTTERBASE_DEFAULT_REGION=us-west-2` on butterbase-platform
- [ ] Clone a us-east-1 template with no `dest_region` in the body → dest app lands in us-west-2
- [ ] Clone with explicit `dest_region: us-east-1` → still honors the override