### PR TITLE
fix(provisioner): insertAppRow uses caller-resolved target org

### DIFF
--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -253,7 +253,7 @@ export async function initRoutes(app: FastifyInstance) {
     const appId = generateAppId();
 
     const { app: appRow, isExisting } = await insertAppRow(
-      provisionRegion, app.controlDb, name, ownerId, appId
+      provisionRegion, app.controlDb, name, ownerId, appId, orgId
     );
 
     if (isExisting) {

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -64,6 +64,7 @@ export async function insertAppRow(
   name: string,
   ownerId: string,
   appId: string,
+  targetOrganizationId?: string,
 ): Promise<{ app: App; isExisting: boolean }> {
   // Write the apps row into the TARGET region's runtime DB (where the app
   // is homed), not the local machine's runtime DB. Previously this used
@@ -81,8 +82,14 @@ export async function insertAppRow(
     return { app: existing.rows[0], isExisting: true };
   }
 
-  // Validate owner exists and resolve their org (platform-tier, stays on controlDb)
-  const organizationId = await resolveOrganizationId(controlDb, ownerId);
+  // Prefer the caller-resolved target org (matches what the route wrote to
+  // org_app_index). Falling back to resolveOrganizationId(ownerId) here —
+  // the pre-orgs path — silently placed team-org apps in the owner's
+  // personal org on the runtime side while org_app_index correctly pointed
+  // at the team org. The mismatch made those apps invisible in the
+  // dashboard's org-scoped list (which filters by apps.organization_id).
+  const organizationId = targetOrganizationId
+    ?? await resolveOrganizationId(controlDb, ownerId);
 
   const dbName = appId;
   await runtimeDb.query(


### PR DESCRIPTION
## Summary
Fix a silent cross-database inconsistency: `/init` writes the target org to `org_app_index` but the runtime `apps.organization_id` was always set to the caller's personal org. Team-org apps appeared to vanish from the dashboard because `dashboard-api`'s list query filters on `apps.organization_id`.

## Root cause
`/init` resolves the target org up-front (body `organization_id` → JWT `x-organization-id` → personal fallback) and uses it for `addOrgAppIndex`. But it passed only `ownerId` into `insertAppRow`, which then called `resolveOrganizationId(controlDb, ownerId)` independently — always returning the caller's personal org.

## Fix
- Add optional `targetOrganizationId` param to `insertAppRow`. When set, use it directly instead of re-resolving from the owner.
- `/init` passes the already-resolved `orgId`.
- Clone worker path unchanged (falls through to the old behavior). Clone-side fix needs `template_clone_jobs.target_organization_id` — filed as follow-up.

## Real-world incident
- Ramis (@hackathon, 2026-07-07) — reported his team-org apps invisible. Root cause was actually two-part: dashboard-api wasn't forwarding the header (fixed in internal PR #44), and this bug. His DB rows were repaired manually.
- Ken (self) — created two test apps via the fixed dashboard flow, hit the same runtime-side mismatch. Also repaired manually.

## Blast radius
Zero other affected apps in prod — team-org creates only started reaching this code path 30 min ago when internal PR #44 shipped the header plumbing. All 4 known affected apps were repaired via direct SQL before this PR.

## Test plan
- [ ] Deploy platform
- [ ] init_app with organization_id → runtime apps.organization_id matches
- [ ] init_app default → matches caller's personal org (existing behavior preserved)