### PR TITLE
fix(clone-worker): pass job.dest_organization_id into insertAppRow

### DIFF
--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -520,7 +520,21 @@ async function executeClone(
       } else {
         destAppId = generateAppId();
         const destName = job.dest_app_name ?? `Clone of ${job.source_app_id}`;
-        await insertAppRow(job.dest_region, controlDb, destName, job.requested_by_user_id, destAppId);
+
+        // Resolve the destination org up-front. Passed into insertAppRow so
+        // the runtime apps.organization_id lines up with the control-plane
+        // org_app_index write below. Without this, insertAppRow would fall
+        // back to resolveOrganizationId(user) → the requester's personal
+        // org — mirroring the /init bug fixed in provisioner.ts — and the
+        // clone would silently vanish from the target org's dashboard.
+        //
+        // Prefer the job's dest_organization_id (set by the clone route from
+        // the same precedence /init uses). Fall back to the requester's
+        // personal org for legacy jobs written before migration 092.
+        const destOrgId = job.dest_organization_id
+          ?? await resolveOrganizationId(controlDb, job.requested_by_user_id);
+
+        await insertAppRow(job.dest_region, controlDb, destName, job.requested_by_user_id, destAppId, destOrgId);
         await setCloneJobStatus(controlDb, jobId, { dest_app_id: destAppId });
 
         // Reserve a subdomain for the dest. Mirrors routes/init.ts: derive
@@ -543,12 +557,6 @@ async function executeClone(
         // Cross-region index so authorizeRepoRead/Write and other lookups can
         // resolve the dest app's region. Init route does the same step after
         // its insertAppRow; the clone worker is the equivalent caller here.
-        //
-        // Prefer the job's dest_organization_id (set by the clone route from
-        // the same precedence /init uses). Fall back to the requester's
-        // personal org for legacy jobs written before migration 092.
-        const destOrgId = job.dest_organization_id
-          ?? await resolveOrganizationId(controlDb, job.requested_by_user_id);
         await addOrgAppIndex(controlDb, {
           organizationId: destOrgId,
           appId: destAppId,


### PR DESCRIPTION
## Summary
Companion to #80. That PR made `insertAppRow` accept an optional target org but only threaded it through from `/init`. The clone worker still called `insertAppRow` with only the requester, so the runtime `apps.organization_id` was silently set to the requester's personal org (via `resolveOrganizationId`) — while `addOrgAppIndex` correctly used `job.dest_organization_id` for the control-plane row.

Same silent divergence that hid team-org apps from the dashboard, now on the clone path.

## Fix
Hoist the `destOrgId` computation above the `insertAppRow` call and pass it through as the 6th arg. The `job.dest_organization_id ?? resolveOrganizationId(user)` fallback is preserved for legacy jobs written before migration 092.

## Blast radius (post-#76 clones only)
Any dashboard clone where the caller was in a team org: `dest_organization_id` was populated on the job by `/clone`, but `insertAppRow` ignored it. Result was control-plane in team org, runtime in personal — the clone would silently vanish from the team org's dashboard. Frontend fix (dashboard-side) is shipping in the companion internal PR.

## Test plan
- [ ] Deploy platform
- [ ] Trigger a clone via MCP with `organization_id: <team-org>` → both `apps.organization_id` (runtime) and `org_app_index.organization_id` (control) reflect the team org
- [ ] Trigger a clone with no `organization_id` → both reflect the caller's personal org (existing behavior preserved)