### PR TITLE
chore(ctx-invoke-do): follow-ups — scrub fn key + backfill + rotate

### DIFF
--- a/scripts/backfill-do-invoker-env.ts
+++ b/scripts/backfill-do-invoker-env.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill: redeploy all apps with active Durable Objects so their DO Worker
+ * picks up the new DO_DISPATCH binding + DO_INVOKER_URL/TOKEN env bundle
+ * introduced by ctx.invokeDO.
+ *
+ * Background: on the ctx.invokeDO ship, control-api's bundleAndDeploy started
+ * injecting a dispatch_namespace binding named DO_DISPATCH and two platform
+ * env keys (DO_INVOKER_URL, DO_INVOKER_TOKEN) into every user DO Worker's
+ * metadata. Existing DO scripts deployed before that ship do NOT have any of
+ * these — they'll never gain them until their next bundleAndDeploy fires
+ * (e.g. the user runs manage_durable_objects deploy again, or edits DO env).
+ * This script forces a redeploy on each app so ctx.invoke / ctx.invokeDO
+ * from inside DO code Just Works everywhere.
+ *
+ * Usage:
+ *   BUTTERBASE_REGIONS=us-east-1,us-west-2 \
+ *   CONTROL_DB_URL=<control> \
+ *   NEON_RUNTIME_PROJECT_ID_US_EAST_1=<runtime-url> \
+ *   NEON_RUNTIME_PROJECT_ID_US_WEST_2=<runtime-url> \
+ *   DO_INVOKER_URL=... DO_INVOKER_TOKEN=... \
+ *   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... \
+ *   AUTH_ENCRYPTION_KEY=... \
+ *     tsx scripts/backfill-do-invoker-env.ts          # dry-run (default)
+ *     tsx scripts/backfill-do-invoker-env.ts --fix    # actually redeploy
+ *     tsx scripts/backfill-do-invoker-env.ts --fix --app app_xyz
+ *     tsx scripts/backfill-do-invoker-env.ts --fix --region us-east-1
+ *
+ * Environment: expects the SAME env the control-api process runs with in
+ * prod (CF creds + region URLs + AES key + do-invoker URL/TOKEN so
+ * config.doInvoker resolves). Simplest way: fly ssh into butterbase-platform,
+ * `env > /tmp/env`, then run this script locally with `env $(cat /tmp/env)`
+ * — or invoke it inside the Fly container directly.
+ */
+import pg from 'pg';
+
+const FIX = process.argv.includes('--fix');
+const APP_ARG_IDX = process.argv.indexOf('--app');
+const APP_FILTER = APP_ARG_IDX >= 0 ? process.argv[APP_ARG_IDX + 1] : null;
+const REGION_ARG_IDX = process.argv.indexOf('--region');
+const REGION_FILTER = REGION_ARG_IDX >= 0 ? process.argv[REGION_ARG_IDX + 1] : null;
+
+interface AppRow {
+  app_id: string;
+  active_class_count: number;
+}
+
+async function findAppsWithActiveDOs(pool: pg.Pool): Promise<AppRow[]> {
+  const filterClause = APP_FILTER ? 'AND app_id = $1' : '';
+  const params: unknown[] = APP_FILTER ? [APP_FILTER] : [];
+  const r = await pool.query<AppRow>(
+    `SELECT app_id, COUNT(*)::int AS active_class_count
+       FROM app_durable_objects
+      WHERE status = 'READY' ${filterClause}
+      GROUP BY app_id
+      ORDER BY app_id`,
+    params,
+  );
+  return r.rows;
+}
+
+async function processRegion(
+  region: string,
+  runtimeUrl: string,
+  controlPool: pg.Pool,
+): Promise<{ found: number; redeployed: number; failed: number }> {
+  const runtimePool = new pg.Pool({ connectionString: runtimeUrl });
+  const stats = { found: 0, redeployed: 0, failed: 0 };
+  try {
+    const apps = await findAppsWithActiveDOs(runtimePool);
+    stats.found = apps.length;
+    console.log(`[${region}] ${apps.length} app(s) with active DOs`);
+
+    if (!FIX) {
+      for (const { app_id, active_class_count } of apps) {
+        console.log(`  [${app_id}] ${active_class_count} class(es) — would redeploy`);
+      }
+      return stats;
+    }
+
+    // Lazy import so the script can dry-run without pulling in control-api
+    // deps (crypto, cf-client, etc.).
+    const { redeployIfActive } = await import(
+      '../services/control-api/src/services/durable-objects.service.js'
+    );
+
+    for (const { app_id, active_class_count } of apps) {
+      process.stdout.write(`  [${app_id}] ${active_class_count} class(es) — redeploying… `);
+      try {
+        const started = Date.now();
+        const didRedeploy = await redeployIfActive(runtimePool, controlPool, app_id);
+        if (didRedeploy) {
+          stats.redeployed++;
+          console.log(`ok (${Date.now() - started}ms)`);
+        } else {
+          console.log(`skipped (no active classes)`);
+        }
+      } catch (err) {
+        stats.failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`FAIL: ${msg}`);
+      }
+    }
+  } finally {
+    await runtimePool.end();
+  }
+  return stats;
+}
+
+async function main(): Promise<void> {
+  const controlUrl = process.env.CONTROL_DB_URL;
+  if (!controlUrl) throw new Error('CONTROL_DB_URL is required');
+
+  const regionsRaw = (process.env.BUTTERBASE_REGIONS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+  const regions = REGION_FILTER
+    ? regionsRaw.filter(r => r === REGION_FILTER)
+    : regionsRaw;
+  if (regions.length === 0) {
+    throw new Error(REGION_FILTER
+      ? `BUTTERBASE_REGIONS does not include --region ${REGION_FILTER}`
+      : 'BUTTERBASE_REGIONS is empty');
+  }
+
+  console.log(`mode: ${FIX ? 'APPLY (real redeploy)' : 'dry-run'}`);
+  if (APP_FILTER) console.log(`app filter: ${APP_FILTER}`);
+  if (REGION_FILTER) console.log(`region filter: ${REGION_FILTER}`);
+
+  if (FIX && !process.env.CLOUDFLARE_API_TOKEN) {
+    throw new Error('--fix requires CLOUDFLARE_API_TOKEN (each redeploy PUTs to CF)');
+  }
+  if (FIX && !process.env.DO_INVOKER_URL) {
+    console.warn('WARNING: DO_INVOKER_URL not set — redeployed DOs will NOT get the invoker env keys. Set DO_INVOKER_URL + DO_INVOKER_TOKEN before running with --fix if you want a full backfill.');
+  }
+
+  const controlPool = new pg.Pool({ connectionString: controlUrl });
+  let totalFound = 0, totalRedeployed = 0, totalFailed = 0;
+
+  try {
+    for (const region of regions) {
+      const urlVar = `NEON_RUNTIME_PROJECT_ID_${region.toUpperCase().replace(/-/g, '_')}`;
+      const url = process.env[urlVar];
+      if (!url) {
+        console.warn(`[${region}] no ${urlVar}; skipping`);
+        continue;
+      }
+      const s = await processRegion(region, url, controlPool);
+      totalFound += s.found;
+      totalRedeployed += s.redeployed;
+      totalFailed += s.failed;
+    }
+  } finally {
+    await controlPool.end();
+  }
+
+  console.log(`\nsummary: ${totalFound} app(s) with active DOs, ${totalRedeployed} redeployed, ${totalFailed} failed`);
+  if (!FIX && totalFound > 0) {
+    console.log('(run with --fix to actually redeploy)');
+  }
+  if (totalFailed > 0) process.exit(1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/rotate-do-invoker-token.sh
+++ b/scripts/rotate-do-invoker-token.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Rotate DO_INVOKER_TOKEN across the three places that must agree:
+#
+#   1. Cloudflare Worker `do-invoker` (wrangler secret)
+#   2. Fly app `butterbase-platform` (control-api reads it into config.doInvoker,
+#      injected into every user DO Worker's env bundle on next bundleAndDeploy)
+#   3. Fly app `butterbase-runtime` (deno-runtime reads it into the fn ctx source
+#      inlined for ctx.invokeDO's Authorization header)
+#
+# Any drift between these three values breaks ctx.invokeDO with a 401 at the
+# do-invoker shim.
+#
+# Usage:
+#   scripts/rotate-do-invoker-token.sh
+#
+# Env (required):
+#   CLOUDFLARE_ACCOUNT_ID    — the CF account do-invoker lives on
+#
+# Env (optional):
+#   FLY_PLATFORM_APP=butterbase-platform
+#   FLY_RUNTIME_APP=butterbase-runtime
+#   WORKER_NAME=do-invoker
+#   DRY_RUN=1                — print what would happen, don't touch anything
+#
+set -euo pipefail
+
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+FLY_PLATFORM_APP="${FLY_PLATFORM_APP:-butterbase-platform}"
+FLY_RUNTIME_APP="${FLY_RUNTIME_APP:-butterbase-runtime}"
+WORKER_NAME="${WORKER_NAME:-do-invoker}"
+
+log() { printf '%s\n' "$*" >&2; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Sanity-check the CLIs before we start rotating anything.
+command -v wrangler >/dev/null || die "wrangler CLI not found on PATH"
+command -v fly >/dev/null || die "fly CLI not found on PATH"
+command -v openssl >/dev/null || die "openssl not found on PATH"
+command -v curl >/dev/null || die "curl not found on PATH"
+
+# 1. Mint a fresh token. 32 bytes / 64 hex chars.
+NEW_TOKEN="$(openssl rand -hex 32)"
+if [ "${#NEW_TOKEN}" -ne 64 ]; then
+  die "openssl rand did not produce a 64-char token"
+fi
+log "==> minted new token (64 hex chars, first 8 = ${NEW_TOKEN:0:8}…)"
+
+if [ "${DRY_RUN:-}" = "1" ]; then
+  log "DRY_RUN=1 — would now set on:"
+  log "  - CF Worker $WORKER_NAME (account $CLOUDFLARE_ACCOUNT_ID)"
+  log "  - Fly app $FLY_PLATFORM_APP"
+  log "  - Fly app $FLY_RUNTIME_APP"
+  exit 0
+fi
+
+# 2. Set on the CF Worker first. If this fails the platform is unchanged.
+log "==> setting DO_INVOKER_TOKEN on CF Worker $WORKER_NAME"
+printf '%s' "$NEW_TOKEN" | CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" wrangler secret put DO_INVOKER_TOKEN --name "$WORKER_NAME" >&2 \
+  || die "wrangler secret put failed"
+
+# 3. Discover the Worker URL — needed for the verify step. wrangler doesn't
+# expose it cleanly, so grep it out of `wrangler deployments list` output.
+WORKER_URL="$(wrangler deployments list --name "$WORKER_NAME" 2>&1 | grep -oE 'https://[a-z0-9.-]+\.workers\.dev' | head -1 || true)"
+if [ -z "$WORKER_URL" ]; then
+  # Fallback: try the common shape. Caller can also set WORKER_URL explicitly.
+  WORKER_URL="${WORKER_URL_OVERRIDE:-https://${WORKER_NAME}.workers.dev}"
+  warn "could not auto-detect worker URL; falling back to $WORKER_URL. Set WORKER_URL_OVERRIDE if this is wrong."
+fi
+
+# 4. Stage on both Fly apps. --stage means the machine is NOT restarted yet;
+# a subsequent `fly deploy` or `fly machine restart` picks it up.
+for APP in "$FLY_PLATFORM_APP" "$FLY_RUNTIME_APP"; do
+  log "==> staging DO_INVOKER_TOKEN on Fly app $APP"
+  fly secrets set --stage --app "$APP" DO_INVOKER_TOKEN="$NEW_TOKEN" >&2 \
+    || die "fly secrets set --stage failed on $APP"
+done
+
+# 5. Restart the machines so the new token is actually live in-process.
+# Using restart rather than deploy so we don't rebuild the image.
+for APP in "$FLY_PLATFORM_APP" "$FLY_RUNTIME_APP"; do
+  log "==> restarting machines on $APP so the staged secret takes effect"
+  fly machine restart --app "$APP" >&2 \
+    || die "fly machine restart failed on $APP — token is staged but not live; manual rollback needed"
+done
+
+# 6. Verify: hit /invoke with the new bearer. Expect 400 (missing routing
+# headers), NOT 401 (which would mean the CF secret didn't propagate).
+log "==> verifying new token against $WORKER_URL/invoke"
+sleep 3  # small buffer for CF secret propagation.
+STATUS="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "authorization: Bearer $NEW_TOKEN" "$WORKER_URL/invoke")"
+if [ "$STATUS" = "400" ]; then
+  log "✓ verified: 400 (missing routing headers) — new token accepted"
+elif [ "$STATUS" = "401" ]; then
+  die "verification 401 — CF secret did not propagate. Fly is now on the NEW token but CF is still on the OLD one. Re-run wrangler secret put manually and re-verify."
+else
+  warn "verification returned $STATUS (expected 400) — investigate before considering rotation complete"
+fi
+
+log ""
+log "rotation complete."
+log "next: audit-log the rotation, and confirm ctx.invokeDO in a test fn still works."

--- a/services/control-api/src/services/do-bundler.test.ts
+++ b/services/control-api/src/services/do-bundler.test.ts
@@ -157,6 +157,13 @@ describe('bundler butterbase.ctx helper', () => {
     expect(bundle).toMatch(/delete\s+\w+\.DO_INVOKER_URL/);
   });
 
+  it("scrubs BUTTERBASE_INTERNAL_FN_KEY from ctx.env (user code should use ctx.invoke)", () => {
+    const { bundle } = buildBundle([
+      { name: 'my-do', code: 'export class MyDo { async fetch(req) { return new Response("ok"); } }', access_mode: 'public' },
+    ]);
+    expect(bundle).toMatch(/delete\s+\w+\.BUTTERBASE_INTERNAL_FN_KEY/);
+  });
+
   it('emits an invokeDO that POSTs to DO_INVOKER_URL/invoke with the right headers', () => {
     const { bundle } = buildBundle([
       { name: 'my-do', code: 'export class MyDo { async fetch(req) { return new Response("ok"); } }', access_mode: 'public' },

--- a/services/control-api/src/services/do-bundler.ts
+++ b/services/control-api/src/services/do-bundler.ts
@@ -254,6 +254,9 @@ const butterbase = {
     const env = { ...envIn };
     delete env.DO_INVOKER_URL;
     delete env.DO_INVOKER_TOKEN;
+    // Platform-injected key used by ctx.invoke below; user code should use
+    // ctx.invoke instead of reading it directly, so hide it from ctx.env.
+    delete env.BUTTERBASE_INTERNAL_FN_KEY;
 
     const caller = req.headers.get('x-butterbase-internal-caller');
     const loopDepthIn = Number(req.headers.get('x-butterbase-loop-depth') || '0') || 0;


### PR DESCRIPTION
Three small follow-ups to the ctx.invokeDO ship (#84).

## Changes

- **do-bundler**: also delete BUTTERBASE_INTERNAL_FN_KEY from ctx.env. Task 7 injects it so the butterbase.ctx() helper's ctx.invoke can mint fn→fn bearer headers; user code should call ctx.invoke instead of reading the key directly. Prod smoke on #84 confirmed the key was visible via ctx.env — this closes that leak.
- **scripts/backfill-do-invoker-env.ts**: iterate all apps with active DOs across regions and call redeployIfActive(). Existing DOs deployed before #84 shipped do NOT have the DO_DISPATCH binding / invoker env until their next bundleAndDeploy fires. Dry-run default; --fix; --app / --region.
- **scripts/rotate-do-invoker-token.sh**: atomic rotation across CF Worker + both Fly apps + probe-verify at the end (expect 400 missing routing headers, NOT 401).

## Test plan

- [x] Unit test for the scrub (do-bundler.test.ts, 21/21 pass)
- [x] Backfill dry-run against local (0 candidates — expected, local DOs are ERROR not READY)
- [x] Rotation script DRY_RUN pass through
- [ ] Post-deploy: re-run the prod E2E — expect `env_leaks_fn_key: false` on the DO probe response