### PR TITLE
feat(clone): auto-mint bb_sk_ into DO env slots on clone

### DIFF
--- a/packages/static-frontend-worker/Dockerfile
+++ b/packages/static-frontend-worker/Dockerfile
@@ -45,8 +45,20 @@ WORKDIR /app
 # Match the devDep version from the package's package.json. Hardcoded here
 # instead of read-from-package because we don't carry the workspace into
 # this stage. Bump in lockstep with packages/static-frontend-worker/package.json.
+#
+# --include=optional is REQUIRED: workerd ships its platform-specific binary
+# (@cloudflare/workerd-linux-{amd64,arm64}) as an optionalDependency, and
+# recent npm versions drop optional deps when --omit=dev is set alone, which
+# makes the container crash at runtime with "The package
+# @cloudflare/workerd-linux-arm64 could not be found."
+#
+# Do NOT pipe npm through `| tail -N` here without also setting pipefail —
+# an earlier version of this line piped through `| tail -5` and silently
+# swallowed npm's non-zero exit, producing an image missing the workerd
+# binary. node:22-slim's /bin/sh is dash and doesn't support pipefail, so
+# we just let npm output land in the build log in full.
 RUN npm init -y >/dev/null && \
-    npm install --omit=dev --no-package-lock miniflare@^4.20260426.0 2>&1 | tail -5
+    npm install --omit=dev --include=optional --no-package-lock miniflare@^4.20260426.0
 
 COPY --from=builder /app/submodules/butterbase-oss/packages/static-frontend-worker/dist ./dist/
 COPY --from=builder /app/submodules/butterbase-oss/packages/static-frontend-worker/scripts ./scripts/

--- a/services/control-api/src/routes/__tests__/clone-preflight-do-key-meta.test.ts
+++ b/services/control-api/src/routes/__tests__/clone-preflight-do-key-meta.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// Mocks matching the shape of the sibling clone-preflight.test.ts, except
+// AUTO_MINT_CONVENTION_KEYS carries the real convention names so the route's
+// classify() branch can annotate DO env keys.
+vi.mock('../../services/region-resolver.js', () => ({
+  resolveAppHomeRegion: vi.fn().mockResolvedValue('us-east-1'),
+}));
+vi.mock('../../services/runtime-db.js', () => ({
+  getRuntimeDbPool: vi.fn(),
+}));
+vi.mock('../../services/clone-env-vars.js', () => ({
+  listSourceEnvVarKeys: vi.fn().mockResolvedValue([]),
+  detectConventions: vi.fn().mockReturnValue([]),
+  AUTO_MINT_CONVENTION_KEYS: ['BUTTERBASE_API_KEY', 'BB_SUBSTRATE_KEY'],
+  STATIC_FILL_KEYS: [],
+}));
+vi.mock('../../services/durable-objects.service.js', () => ({
+  listDoEnvVarKeys: vi.fn(),
+}));
+vi.mock('../../services/crypto.js', () => ({
+  encrypt: vi.fn((s: string) => `encrypted_${s}`),
+  decrypt: vi.fn((s: string) => s.replace('encrypted_', '')),
+}));
+
+import Fastify from 'fastify';
+import { cloneRoutesPreflight } from '../clone-preflight.js';
+import { getRuntimeDbPool } from '../../services/runtime-db.js';
+import { listDoEnvVarKeys } from '../../services/durable-objects.service.js';
+
+describe('GET clone-preflight annotates DO env keys via key_meta', () => {
+  let app: FastifyInstance;
+  let mockRuntime: { query: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    vi.stubEnv('AUTH_ENCRYPTION_KEY', '00'.repeat(32));
+    mockRuntime = { query: vi.fn() };
+    (getRuntimeDbPool as any).mockReturnValue(mockRuntime);
+    (listDoEnvVarKeys as any).mockReset();
+
+    // Default: source is a public app with no fn/app env vars. Individual
+    // tests override the DO env key list via listDoEnvVarKeys mock.
+    mockRuntime.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM apps')) {
+        return { rows: [{ visibility: 'public', owner_id: 'u_owner' }] };
+      }
+      return { rows: [] };
+    });
+
+    app = Fastify();
+    (app as any).controlDb = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    cloneRoutesPreflight(app);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('marks BUTTERBASE_API_KEY on the DO side as auto_filled and skips the "must re-set" note', async () => {
+    (listDoEnvVarKeys as any).mockResolvedValue(['BUTTERBASE_API_KEY']);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/templates/app_source_x/clone-preflight',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.durable_objects.env_keys).toEqual(['BUTTERBASE_API_KEY']);
+    expect(body.durable_objects.key_meta).toEqual([
+      {
+        key: 'BUTTERBASE_API_KEY',
+        status: 'auto_filled',
+        reason: 'Auto-minted bb_sk_* scoped to the new app (shared with functions).',
+      },
+    ]);
+    // Note only fires for user_required keys. All keys are auto_filled here,
+    // so no leftover "must re-set post-clone" copy — that would be misleading.
+    expect(body.durable_objects.note).toBeUndefined();
+  });
+
+  it('marks non-convention DO keys as user_required and keeps the re-set note', async () => {
+    (listDoEnvVarKeys as any).mockResolvedValue(['CUSTOM_SECRET', 'ANOTHER_KEY']);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/templates/app_source_x/clone-preflight',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.durable_objects.env_keys.sort()).toEqual(['ANOTHER_KEY', 'CUSTOM_SECRET']);
+    expect(body.durable_objects.key_meta).toEqual([
+      { key: 'CUSTOM_SECRET', status: 'user_required' },
+      { key: 'ANOTHER_KEY', status: 'user_required' },
+    ]);
+    expect(body.durable_objects.note).toMatch(/user_required key/);
+  });
+
+  it('mixes classifications when source has both convention and non-convention DO keys', async () => {
+    (listDoEnvVarKeys as any).mockResolvedValue(['BB_SUBSTRATE_KEY', 'CUSTOM_SECRET']);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/templates/app_source_x/clone-preflight',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.durable_objects.key_meta).toEqual([
+      {
+        key: 'BB_SUBSTRATE_KEY',
+        status: 'auto_filled',
+        reason: 'Auto-minted bb_sk_* scoped to the new app (shared with functions).',
+      },
+      { key: 'CUSTOM_SECRET', status: 'user_required' },
+    ]);
+    // Note fires because at least one key is user_required.
+    expect(body.durable_objects.note).toMatch(/user_required key/);
+  });
+
+  it('emits an empty key_meta and no note when the source has no DO env keys', async () => {
+    (listDoEnvVarKeys as any).mockResolvedValue([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/templates/app_source_x/clone-preflight',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.durable_objects.env_keys).toEqual([]);
+    expect(body.durable_objects.key_meta).toEqual([]);
+    expect(body.durable_objects.note).toBeUndefined();
+  });
+});

