### PR TITLE
perf(rls): wrap current_setting('app.role') so the service-role check runs once per statement

### DIFF
--- a/db/data-plane/005_rls_role_based.sql
+++ b/db/data-plane/005_rls_role_based.sql
@@ -34,8 +34,8 @@ BEGIN
           EXECUTE format(
             'CREATE POLICY "butterbase_service_policy" ON %I.%I
              FOR ALL
-             USING (current_setting(''app.role'', true) = ''butterbase_service'')
-             WITH CHECK (current_setting(''app.role'', true) = ''butterbase_service'')',
+             USING ((select current_setting(''app.role'', true)) = ''butterbase_service'')
+             WITH CHECK ((select current_setting(''app.role'', true)) = ''butterbase_service'')',
             schema_name, table_name
           );
 
@@ -74,8 +74,8 @@ BEGIN
       EXECUTE format(
         'CREATE POLICY "butterbase_service_policy" ON %I.%I
          FOR ALL
-         USING (current_setting(''app.role'', true) = ''butterbase_service'')
-         WITH CHECK (current_setting(''app.role'', true) = ''butterbase_service'')',
+         USING ((select current_setting(''app.role'', true)) = ''butterbase_service'')
+         WITH CHECK ((select current_setting(''app.role'', true)) = ''butterbase_service'')',
         tbl.schemaname, tbl.tablename
       );
 


### PR DESCRIPTION
## What

`db/data-plane/005_rls_role_based.sql` creates `butterbase_service_policy` on two tables with the service-role check embedded directly in the predicate:

```sql
USING (current_setting('app.role', true) = 'butterbase_service')
WITH CHECK (current_setting('app.role', true) = 'butterbase_service')
```

Unwrapped like this, Postgres re-evaluates `current_setting('app.role', true)` **once per row scanned** — it can't tell the call is constant across the statement.

## Fix

Wrap the session lookup in a scalar sub-select so the planner hoists it to a one-time InitPlan (once per statement instead of once per row):

```sql
USING ((select current_setting('app.role', true)) = 'butterbase_service')
WITH CHECK ((select current_setting('app.role', true)) = 'butterbase_service')
```

The value is identical within a statement, so this is a pure planner optimization — same rows, fewer GUC lookups. Applied to both policy blocks in the file.

Surfaced by [pgrls](https://github.com/pgrls/pgrls) (`PERF001`), an open-source Postgres RLS linter / verifier.
