### PR TITLE
fix(billing): route plan_id writes to the paying org, not the acting user's personal org

### DIFF
--- a/services/control-api/src/routes/billing.ts
+++ b/services/control-api/src/routes/billing.ts
@@ -312,6 +312,7 @@ export async function billingRoutes(app: FastifyInstance) {
         planId: body.planId,
         successUrl,
         cancelUrl,
+        organizationId: request.auth?.organizationId ?? null,
       });
 
       return { sessionId: session.sessionId, url: session.url };

--- a/services/control-api/src/routes/custom-domains.ts
+++ b/services/control-api/src/routes/custom-domains.ts
@@ -54,14 +54,31 @@ export async function customDomainRoutes(fastify: FastifyInstance) {
     const region = await resolveAppHomeRegion(controlDb, appId);
     const runtimeDb = getRuntimeDbPool(config.runtimeDb, region);
 
-    // Plan gate — platform_users + plans live on controlDb
-    const planResult = await controlDb.query(
-      `SELECT p.features FROM platform_users pu
-       JOIN organizations o ON o.id = pu.personal_organization_id
-       JOIN plans p ON p.id = o.plan_id
-       WHERE pu.id = $1`,
-      [userId],
+    // Plan gate — must read the plan of the APP's owning organization, not the
+    // caller's personal_organization_id. For team-org apps, the caller's
+    // personal org may be Playground even when the team org paid for Launch
+    // (and vice versa — a paid personal org can't reach a team app it's a
+    // member of). Fall back to personal_organization_id only for legacy apps
+    // with NULL organization_id (pre-backfill).
+    const appOrgResult = await runtimeDb.query<{ organization_id: string | null; owner_id: string }>(
+      'SELECT organization_id, owner_id FROM apps WHERE id = $1',
+      [appId],
     );
+    const appOrgId = appOrgResult.rows[0]?.organization_id;
+    const planResult = appOrgId
+      ? await controlDb.query(
+          `SELECT p.features FROM organizations o
+           JOIN plans p ON p.id = o.plan_id
+           WHERE o.id = $1`,
+          [appOrgId],
+        )
+      : await controlDb.query(
+          `SELECT p.features FROM platform_users pu
+           JOIN organizations o ON o.id = pu.personal_organization_id
+           JOIN plans p ON p.id = o.plan_id
+           WHERE pu.id = $1`,
+          [appOrgResult.rows[0]?.owner_id ?? userId],
+        );
     const features = (planResult.rows[0]?.features as Record<string, unknown>) || {};
     if (!features.custom_domain) {
       return reply.status(403).send(quotaErrors.featureNotAvailable('custom_domain'));

--- a/services/control-api/src/services/state-outbox.ts
+++ b/services/control-api/src/services/state-outbox.ts
@@ -12,8 +12,17 @@ export interface WriteResult {
 }
 
 /**
- * Atomically updates the listed fields on the user's personal organization and
- * writes a paired row to user_state_outbox. Returns the assigned outbox version.
+ * Atomically updates the listed fields on the target organization and writes a
+ * paired row to user_state_outbox. Returns the assigned outbox version.
+ *
+ * Target org resolution:
+ *   - If `organizationId` is provided, that org is updated. Callers on the
+ *     billing path (checkout, subscription cancel) MUST pass it — a team-org
+ *     member checking out otherwise mis-routes the plan_id write to the
+ *     acting user's personal org (incident 2026-07-14).
+ *   - If omitted, falls back to `platform_users.personal_organization_id` for
+ *     `userId`. Kept for callers where user == org (soft-lock, spending cap
+ *     bumps on the personal org, etc.).
  *
  * Use this for EVERY mutation of organizations.{account_status, plan_id,
  * spending_cap_usd}. Do not write those columns directly with bare UPDATEs.
@@ -24,7 +33,8 @@ export interface WriteResult {
 export async function writeUserStateChange(
   platformPool: pg.Pool,
   userId: string,
-  change: UserStateChange
+  change: UserStateChange,
+  organizationId?: string
 ): Promise<WriteResult> {
   const keys = Object.keys(change) as OutboxField[];
   if (keys.length === 0) throw new Error('writeUserStateChange: no fields provided');
@@ -40,19 +50,24 @@ export async function writeUserStateChange(
   const client = await platformPool.connect();
   try {
     await client.query('BEGIN');
-    const upd = await client.query(
-      `UPDATE organizations SET ${setClause} WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $1)`,
-      [userId, ...values]
-    );
+    const upd = organizationId
+      ? await client.query(
+          `UPDATE organizations SET ${setClause} WHERE id = $1`,
+          [organizationId, ...values]
+        )
+      : await client.query(
+          `UPDATE organizations SET ${setClause} WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $1)`,
+          [userId, ...values]
+        );
     if (upd.rowCount === 0) {
-      throw new NotFoundError('user', userId);
+      throw new NotFoundError(organizationId ? 'organization' : 'user', organizationId ?? userId);
     }
-    const organizationId = await resolveOrganizationId(platformPool, userId);
+    const outboxOrgId = organizationId ?? (await resolveOrganizationId(platformPool, userId));
     const ins = await client.query<{ version: string }>(
       `INSERT INTO user_state_outbox (user_id, organization_id, fields_changed)
        VALUES ($1, $2, $3::jsonb)
        RETURNING version`,
-      [userId, organizationId, JSON.stringify(change)]
+      [userId, outboxOrgId, JSON.stringify(change)]
     );
     await client.query('COMMIT');
     return { version: parseInt(ins.rows[0].version, 10) };


### PR DESCRIPTION
## Incident (2026-07-14)

Team-org owner josh@mnexa.ai paid for Launch via co-owner statzihuai@gmail.com for org `dce4ed8f-…`. Stripe subscription active, monthly allowance bumped to \$5 — but `organizations.plan_id` stayed `playground`, so `POST /v1/:appId/custom-domains` returned 403 and the dashboard kept showing "Playground". **10 more orgs** across the last month are in the same inconsistent state.

## Root cause

Two divergent org identities in the webhook pipeline.

- The Python `dashboard-api` route `POST /dashboard/organizations/{org_id}/billing/checkout` correctly stamps `organization_id` into Stripe metadata. The subscription row + `stripe_customer_id` + `billing_period_start` + monthly allowance all land on the paying org.
- BUT the post-commit `writeUserStateChange(db, session.metadata.user_id, change)` in the overlay webhook resolved the target org via `platform_users.personal_organization_id` of the acting user. When a co-owner initiates a team-org checkout, the plan_id upgrade is sprayed onto that co-owner's own personal org — not the org that paid.

Compounding: `custom-domains.ts` gate joined `plans` via `personal_organization_id`, so it also read the wrong org's plan.

Failure was silent — the post-commit outbox call is wrapped in `try/catch` with `console.warn` only.

## Changes

- **`state-outbox.ts`** — `writeUserStateChange` takes an optional `organizationId`. When provided, `UPDATE organizations` targets that id directly. Fallback to `personal_organization_id` preserved for callers where user == org (soft-lock, personal spending-cap raise).
- **`routes/custom-domains.ts`** — plan gate reads `plans.features` via the **app's** owning `organization_id`. Legacy apps with NULL `organization_id` fall back to the app owner's personal org.
- **`routes/billing.ts`** — passes `request.auth?.organizationId` into `createCheckoutSession` so a team-org-scoped session upgrades the intended org even in the OSS-hosted checkout path.

## Incident report

Full write-up + reconcile SQL for the 10 affected orgs: `docs/incidents/2026-07-14-billing-outbox-team-org-misroute.md` (lives in butterbase-internal).

## Test plan

- [ ] `cd services/control-api && npx tsc --noEmit` (clean)
- [ ] `pnpm -w test --filter @butterbase/control-api state-outbox` — existing tests still pass with 3-arg call.
- [ ] Add regression test: `writeUserStateChange(db, actorUserId, change, targetOrgId)` writes to `targetOrgId`, not actor's personal org.
- [ ] Manual: create a team-org checkout via `POST /dashboard/organizations/{org_id}/billing/checkout` as a non-owner member; confirm `organizations.plan_id` on `org_id` (not actor's personal) flips to the purchased plan.
- [ ] Manual: `POST /v1/:appId/custom-domains` on a team-org app after upgrade returns 200, not 403.

## Follow-ups (not this PR)

- Alert on any `[Stripe Webhook] post-commit outbox write failed` log line (currently `console.warn` only, invisible).
- Downgrade endpoint / surface Stripe Customer Portal — right now the only path back to `playground` is a full subscription cancel.
- Nightly reconciler that flags any `organizations.plan_id` disagreement with its most-recent live subscription.