--- a/services/control-api/src/routes/clone-preflight.ts
+++ b/services/control-api/src/routes/clone-preflight.ts
@@ -142,8 +142,17 @@ export function cloneRoutesPreflight(app: FastifyInstance) {
           })),
           durable_objects: {
             env_keys: doEnvKeys,
-            note: doEnvKeys.length > 0
-              ? 'DO env var values are not carried across clones. Re-set each key via manage_durable_objects action=set_env once the clone completes.'
+            // Same per-key annotation shape as functions: convention keys are
+            // auto-minted with the shared clone bb_sk_*; anything else remains
+            // a secret the caller must re-set via manage_durable_objects
+            // action=set_env after clone.
+            key_meta: doEnvKeys.map((k) =>
+              AUTO_MINT_CONVENTION_KEYS.includes(k)
+                ? { key: k, status: 'auto_filled' as const, reason: 'Auto-minted bb_sk_* scoped to the new app (shared with functions).' }
+                : { key: k, status: 'user_required' as const },
+            ),
+            note: doEnvKeys.some((k) => !AUTO_MINT_CONVENTION_KEYS.includes(k))
+              ? 'Non-convention DO env values are not carried across clones. Re-set each user_required key via manage_durable_objects action=set_env once the clone completes.'
               : undefined,
           },
           app_env: {

--- a/services/control-api/src/services/__tests__/clone-env-vars.test.ts
+++ b/services/control-api/src/services/__tests__/clone-env-vars.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { listSourceEnvVarKeys, detectConventions, mintApiKeyForClone, resolveStaticFills, AUTO_MINT_CONVENTION_KEYS, STATIC_FILL_KEYS } from '../clone-env-vars.js';
 import { encrypt } from '../crypto.js';
-import { runtimeDb, controlDb } from '../../__tests__/test-helpers/control-db.js';
-import { randomUUID } from 'node:crypto';
+import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/control-db.js';
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
 const describeDb = RUN_DB_TESTS ? describe : describe.skip;
@@ -90,13 +89,10 @@ describe('resolveStaticFills', () => {
 
 describeDb('mintApiKeyForClone', () => {
   it('mints a bb_sk_* key scoped to the dest app and owner', async () => {
-    const ownerId = randomUUID();
-    // platform_users has a FK target — seed an owner row first
-    await controlDb.query(
-      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true)
-       ON CONFLICT (id) DO NOTHING`,
-      [ownerId, `auto-mint-test-${ownerId}@x.com`],
-    );
+    // Seed a platform_users row (with the required personal_organization_id
+    // populated) via the shared helper — a plain INSERT would violate the
+    // NOT NULL FK constraint on platform_users.personal_organization_id.
+    const { id: ownerId } = await seedUser(`auto-mint-test-${Date.now()}@x.com`);
 
     const destAppId = `app_dest_mint_test_${ownerId.slice(0, 8)}`;
     const { key, keyId } = await mintApiKeyForClone(controlDb, {
@@ -117,6 +113,9 @@ describeDb('mintApiKeyForClone', () => {
     expect(row.rows[0].name).toBe(`Auto-mint for clone (${destAppId})`);
 
     await controlDb.query(`DELETE FROM api_keys WHERE id = $1`, [keyId]);
+    // platform_users first (FK: user.personal_organization_id → orgs.id),
+    // organizations second — reverse of seedUser's insert order.
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
   });
 });

--- a/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
+++ b/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { replayFunctions } from '../clone-replay.js';
 import { decrypt } from '../crypto.js';
-import { runtimeDb, controlDb } from '../../__tests__/test-helpers/control-db.js';
-import { randomUUID } from 'node:crypto';
+import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/control-db.js';
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
 const describeDb = RUN_DB_TESTS ? describe : describe.skip;
@@ -11,11 +10,7 @@ const noopLogger = { info() {}, warn() {} };
 
 describeDb('replayFunctions with pending env vars', () => {
   it('writes provided values into the dest function encrypted_env_vars', async () => {
-    const ownerId = randomUUID();
-    await controlDb.query(
-      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
-      [ownerId, `replay-env-${ownerId}@x.com`],
-    );
+    const { id: ownerId } = await seedUser(`replay-env-${Date.now()}@x.com`);
     const srcId = `app_replay_src_${ownerId.slice(0, 8)}`;
     const destId = `app_replay_dst_${ownerId.slice(0, 8)}`;
     for (const id of [srcId, destId]) {
@@ -49,14 +44,11 @@ describeDb('replayFunctions with pending env vars', () => {
     await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
   });
 
   it('reports unfilled keys when source has more keys than the user supplied', async () => {
-    const ownerId = randomUUID();
-    await controlDb.query(
-      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
-      [ownerId, `replay-env-unf-${ownerId}@x.com`],
-    );
+    const { id: ownerId } = await seedUser(`replay-env-unf-${Date.now()}@x.com`);
     const srcId = `app_replay_src_unf_${ownerId.slice(0, 8)}`;
     const destId = `app_replay_dst_unf_${ownerId.slice(0, 8)}`;
     for (const id of [srcId, destId]) {
@@ -86,6 +78,7 @@ describeDb('replayFunctions with pending env vars', () => {
     await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
   });
 
   // Phase 4 contract: one shared bb_sk_* per clone, fanned out to every fn
@@ -94,11 +87,7 @@ describeDb('replayFunctions with pending env vars', () => {
   // callee compared the bearer to its own env. See
   // backfill-consolidate-clone-keys.ts for the matching cleanup script.
   it('mints exactly one shared bb_sk_* and assigns the same value to every fn', async () => {
-    const ownerId = randomUUID();
-    await controlDb.query(
-      `INSERT INTO platform_users (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING`,
-      [ownerId, `replay-shared-${ownerId}@x.com`],
-    );
+    const { id: ownerId } = await seedUser(`replay-shared-${Date.now()}@x.com`);
     const srcId = `app_replay_shared_src_${ownerId.slice(0, 8)}`;
     const destId = `app_replay_shared_dst_${ownerId.slice(0, 8)}`;
     for (const id of [srcId, destId]) {
@@ -153,5 +142,6 @@ describeDb('replayFunctions with pending env vars', () => {
     await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
   });
 });

--- a/services/control-api/src/services/__tests__/clone-replay-pre-minted-shared-key.test.ts
+++ b/services/control-api/src/services/__tests__/clone-replay-pre-minted-shared-key.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { replayFunctions } from '../clone-replay.js';
+import { decrypt, encrypt } from '../crypto.js';
+import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/control-db.js';
+
+// This file covers the DO/fn parity path introduced with `preMintedSharedKey`.
+// When the orchestrator (neon-task-worker) mints a shared bb_sk_* for the DO
+// side, it passes the same key into replayFunctions so both sides carry the
+// exact same intra-app credential. Two invariants under test:
+//   1. The value is reused verbatim (fn env decrypts to the exact string passed).
+//   2. No second mint happens — api_keys stays empty for that clone.
+// The companion "existing behavior when not provided" case is already covered
+// by clone-replay-env-vars.test.ts:96 ("mints exactly one shared bb_sk_*").
+
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
+const describeDb = RUN_DB_TESTS ? describe : describe.skip;
+
+const noopLogger = { info() {}, warn() {} };
+
+describeDb('replayFunctions honors preMintedSharedKey', () => {
+  it('reuses the pre-minted key verbatim across every convention-key function', async () => {
+    const { id: ownerId } = await seedUser(`pre-minted-${Date.now()}@x.com`);
+    const srcId = `app_pre_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_pre_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+         ON CONFLICT (id) DO NOTHING`,
+        [id, ownerId],
+      );
+    }
+    // Every source fn declares BUTTERBASE_API_KEY, so replayFunctions'
+    // convention detection triggers on all three.
+    const enc = encrypt(
+      JSON.stringify({ BUTTERBASE_API_KEY: 'placeholder-in-source' }),
+      process.env.AUTH_ENCRYPTION_KEY!,
+    );
+    for (const fn of ['agent-chat', 'ingest', 'cron']) {
+      await runtimeDb.query(
+        `INSERT INTO app_functions (id, app_id, name, code, encrypted_env_vars, deployed_by)
+         VALUES (gen_random_uuid(), $1, $2, '/* code */', $3, $4)`,
+        [srcId, fn, enc, ownerId],
+      );
+    }
+
+    // The sentinel value we hand in — a real orchestrator would pass a freshly
+    // minted bb_sk_*, but for testing the reuse path any string works.
+    const PRE_MINTED = 'bb_sk_pre_minted_from_orchestrator_12345';
+
+    const result = await replayFunctions(
+      runtimeDb, runtimeDb, srcId, destId, ownerId, noopLogger,
+      {
+        // preMintedSharedKey is set; controlPool/destAppOwnerId are NOT passed
+        // because the precondition check in clone-replay.ts should only fire
+        // when the internal mint path is taken.
+        preMintedSharedKey: PRE_MINTED,
+      },
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.unfilledEnvVars).toEqual({});
+
+    const rows = await runtimeDb.query<{ name: string; encrypted_env_vars: string }>(
+      `SELECT name, encrypted_env_vars FROM app_functions WHERE app_id = $1 ORDER BY name`,
+      [destId],
+    );
+    expect(rows.rows.length).toBe(3);
+    for (const r of rows.rows) {
+      const env = JSON.parse(decrypt(r.encrypted_env_vars, process.env.AUTH_ENCRYPTION_KEY!));
+      expect(env.BUTTERBASE_API_KEY).toBe(PRE_MINTED);
+    }
+
+    // No API key rows on control-plane — this is the whole point: the
+    // orchestrator already minted, replayFunctions must NOT mint again.
+    const keyRows = await controlDb.query<{ id: string }>(
+      `SELECT id FROM api_keys WHERE user_id = $1 AND name LIKE $2`,
+      [ownerId, `Auto-mint for clone (${destId})%`],
+    );
+    expect(keyRows.rows.length).toBe(0);
+
+    await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
+    await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+    // platform_users → organizations order: FK is user.personal_organization_id
+    // → orgs.id, so users must go first.
+    await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+  });
+
+  it('does not require controlPool/destAppOwnerId when preMintedSharedKey is set', async () => {
+    // Regression guard: pre-Phase-4 the precondition check hard-failed the
+    // clone if controlPool + destAppOwnerId were absent, even when a caller
+    // had already minted the key. That would defeat the whole point of the
+    // orchestrator-level mint: the DO side would mint, but the fn side would
+    // still throw. Verify the precondition is bypassed when preMintedSharedKey
+    // is supplied.
+    const { id: ownerId } = await seedUser(`pre-mint-precond-${Date.now()}@x.com`);
+    const srcId = `app_pre_pc_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_pre_pc_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+         ON CONFLICT (id) DO NOTHING`,
+        [id, ownerId],
+      );
+    }
+    const enc = encrypt(
+      JSON.stringify({ BUTTERBASE_API_KEY: 'src-value' }),
+      process.env.AUTH_ENCRYPTION_KEY!,
+    );
+    await runtimeDb.query(
+      `INSERT INTO app_functions (id, app_id, name, code, encrypted_env_vars, deployed_by)
+       VALUES (gen_random_uuid(), $1, 'lone-fn', '/* code */', $2, $3)`,
+      [srcId, enc, ownerId],
+    );
+
+    // Deliberately omit controlPool + destAppOwnerId — the pre-existing
+    // internal-mint branch would throw here; the preMintedSharedKey branch
+    // must NOT.
+    await expect(
+      replayFunctions(runtimeDb, runtimeDb, srcId, destId, ownerId, noopLogger, {
+        preMintedSharedKey: 'bb_sk_precondition_test',
+      }),
+    ).resolves.toBeDefined();
+
+    await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
+    await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+    // platform_users → organizations order: FK is user.personal_organization_id
+    // → orgs.id, so users must go first.
+    await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+    await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+  });
+});

--- a/services/control-api/src/services/__tests__/durable-objects-clone-mint.test.ts
+++ b/services/control-api/src/services/__tests__/durable-objects-clone-mint.test.ts
@@ -1,0 +1,246 @@
+process.env.AUTH_ENCRYPTION_KEY ??= '00'.repeat(32);
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'node:crypto';
+
+// Mock CF's Workers for Platforms API so bundleAndDeploy stays in-process.
+// The auto-mint write happens BEFORE bundleAndDeploy inside
+// replayDurableObjectsForClone, so a successful CF stub also lets us verify
+// the READY status transition on the destination DO row.
+vi.mock('../cloudflare-wfp.js', () => ({
+  NS: 'bb-frontends',
+  deployDoWorker: vi.fn().mockResolvedValue({ newTag: 'v-test-clone' }),
+  deleteDoWorker: vi.fn().mockResolvedValue(undefined),
+  getDoWorkerMigrationTag: vi.fn().mockResolvedValue(null),
+}));
+
+import { replayDurableObjectsForClone } from '../durable-objects.service.js';
+import { decrypt, encrypt } from '../crypto.js';
+import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/control-db.js';
+
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
+const describeDb = RUN_DB_TESTS ? describe : describe.skip;
+
+// A minimally-valid DO class source — buildBundle re-extracts class_name via
+// regex from `export class Name extends DurableObject`, so this string is not
+// arbitrary. Matches the shape used by durable-objects.service.test.ts fixtures.
+const DO_CODE = `
+export class ChatRoom {
+  constructor(state, env) {}
+  async fetch(request) { return new Response('hi'); }
+}
+`;
+
+async function seedSourceDo(
+  srcId: string,
+  doName: string,
+  className: string,
+  envKeys: Record<string, string> = {},
+) {
+  const codeSha = createHash('sha256').update(DO_CODE).digest('hex');
+  await runtimeDb.query(
+    `INSERT INTO app_durable_objects (app_id, name, class_name, code, code_sha, access_mode, status)
+     VALUES ($1, $2, $3, $4, $5, 'authenticated', 'READY')`,
+    [srcId, doName, className, DO_CODE, codeSha],
+  );
+  for (const [key, value] of Object.entries(envKeys)) {
+    const enc = encrypt(value, process.env.AUTH_ENCRYPTION_KEY!);
+    await runtimeDb.query(
+      `INSERT INTO app_do_env_vars (app_id, key, encrypted_value) VALUES ($1, $2, $3)`,
+      [srcId, key, enc],
+    );
+  }
+}
+
+async function cleanup(ownerId: string, srcId: string, destId: string) {
+  await runtimeDb.query(`DELETE FROM app_do_env_vars WHERE app_id IN ($1, $2)`, [srcId, destId]);
+  await runtimeDb.query(`DELETE FROM app_durable_objects WHERE app_id IN ($1, $2)`, [srcId, destId]);
+  await runtimeDb.query(`DELETE FROM app_do_deploy_state WHERE app_id IN ($1, $2)`, [srcId, destId]);
+  await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+  await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+  await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+}
+
+describeDb('replayDurableObjectsForClone auto-mint into app_do_env_vars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes the shared minted key into every convention DO env slot on the dest', async () => {
+    const { id: ownerId } = await seedUser(`do-mint-conv-${Date.now()}@x.com`);
+    const srcId = `app_do_conv_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_do_conv_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+        [id, ownerId],
+      );
+    }
+    await seedSourceDo(srcId, 'chat', 'ChatRoom', {
+      BUTTERBASE_API_KEY: 'placeholder-in-source',
+      BB_SUBSTRATE_KEY: 'placeholder-substrate',
+    });
+
+    const SHARED_KEY = 'bb_sk_orchestrator_minted_abc123';
+
+    const result = await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+      { sharedMintedKey: SHARED_KEY },
+    );
+
+    expect(result.cloned).toEqual(['chat']);
+    expect(result.do_env_keys.sort()).toEqual(['BB_SUBSTRATE_KEY', 'BUTTERBASE_API_KEY']);
+    expect(result.auto_minted_keys.sort()).toEqual(['BB_SUBSTRATE_KEY', 'BUTTERBASE_API_KEY']);
+
+    const destRows = await runtimeDb.query<{ key: string; encrypted_value: string }>(
+      `SELECT key, encrypted_value FROM app_do_env_vars WHERE app_id = $1 ORDER BY key`,
+      [destId],
+    );
+    expect(destRows.rows.length).toBe(2);
+    for (const row of destRows.rows) {
+      expect(decrypt(row.encrypted_value, process.env.AUTH_ENCRYPTION_KEY!)).toBe(SHARED_KEY);
+    }
+
+    await cleanup(ownerId, srcId, destId);
+  });
+
+  it('does not touch app_do_env_vars when no shared key is provided (even with convention keys on source)', async () => {
+    const { id: ownerId } = await seedUser(`do-mint-noshared-${Date.now()}@x.com`);
+    const srcId = `app_do_no_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_do_no_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+        [id, ownerId],
+      );
+    }
+    await seedSourceDo(srcId, 'chat', 'ChatRoom', {
+      BUTTERBASE_API_KEY: 'src-value',
+    });
+
+    // No sharedMintedKey → convention detection still fires (do_env_keys is
+    // still populated for observability) but zero writes to the dest.
+    const result = await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+    );
+
+    expect(result.cloned).toEqual(['chat']);
+    expect(result.do_env_keys).toEqual(['BUTTERBASE_API_KEY']);
+    expect(result.auto_minted_keys).toEqual([]);
+
+    const destRows = await runtimeDb.query<{ key: string }>(
+      `SELECT key FROM app_do_env_vars WHERE app_id = $1`,
+      [destId],
+    );
+    expect(destRows.rows.length).toBe(0);
+
+    await cleanup(ownerId, srcId, destId);
+  });
+
+  it('honors explicitAutoMintKeys alongside convention keys, deduping the write set', async () => {
+    const { id: ownerId } = await seedUser(`do-mint-explicit-${Date.now()}@x.com`);
+    const srcId = `app_do_exp_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_do_exp_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+        [id, ownerId],
+      );
+    }
+    // Source declares one convention key (BUTTERBASE_API_KEY) and one
+    // non-convention key (CUSTOM_TOKEN). Caller explicitly requests
+    // BUTTERBASE_API_KEY (redundant — should dedupe with convention path) plus
+    // CUSTOM_TOKEN (not convention — only reachable via explicit opt-in).
+    await seedSourceDo(srcId, 'chat', 'ChatRoom', {
+      BUTTERBASE_API_KEY: 'placeholder',
+      CUSTOM_TOKEN: 'placeholder-custom',
+    });
+
+    const SHARED_KEY = 'bb_sk_explicit_test_xyz';
+
+    const result = await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+      {
+        sharedMintedKey: SHARED_KEY,
+        explicitAutoMintKeys: ['BUTTERBASE_API_KEY', 'CUSTOM_TOKEN'],
+      },
+    );
+
+    expect(result.auto_minted_keys.sort()).toEqual(['BUTTERBASE_API_KEY', 'CUSTOM_TOKEN']);
+
+    const destRows = await runtimeDb.query<{ key: string; encrypted_value: string }>(
+      `SELECT key, encrypted_value FROM app_do_env_vars WHERE app_id = $1 ORDER BY key`,
+      [destId],
+    );
+    // Two rows written, one bb_sk_ value each. Nothing for BB_SUBSTRATE_KEY —
+    // it wasn't in the source and wasn't in the explicit list.
+    expect(destRows.rows.map((r) => r.key)).toEqual(['BUTTERBASE_API_KEY', 'CUSTOM_TOKEN']);
+    for (const row of destRows.rows) {
+      expect(decrypt(row.encrypted_value, process.env.AUTH_ENCRYPTION_KEY!)).toBe(SHARED_KEY);
+    }
+
+    await cleanup(ownerId, srcId, destId);
+  });
+
+  it('returns empty auto_minted_keys and does not write when source has no DOs', async () => {
+    const { id: ownerId } = await seedUser(`do-mint-empty-${Date.now()}@x.com`);
+    const srcId = `app_do_empty_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_do_empty_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+        [id, ownerId],
+      );
+    }
+
+    const result = await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+      { sharedMintedKey: 'bb_sk_ignored' },
+    );
+
+    expect(result).toEqual({ cloned: [], do_env_keys: [], auto_minted_keys: [] });
+
+    const destRows = await runtimeDb.query<{ key: string }>(
+      `SELECT key FROM app_do_env_vars WHERE app_id = $1`,
+      [destId],
+    );
+    expect(destRows.rows.length).toBe(0);
+
+    await cleanup(ownerId, srcId, destId);
+  });
+
+  it('is idempotent — a second call with the same shared key upserts, not duplicates', async () => {
+    const { id: ownerId } = await seedUser(`do-mint-idem-${Date.now()}@x.com`);
+    const srcId = `app_do_idem_src_${ownerId.slice(0, 8)}`;
+    const destId = `app_do_idem_dst_${ownerId.slice(0, 8)}`;
+    for (const id of [srcId, destId]) {
+      await runtimeDb.query(
+        `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+        [id, ownerId],
+      );
+    }
+    await seedSourceDo(srcId, 'chat', 'ChatRoom', {
+      BUTTERBASE_API_KEY: 'placeholder',
+    });
+
+    await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+      { sharedMintedKey: 'bb_sk_first_mint' },
+    );
+    // Second call with a different value (simulating a re-run after a partial
+    // failure that re-minted). The dest row must upsert, not insert-conflict.
+    await replayDurableObjectsForClone(
+      runtimeDb, runtimeDb, controlDb, srcId, destId, ownerId,
+      { sharedMintedKey: 'bb_sk_second_mint' },
+    );
+
+    const destRows = await runtimeDb.query<{ key: string; encrypted_value: string }>(
+      `SELECT key, encrypted_value FROM app_do_env_vars WHERE app_id = $1`,
+      [destId],
+    );
+    expect(destRows.rows.length).toBe(1);
+    expect(decrypt(destRows.rows[0].encrypted_value, process.env.AUTH_ENCRYPTION_KEY!))
+      .toBe('bb_sk_second_mint');
+
+    await cleanup(ownerId, srcId, destId);
+  });
+});

