### PR TITLE
docs: CHANGELOG + DO docs for follow-ups (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 
 ### Added
 
+- **Durable Objects (security)**: `ctx.env` on the DO side now scrubs
+  `BUTTERBASE_INTERNAL_FN_KEY` (in addition to `DO_INVOKER_URL` /
+  `DO_INVOKER_TOKEN`). The platform still injects the key into DO env so
+  `ctx.invoke` can mint fn→fn bearer headers — user code should use
+  `ctx.invoke(...)` instead of reading the key directly. Old DO code that
+  ignored `ctx.env` is unaffected.
+- **Ops**: `scripts/backfill-do-invoker-env.ts` — iterate all apps with active
+  Durable Objects and call `redeployIfActive` on each so their DO Worker picks
+  up the `DO_DISPATCH` binding + `DO_INVOKER_*` env keys. Dry-run default;
+  `--fix` to apply; `--app` / `--region` to scope. Run once after the first
+  ctx.invokeDO deploy per environment.
+- **Ops**: `scripts/rotate-do-invoker-token.sh` — atomic rotation across the
+  `do-invoker` CF Worker (`wrangler secret put`) and both Fly apps
+  (`butterbase-platform`, `butterbase-runtime`). Verifies at the end by
+  probing `/invoke` with the new bearer (expects 400 missing routing headers,
+  NOT 401). Set `DRY_RUN=1` to walk through without touching anything.
 - **Functions**: `ctx.invokeDO(className, instanceKey, body?, opts?)` for calling a
   same-app Durable Object from a function. Uses a platform-managed bearer (never
   exposed via `ctx.env`); intra-app callers reach the DO without going through

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -188,6 +188,20 @@ const { data, error } = await butterbase.functions.invoke('my-function', {
 });
 ```
 
+> **Inside a function's handler** (server-side, not this client SDK), your
+> `ctx` gives you the same primitives for calling siblings without plumbing
+> a bearer:
+>
+> ```typescript
+> export async function handler(req, ctx) {
+>   const r1 = await ctx.invoke('sibling-fn', { hello: 'world' });
+>   const r2 = await ctx.invokeDO('room', 'room-42', { cmd: 'join' });
+>   return new Response('ok');
+> }
+> ```
+>
+> See the platform docs: [Functions → Server-to-server](https://docs.butterbase.ai/core-concepts/functions#server-to-server-function-calls) and [Durable Objects → Server-to-server](https://docs.butterbase.ai/core-concepts/durable-objects#server-to-server-calls-into-durable-objects).
+
 ## Query Builder
 
 ### Operators

--- a/services/docs/src/content/docs/core-concepts/durable-objects.md
+++ b/services/docs/src/content/docs/core-concepts/durable-objects.md
@@ -227,6 +227,23 @@ DO code opts into ctx via a helper. The bundler prepends `butterbase` to every D
 
 Old DO code that doesn't call `butterbase.ctx(...)` continues to work unchanged.
 
+### What's NOT in `ctx.env`
+
+`ctx.env` deliberately hides platform-only keys that user code should never
+read directly:
+
+- `DO_INVOKER_URL` / `DO_INVOKER_TOKEN` — the shim's bearer. Use
+  `ctx.invokeDO(...)` instead of trying to reach it yourself.
+- `BUTTERBASE_INTERNAL_FN_KEY` — the fn-invocation bearer. Use `ctx.invoke(...)`
+  instead of minting your own Authorization header.
+
+Everything else (all `BUTTERBASE_*` platform values, your `app_env_vars`, your
+per-DO env vars) remains visible via `ctx.env` exactly as documented for
+functions. If you want the underlying `this.env` directly (e.g. to log the
+raw key set for a bug report), that's still available inside the class body
+untouched — the scrub only applies to the object returned by
+`butterbase.ctx(...)`.
+
 ### Who called me?
 
 Requests arriving via server-to-server routing carry:

--- a/services/mcp-server/src/tools/deploy-function.ts
+++ b/services/mcp-server/src/tools/deploy-function.ts
@@ -83,6 +83,15 @@ Example:
     });
   }
 
+Server-to-server calls from inside a function:
+  - ctx.invoke('fn-name', body?, opts?) — call a sibling function in the same app.
+    Platform-managed bearer, no env plumbing. ctx.user.id propagates automatically;
+    the callee sees ctx.caller.type === 'loopback'. Loop-depth capped at 4.
+  - ctx.invokeDO('class-name', 'instance-key', body?, opts?) — call a sibling
+    Durable Object in the same app. Routed through a platform shim; no public
+    URL or bearer to plumb. Depth shared with ctx.invoke.
+  See docs → Functions → Server-to-server, and Durable Objects → Server-to-server.
+
 Row-Level Security in Functions:
   Functions respect RLS policies based on how they're invoked:
 


### PR DESCRIPTION
Belated docs pass for the ctx.invokeDO follow-ups shipped in #85.

- CHANGELOG.md Unreleased entries for the scrub, backfill script, and rotation script.
- durable-objects.md gains a 'What's NOT in ctx.env' subsection covering the three scrubbed keys and why (users should use ctx.invoke / ctx.invokeDO instead of the underlying bearers).

Docs-only; no code changes.