### PR TITLE
feat(provisioning): gate new apps on BUTTERBASE_PROVISION_ALLOWED_REGIONS

### DIFF
--- a/services/control-api/src/routes/clone.ts
+++ b/services/control-api/src/routes/clone.ts
@@ -221,6 +221,24 @@ export function cloneRoutes(app: FastifyInstance) {
       body.region ??
       process.env.BUTTERBASE_DEFAULT_REGION ??
       src.region;
+
+    // Reject clones targeting a region temporarily closed to new apps.
+    // BUTTERBASE_PROVISION_ALLOWED_REGIONS is a subset of BUTTERBASE_REGIONS
+    // — the latter controls serving, the former controls new writes. When
+    // unset, all serving regions accept new apps (existing behavior).
+    const provisionAllowedRaw =
+      process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS
+        ?? process.env.BUTTERBASE_REGIONS
+        ?? '';
+    const provisionAllowed = provisionAllowedRaw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (provisionAllowed.length > 0 && !provisionAllowed.includes(destRegion)) {
+      return reply.code(400).send(createAgentError({
+        code: VALIDATION_INVALID_SCHEMA,
+        message: `Region "${destRegion}" is not currently accepting new apps.`,
+        remediation: `Pass an explicit dest_region from: ${provisionAllowed.join(', ')}.`,
+        documentation_url: getDocUrl(VALIDATION_INVALID_SCHEMA),
+      }));
+    }
     const job = await createCloneJob(app.controlDb, {
       sourceAppId: source_app_id,
       sourceSnapshotId: src.repo_latest_snapshot,

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -139,10 +139,22 @@ export async function initRoutes(app: FastifyInstance) {
     // app provisioned in us-west-2 even when they didn't pick a region.
     // The default needs to be deterministic across machines.
     const allowedRegions = (process.env.BUTTERBASE_REGIONS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+    // Regions that accept NEW app provisioning. Defaults to allowedRegions
+    // (BUTTERBASE_REGIONS gates both serving and provisioning). Setting
+    // BUTTERBASE_PROVISION_ALLOWED_REGIONS to a subset (e.g. "us-west-2")
+    // lets operators temporarily close a region to new writes without
+    // breaking traffic to apps already homed there — needed when one
+    // region has hit an infra ceiling (Neon's 500 databases-per-branch).
+    const provisionAllowed = (
+      process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS
+        ?? process.env.BUTTERBASE_REGIONS
+        ?? ''
+    ).split(',').map((s) => s.trim()).filter(Boolean);
     const bodyRegion = (request.body as { region?: string } | undefined)?.region;
     const provisionRegion =
       bodyRegion ??
       process.env.BUTTERBASE_DEFAULT_REGION ??
+      provisionAllowed[0] ??
       allowedRegions[0] ??
       'local';
 
@@ -150,6 +162,12 @@ export async function initRoutes(app: FastifyInstance) {
       return reply.code(400).send({
         error: `Region "${provisionRegion}" is not in BUTTERBASE_REGIONS`,
         allowed: allowedRegions,
+      });
+    }
+    if (!provisionAllowed.includes(provisionRegion)) {
+      return reply.code(400).send({
+        error: `Region "${provisionRegion}" is not currently accepting new apps`,
+        allowed: provisionAllowed,
       });
     }
     try {


### PR DESCRIPTION
## Summary
- `BUTTERBASE_REGIONS` currently gates BOTH serving traffic AND accepting new provisions. When one region hits a capacity ceiling, we can't close it to new writes without also breaking every app already homed there.
- Add optional `BUTTERBASE_PROVISION_ALLOWED_REGIONS` (subset of `BUTTERBASE_REGIONS`). When set, `/init` and `/v1/templates/:id/clone` reject targets outside it with a 400.
- When unset, behavior is unchanged.

## Context
us-east-1 hit Neon's 500-databases-per-branch cap earlier today. We diverted defaults to us-west-2 (#77) but explicit `region: us-east-1` still succeeded — eating the ~95 remaining slots. With hackathon traffic starting tomorrow, we need a firm gate.

Set `BUTTERBASE_PROVISION_ALLOWED_REGIONS=us-west-2` on butterbase-platform for the hackathon window. Existing us-east-1 apps keep serving normally.

## Test plan
- [ ] Deploy with BUTTERBASE_PROVISION_ALLOWED_REGIONS=us-west-2
- [ ] init_app with region us-east-1 → 400
- [ ] init_app with region us-west-2 → provisions
- [ ] init_app no region → provisions in us-west-2
- [ ] clone with dest_region us-east-1 → 400
- [ ] clone default → provisions in us-west-2
- [ ] Existing us-east-1 apps still serve normally