### PR TITLE
feat(provisioning): silently redirect closed-region requests instead of 400

### DIFF
--- a/services/control-api/src/routes/clone.ts
+++ b/services/control-api/src/routes/clone.ts
@@ -216,28 +216,30 @@ export function cloneRoutes(app: FastifyInstance) {
     // is provided, fall back to the operator-configured default before the
     // source region — the source may be at capacity while the default has
     // headroom (Neon's 500-databases-per-branch limit).
-    const destRegion =
+    const requestedDestRegion =
       body.dest_region ??
       body.region ??
       process.env.BUTTERBASE_DEFAULT_REGION ??
       src.region;
 
-    // Reject clones targeting a region temporarily closed to new apps.
-    // BUTTERBASE_PROVISION_ALLOWED_REGIONS is a subset of BUTTERBASE_REGIONS
-    // — the latter controls serving, the former controls new writes. When
-    // unset, all serving regions accept new apps (existing behavior).
-    const provisionAllowedRaw =
+    // If the caller pinned a region temporarily closed to new apps (e.g.
+    // dashboard clone form defaults to source.region), silently redirect
+    // to the first open region rather than 400ing. Silent-failing clones
+    // during a hackathon is worse UX than a transparent cross-region
+    // clone. We log the override so operators can audit it.
+    const provisionAllowed = (
       process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS
         ?? process.env.BUTTERBASE_REGIONS
-        ?? '';
-    const provisionAllowed = provisionAllowedRaw.split(',').map((s) => s.trim()).filter(Boolean);
+        ?? ''
+    ).split(',').map((s) => s.trim()).filter(Boolean);
+    let destRegion = requestedDestRegion;
     if (provisionAllowed.length > 0 && !provisionAllowed.includes(destRegion)) {
-      return reply.code(400).send(createAgentError({
-        code: VALIDATION_INVALID_SCHEMA,
-        message: `Region "${destRegion}" is not currently accepting new apps.`,
-        remediation: `Pass an explicit dest_region from: ${provisionAllowed.join(', ')}.`,
-        documentation_url: getDocUrl(VALIDATION_INVALID_SCHEMA),
-      }));
+      const fallback = provisionAllowed[0];
+      request.log.warn(
+        { requestedDestRegion, destRegion: fallback, sourceRegion: src.region, allowed: provisionAllowed },
+        '[clone] redirecting new clone to open region',
+      );
+      destRegion = fallback;
     }
     const job = await createCloneJob(app.controlDb, {
       sourceAppId: source_app_id,

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -151,24 +151,33 @@ export async function initRoutes(app: FastifyInstance) {
         ?? ''
     ).split(',').map((s) => s.trim()).filter(Boolean);
     const bodyRegion = (request.body as { region?: string } | undefined)?.region;
-    const provisionRegion =
+    const requestedRegion =
       bodyRegion ??
       process.env.BUTTERBASE_DEFAULT_REGION ??
       provisionAllowed[0] ??
       allowedRegions[0] ??
       'local';
 
-    if (!allowedRegions.includes(provisionRegion)) {
+    if (!allowedRegions.includes(requestedRegion)) {
       return reply.code(400).send({
-        error: `Region "${provisionRegion}" is not in BUTTERBASE_REGIONS`,
+        error: `Region "${requestedRegion}" is not in BUTTERBASE_REGIONS`,
         allowed: allowedRegions,
       });
     }
-    if (!provisionAllowed.includes(provisionRegion)) {
-      return reply.code(400).send({
-        error: `Region "${provisionRegion}" is not currently accepting new apps`,
-        allowed: provisionAllowed,
-      });
+    // If the caller asked for a region that's temporarily closed to new
+    // apps, silently redirect to the first open region rather than 400ing.
+    // Dashboard/CLI flows often pin a region from the template's source and
+    // failing them mid-hackathon is worse UX than a transparent move. The
+    // response body doesn't currently expose region, so callers see nothing
+    // surprising; we log the override so operators can audit it.
+    let provisionRegion = requestedRegion;
+    if (provisionAllowed.length > 0 && !provisionAllowed.includes(requestedRegion)) {
+      const fallback = provisionAllowed[0];
+      request.log.warn(
+        { requestedRegion, provisionRegion: fallback, allowed: provisionAllowed },
+        '[init] redirecting new app to open region',
+      );
+      provisionRegion = fallback;
     }
     try {
       getDataProjectIdForRegion(provisionRegion);


### PR DESCRIPTION
## Summary
- Follow-up to #78. That PR returned 400 when a caller pinned a region that BUTTERBASE_PROVISION_ALLOWED_REGIONS excluded. This changes both routes (/init and /clone) to instead silently redirect to the first allowed region and log the override.
- Hackathon UX: dashboard clone forms pin dest_region to the template's source region. Failing them mid-flow is worse than a transparent cross-region provision.
- API response doesn't expose region today, so callers see nothing surprising. Log line lets operators audit the redirects.

## Test plan
- [ ] Deploy with BUTTERBASE_PROVISION_ALLOWED_REGIONS=us-west-2
- [ ] init_app with region us-east-1 → provisions in us-west-2 (200)
- [ ] init_app with region us-west-2 → provisions in us-west-2
- [ ] init_app no region → provisions in us-west-2
- [ ] clone with dest_region us-east-1 → clones to us-west-2
- [ ] clone default → clones to us-west-2
- [ ] Existing us-east-1 apps still serve normally
- [ ] Check logs for '[init] redirecting new app to open region' / '[clone] redirecting new clone to open region'