--- a/services/control-api/src/services/clone-replay.ts
+++ b/services/control-api/src/services/clone-replay.ts
@@ -31,6 +31,11 @@ export interface ReplayFunctionsEnvVarOpts {
   controlPool?: pg.Pool;
   /** Dest app owner id — required for auto-mint (key is minted under this user). */
   destAppOwnerId?: string;
+  /** When the orchestrator already minted a shared bb_sk_* (e.g. because the
+   *  DO replay side needed it), pass it here so replayFunctions reuses it
+   *  instead of minting a second one. Preserves "at most one shared key per
+   *  clone." */
+  preMintedSharedKey?: string | null;
 }
 
 /**
@@ -406,28 +411,36 @@ export async function replayFunctions(
       [...keys].some(k => AUTO_MINT_CONVENTION_KEYS.includes(k)),
     );
   if (anyFnNeedsMint) {
-    // Preconditions that make the mint IMPOSSIBLE rather than just failed:
-    // hard-fail so the caller sees the problem instead of silently continuing
-    // with an app whose intra-fn calls will 401. The mint call itself can
-    // still fail transiently (network, Neon hiccup) — that stays a warning
-    // so the rest of the clone (schema, RLS, storage, etc.) still lands.
-    if (!opts?.controlPool || !opts?.destAppOwnerId) {
-      throw new Error(
-        `auto-mint precondition missing (controlPool=${!!opts?.controlPool}, destAppOwnerId=${!!opts?.destAppOwnerId}). ` +
-          `Cloned functions require BUTTERBASE_API_KEY / BB_SUBSTRATE_KEY; refusing to complete clone with 401 baked in.`,
-      );
-    }
-    try {
-      const minted = await mintApiKeyForClone(opts.controlPool, {
-        ownerId: opts.destAppOwnerId,
-        destAppId,
-      });
-      sharedMintedKey = minted.key;
-      logger.info({ destAppId, keyId: minted.keyId }, '[clone] shared API key minted for clone');
-    } catch (mintErr) {
-      sharedMintError = `shared key mint failed: ${(mintErr as Error).message}`;
-      warnings.push(sharedMintError);
-      logger.warn({ err: mintErr, destAppId }, '[clone] shared key mint failed; per-function keys will remain unfilled');
+    if (opts?.preMintedSharedKey) {
+      // Orchestrator already minted (typically because the DO replay needed a
+      // shared key). Reuse verbatim — same key must land in DO env and fn env
+      // for intra-app bearer checks to match.
+      sharedMintedKey = opts.preMintedSharedKey;
+      logger.info({ destAppId }, '[clone] reusing pre-minted shared API key');
+    } else {
+      // Preconditions that make the mint IMPOSSIBLE rather than just failed:
+      // hard-fail so the caller sees the problem instead of silently continuing
+      // with an app whose intra-fn calls will 401. The mint call itself can
+      // still fail transiently (network, Neon hiccup) — that stays a warning
+      // so the rest of the clone (schema, RLS, storage, etc.) still lands.
+      if (!opts?.controlPool || !opts?.destAppOwnerId) {
+        throw new Error(
+          `auto-mint precondition missing (controlPool=${!!opts?.controlPool}, destAppOwnerId=${!!opts?.destAppOwnerId}). ` +
+            `Cloned functions require BUTTERBASE_API_KEY / BB_SUBSTRATE_KEY; refusing to complete clone with 401 baked in.`,
+        );
+      }
+      try {
+        const minted = await mintApiKeyForClone(opts.controlPool, {
+          ownerId: opts.destAppOwnerId,
+          destAppId,
+        });
+        sharedMintedKey = minted.key;
+        logger.info({ destAppId, keyId: minted.keyId }, '[clone] shared API key minted for clone');
+      } catch (mintErr) {
+        sharedMintError = `shared key mint failed: ${(mintErr as Error).message}`;
+        warnings.push(sharedMintError);
+        logger.warn({ err: mintErr, destAppId }, '[clone] shared key mint failed; per-function keys will remain unfilled');
+      }
     }
   }
 

--- a/services/control-api/src/services/durable-objects.service.ts
+++ b/services/control-api/src/services/durable-objects.service.ts
@@ -23,6 +23,7 @@ import {
 } from './do-bundler.js';
 import { validateEnvKeys } from '../lib/env-vars.js';
 import { buildDoEnvBundle } from './do-env-bundle.js';
+import { AUTO_MINT_CONVENTION_KEYS } from './clone-env-vars.js';
 import { config } from '../config.js';
 
 export class DurableObjectError extends Error {
@@ -532,6 +533,20 @@ export async function listDoEnvVarKeys(db: Pool, appId: string): Promise<string[
 export interface CloneReplayResult {
   cloned: string[];
   do_env_keys: string[];
+  /** DO env keys that received a value from the shared clone-minted bb_sk_*.
+   *  Empty when no shared key was passed or no keys matched a convention. */
+  auto_minted_keys: string[];
+}
+
+export interface ReplayDurableObjectsCloneOpts {
+  /** Shared bb_sk_* minted once per clone by the orchestrator. When provided,
+   *  every DO env key that matches AUTO_MINT_CONVENTION_KEYS (or is listed
+   *  in explicitAutoMintKeys) is written to app_do_env_vars on the dest with
+   *  this value before bundleAndDeploy runs. */
+  sharedMintedKey?: string | null;
+  /** Extra DO env keys the caller explicitly asked to auto-fill with the
+   *  shared minted key, beyond convention-matched keys. */
+  explicitAutoMintKeys?: string[];
 }
 
 /**
@@ -541,12 +556,16 @@ export interface CloneReplayResult {
  * replay so that functions whose env vars reference `<appId>_do` URLs can
  * be pointed at the dest namespace by the caller.
  *
- * Values of DO env vars are NOT copied — they're secrets held only in the
- * source's encryption envelope. Their KEYS are returned so the clone caller
- * can surface them alongside function env keys in the pending_env_vars flow.
+ * Values of DO env vars are NOT copied wholesale — they're secrets held only
+ * in the source's encryption envelope. Their KEYS are returned so the clone
+ * caller can surface them alongside function env keys in the pending_env_vars
+ * flow. The one exception is convention keys (BUTTERBASE_API_KEY /
+ * BB_SUBSTRATE_KEY): when `opts.sharedMintedKey` is provided, those keys are
+ * filled with the shared minted bb_sk_* so DOs and functions on the cloned
+ * app share the same intra-app credential without a manual set_env step.
  *
- * If the source has no active DOs, returns `{ cloned: [], do_env_keys: [] }`
- * without deploying anything.
+ * If the source has no active DOs, returns `{ cloned: [], do_env_keys: [],
+ * auto_minted_keys: [] }` without deploying anything.
  */
 export async function replayDurableObjectsForClone(
   sourceDb: Pool,
@@ -555,6 +574,7 @@ export async function replayDurableObjectsForClone(
   sourceAppId: string,
   destAppId: string,
   destUserId: string,
+  opts?: ReplayDurableObjectsCloneOpts,
 ): Promise<CloneReplayResult> {
   const src = await sourceDb.query<{
     name: string;
@@ -575,7 +595,7 @@ export async function replayDurableObjectsForClone(
   const doEnvKeys = keysRes.rows.map((r) => r.key);
 
   if (src.rows.length === 0) {
-    return { cloned: [], do_env_keys: doEnvKeys };
+    return { cloned: [], do_env_keys: doEnvKeys, auto_minted_keys: [] };
   }
 
   // Insert every source class into the dest at status='BUILDING'. On conflict
@@ -601,6 +621,35 @@ export async function replayDurableObjectsForClone(
     insertedIds.push(ins.rows[0].id);
   }
 
+  // Auto-mint convention keys into app_do_env_vars BEFORE bundleAndDeploy so
+  // the deploy picks up the values on first roll. Bypasses setDoEnvVar's
+  // reserved-prefix guard (BUTTERBASE_API_KEY starts with BUTTERBASE_) via
+  // direct SQL — a platform-controlled write of a platform-recognized key,
+  // mirroring how clone-replay writes function encrypted_env_vars for the
+  // same convention. Explicit + convention targets are unioned so a caller
+  // can request a non-convention key too, at the cost of naming it up front.
+  const autoMintedKeys: string[] = [];
+  if (opts?.sharedMintedKey && doEnvKeys.length + (opts.explicitAutoMintKeys?.length ?? 0) > 0) {
+    const conventionTargets = doEnvKeys.filter((k) => AUTO_MINT_CONVENTION_KEYS.includes(k));
+    const explicitTargets = opts.explicitAutoMintKeys ?? [];
+    const mintTargets = Array.from(new Set([...conventionTargets, ...explicitTargets]));
+    if (mintTargets.length > 0) {
+      const encKey = process.env.AUTH_ENCRYPTION_KEY!;
+      const encrypted = encrypt(opts.sharedMintedKey, encKey);
+      for (const key of mintTargets) {
+        await destDb.query(
+          `INSERT INTO app_do_env_vars (app_id, key, encrypted_value)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (app_id, key) DO UPDATE
+             SET encrypted_value = EXCLUDED.encrypted_value,
+                 updated_at = now()`,
+          [destAppId, key, encrypted],
+        );
+        autoMintedKeys.push(key);
+      }
+    }
+  }
+
   try {
     await bundleAndDeploy(destDb, controlDb, destAppId);
   } catch (err) {
@@ -622,7 +671,7 @@ export async function replayDurableObjectsForClone(
     [insertedIds],
   );
 
-  return { cloned: src.rows.map((r) => r.name), do_env_keys: doEnvKeys };
+  return { cloned: src.rows.map((r) => r.name), do_env_keys: doEnvKeys, auto_minted_keys: autoMintedKeys };
 }
 
 // CF binding name pattern: identifier-like, uppercase by convention.

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -22,7 +22,8 @@ import {
 import { S3Client } from '@aws-sdk/client-s3';
 import { getAppPoolForApp } from './app-pool.js';
 import { replaySchema, replayRls, replaySeedData, replayFunctions, replayNonSecretConfig, replayMeetingsWebhook, replayAuthHookBinding, replaySubstrateLink, replayFrontend } from './clone-replay.js';
-import { replayDurableObjectsForClone } from './durable-objects.service.js';
+import { replayDurableObjectsForClone, listDoEnvVarKeys } from './durable-objects.service.js';
+import { AUTO_MINT_CONVENTION_KEYS, mintApiKeyForClone } from './clone-env-vars.js';
 import { replayAppEnvVars } from './clone-app-env.js';
 import { decrypt } from './crypto.js';
 import { insertCloneAuditLog } from './audit/audit-events-service.js';
@@ -722,50 +723,9 @@ async function executeClone(
         logger.warn({ err, destAppId: resolvedDestAppId }, '[clone] app_env_vars replay failed; continuing');
       }
 
-      // Replay Durable Object classes. Must run BEFORE replayFunctions so any
-      // function env var pointing at a `<appId>_do` URL can be re-supplied by
-      // the caller after they see the DO namespace exists on dest. Prior to
-      // this step, DOs silently failed to clone: manage_durable_objects list
-      // on the dest returned an empty array while functions still referenced
-      // the source DO URLs (bug 6a04a0d5). DO env var VALUES are secrets and
-      // never copied — only their KEYS surface, so the caller can re-set them
-      // via manage_durable_objects action=set_env after clone completes.
-      scope.setTag('step', 'replaying_durable_objects');
-      await setCloneJobStatus(controlDb, jobId, { status: 'replaying_durable_objects' });
-      try {
-        const doResult = await replayDurableObjectsForClone(
-          sourceRuntimePool,
-          destRuntimePool,
-          controlDb,
-          job.source_app_id,
-          resolvedDestAppId,
-          job.requested_by_user_id,
-        );
-        if (doResult.cloned.length > 0) {
-          logger.info(
-            { destAppId: resolvedDestAppId, cloned: doResult.cloned, doEnvKeys: doResult.do_env_keys },
-            '[clone] durable objects replayed',
-          );
-          if (doResult.do_env_keys.length > 0) {
-            await appendCloneJobWarnings(controlDb, jobId, [
-              `Durable Objects cloned: ${doResult.cloned.join(', ')}. The DO env keys (${doResult.do_env_keys.join(', ')}) are secrets and were not copied — set them via manage_durable_objects action=set_env after the clone completes.`,
-            ]);
-          }
-        } else {
-          logger.info({ destAppId: resolvedDestAppId }, '[clone] no active durable objects on source');
-        }
-      } catch (err) {
-        // DO replay failure is not silently ignored — surface it as a fatal
-        // clone-job failure so the caller notices instead of getting a
-        // "completed" clone whose DOs are half-deployed.
-        throw err;
-      }
-
-      // Step 5 (Phase 5 A4): Replay app_functions from source runtime DB to dest runtime DB.
-      scope.setTag('step', 'replaying_functions');
-      await setCloneJobStatus(controlDb, jobId, { status: 'replaying_functions' });
-
       // Read the staged env vars + auto-mint requests off the clone job row.
+      // Hoisted above DO replay (previously read just before replayFunctions)
+      // so DO replay can also consume the shared bb_sk_ minted for this clone.
       const cjRow = await controlDb.query<{
         pending_env_vars: string | null;
         auto_mint_requests: { fn_name: string; key: string }[] | null;
@@ -788,14 +748,11 @@ async function executeClone(
       }
       const autoMintRequests = cjRow.rows[0]?.auto_mint_requests ?? undefined;
 
-      // Resolve dest owner id (needed for auto-mint — bb_sk_* is minted under the
-      // dest owner's user_id). One round-trip; cached for the rest of this step.
-      // The dest app was created by an earlier step in this same worker, so we
-      // must be able to read its owner back — an empty result here means the
-      // runtime DB is inconsistent with what we just wrote. Hard-fail rather
-      // than silently skip auto-mint (which downstream would already throw
-      // via the tightened precondition check in replayFunctions, but failing
-      // here gives a more precise error).
+      // Resolve dest owner id once — needed for any auto-mint decision that
+      // follows (bb_sk_ is minted under the dest owner's user_id). Hoisted
+      // above DO replay so the DO side can share the same minted key with the
+      // fn side (one shared credential per clone; intra-app bearer checks
+      // between DO and fn only match when both carry the same value).
       const ownerRow = await destRuntimePool.query<{ owner_id: string }>(
         `SELECT owner_id FROM apps WHERE id = $1`,
         [resolvedDestAppId],
@@ -806,6 +763,110 @@ async function executeClone(
           `[clone] dest app ${resolvedDestAppId} has no owner_id in runtime DB — clone flow inconsistent`,
         );
       }
+
+      // Mint the shared bb_sk_ once if EITHER side (DOs or functions) needs
+      // it. Detection scans:
+      //   - source DO env keys      (auto-mint if any match a convention key)
+      //   - source fn env keys      (same)
+      //   - caller's auto_mint_requests (per-fn explicit opt-in)
+      // If nothing needs it, we don't mint at all. The mint call itself is
+      // best-effort: transient failures surface as a warning and each side
+      // leaves the affected keys unfilled. Preconditions (controlDb pool +
+      // ownerId) are already satisfied here.
+      let sourceDoEnvKeys: string[] = [];
+      try {
+        sourceDoEnvKeys = await listDoEnvVarKeys(sourceRuntimePool, job.source_app_id);
+      } catch (dke) {
+        logger.warn(
+          { err: dke, sourceAppId: job.source_app_id },
+          '[clone] listDoEnvVarKeys failed on source; DO auto-mint disabled for this clone',
+        );
+      }
+      const doNeedsMint = sourceDoEnvKeys.some((k) => AUTO_MINT_CONVENTION_KEYS.includes(k));
+
+      // We can't cheaply pre-list source fn env keys here (that read happens
+      // inside replayFunctions). Mint eagerly only when the DO side needs it
+      // or the caller explicitly opted in; otherwise defer to replayFunctions'
+      // internal mint decision (unchanged path for the fn-only case).
+      let sharedMintedKey: string | null = null;
+      const explicitMintRequested = (autoMintRequests?.length ?? 0) > 0;
+      if (doNeedsMint || explicitMintRequested) {
+        try {
+          const minted = await mintApiKeyForClone(controlDb, {
+            ownerId: destAppOwnerId,
+            destAppId: resolvedDestAppId,
+          });
+          sharedMintedKey = minted.key;
+          logger.info(
+            { destAppId: resolvedDestAppId, keyId: minted.keyId, doNeedsMint, explicitMintRequested },
+            '[clone] shared API key minted for clone (shared across DO + fn replay)',
+          );
+        } catch (mintErr) {
+          const msg = `shared key mint failed: ${(mintErr as Error).message}`;
+          await appendCloneJobWarnings(controlDb, jobId, [msg]);
+          logger.warn(
+            { err: mintErr, destAppId: resolvedDestAppId },
+            '[clone] shared key mint failed; DO auto-mint targets will remain unfilled',
+          );
+        }
+      }
+
+      // Replay Durable Object classes. Must run BEFORE replayFunctions so any
+      // function env var pointing at a `<appId>_do` URL can be re-supplied by
+      // the caller after they see the DO namespace exists on dest. Prior to
+      // this step, DOs silently failed to clone: manage_durable_objects list
+      // on the dest returned an empty array while functions still referenced
+      // the source DO URLs (bug 6a04a0d5). DO env var VALUES are secrets and
+      // never copied — only their KEYS surface, so the caller can re-set them
+      // via manage_durable_objects action=set_env after clone completes. The
+      // one exception is convention keys (BUTTERBASE_API_KEY / BB_SUBSTRATE_KEY):
+      // when the shared bb_sk_ was minted above, those keys are auto-filled
+      // so DO and fn on the cloned app share the same intra-app credential.
+      scope.setTag('step', 'replaying_durable_objects');
+      await setCloneJobStatus(controlDb, jobId, { status: 'replaying_durable_objects' });
+      try {
+        const doResult = await replayDurableObjectsForClone(
+          sourceRuntimePool,
+          destRuntimePool,
+          controlDb,
+          job.source_app_id,
+          resolvedDestAppId,
+          job.requested_by_user_id,
+          { sharedMintedKey },
+        );
+        if (doResult.cloned.length > 0) {
+          logger.info(
+            {
+              destAppId: resolvedDestAppId,
+              cloned: doResult.cloned,
+              doEnvKeys: doResult.do_env_keys,
+              autoMintedKeys: doResult.auto_minted_keys,
+            },
+            '[clone] durable objects replayed',
+          );
+          const unfilled = doResult.do_env_keys.filter((k) => !doResult.auto_minted_keys.includes(k));
+          if (unfilled.length > 0) {
+            await appendCloneJobWarnings(controlDb, jobId, [
+              `Durable Objects cloned: ${doResult.cloned.join(', ')}. Unfilled DO env keys (${unfilled.join(', ')}) are secrets that were not copied — set them via manage_durable_objects action=set_env after the clone completes.`,
+            ]);
+          }
+        } else {
+          logger.info({ destAppId: resolvedDestAppId }, '[clone] no active durable objects on source');
+        }
+      } catch (err) {
+        // DO replay failure is not silently ignored — surface it as a fatal
+        // clone-job failure so the caller notices instead of getting a
+        // "completed" clone whose DOs are half-deployed.
+        throw err;
+      }
+
+      // Step 5 (Phase 5 A4): Replay app_functions from source runtime DB to dest runtime DB.
+      // pendingEnvVarValues, autoMintRequests, and destAppOwnerId are resolved
+      // above the DO replay step so the DO side can share the minted key with
+      // the fn side. `preMintedSharedKey` tells replayFunctions to reuse the
+      // orchestrator-level mint instead of minting a second key.
+      scope.setTag('step', 'replaying_functions');
+      await setCloneJobStatus(controlDb, jobId, { status: 'replaying_functions' });
 
       const fnResult = await replayFunctions(
         sourceRuntimePool,
@@ -819,6 +880,7 @@ async function executeClone(
           autoMintRequests,
           controlPool: controlDb,
           destAppOwnerId,
+          preMintedSharedKey: sharedMintedKey,
         },
       );
       if (fnResult.warnings.length > 0) {


### PR DESCRIPTION
## Summary
- Extends the existing "one shared `bb_sk_*` per clone" auto-mint to Durable Object env slots so cloned apps' DOs no longer 401 on `BUTTERBASE_API_KEY` / `BB_SUBSTRATE_KEY` until the operator manually re-runs `manage_durable_objects set_env`.
- Same key is threaded into both DO replay and function replay, preserving the invariant that intra-app callers share one credential.
- Preflight surfaces the new state via `durable_objects.key_meta` — convention DO keys now report `auto_filled` and the "must re-set post-clone" note only fires for the user-required rows.
- Drive-by: two pre-existing clone tests that raw-INSERT'd `platform_users` without `personal_organization_id` (NOT NULL now) routed through the shared `seedUser()` helper.

## Test plan
- [x] `vitest run` — 11 new cases (DO auto-mint, preMintedSharedKey reuse, preflight key_meta)
- [x] `vitest run` — 5 pre-existing clone tests brought back to green
- [x] `vitest run` — 80 cases total across clone + DO adjacent surface pass together
- [x] Local rebuild — control-api boots healthy, `/health` 200, boot-time audits pass
- [x] Live smoke — `GET /v1/templates/app_nonexistent/clone-preflight` returns the expected 404 with `createAgentError` shape (route wired correctly)

## Deploy notes
- Code-only. No schema change, no new tables, no new env vars.
- Backward compat: new fn signatures gained **optional** opts; `clone-preflight` response gains an **additive** `key_meta` field. Rolling deploy is safe.
- Only Fly service touched is `butterbase-platform` (control-api). Runtime is untouched.

## Related
- Follow-on to #84 (ctx.invokeDO) which shipped the DO-side auth surface but didn't cover the clone-time secret plumbing.