### PR TITLE
feat(clone): CLONE_APP_ENV_OVERRIDES — per-source-app env-var defaults on clone

### DIFF
--- a/services/control-api/src/services/__tests__/clone-app-overrides.test.ts
+++ b/services/control-api/src/services/__tests__/clone-app-overrides.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseCloneAppOverrides,
+  resolveOverridesForClone,
+  getCloneAppOverrides,
+  __resetForTests,
+} from '../clone-app-overrides.js';
+
+describe('parseCloneAppOverrides', () => {
+  it('returns {} when raw is undefined', () => {
+    expect(parseCloneAppOverrides(undefined)).toEqual({});
+  });
+
+  it('returns {} when raw is empty string', () => {
+    expect(parseCloneAppOverrides('')).toEqual({});
+  });
+
+  it('parses a valid blob with mint_hex and static entries', () => {
+    const raw = JSON.stringify({
+      app_source_a: {
+        S1: { type: 'mint_hex', bytes: 32 },
+        M1: { type: 'static', value: 'model-x' },
+      },
+    });
+    const parsed = parseCloneAppOverrides(raw);
+    expect(parsed.app_source_a.S1).toEqual({ type: 'mint_hex', bytes: 32 });
+    expect(parsed.app_source_a.M1).toEqual({ type: 'static', value: 'model-x' });
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseCloneAppOverrides('{not json')).toThrow(/CLONE_APP_ENV_OVERRIDES/);
+  });
+
+  it('throws on unknown spec.type', () => {
+    const raw = JSON.stringify({ app_x: { K: { type: 'wat', value: 'x' } } });
+    expect(() => parseCloneAppOverrides(raw)).toThrow(/unknown override type/);
+  });
+
+  it('throws when mint_hex bytes below range', () => {
+    const raw = JSON.stringify({ app_x: { K: { type: 'mint_hex', bytes: 8 } } });
+    expect(() => parseCloneAppOverrides(raw)).toThrow(/bytes/);
+  });
+
+  it('throws when mint_hex bytes above range', () => {
+    const raw = JSON.stringify({ app_x: { K: { type: 'mint_hex', bytes: 256 } } });
+    expect(() => parseCloneAppOverrides(raw)).toThrow(/bytes/);
+  });
+
+  it('throws when static.value is not a string', () => {
+    const raw = JSON.stringify({ app_x: { K: { type: 'static', value: 42 } } });
+    expect(() => parseCloneAppOverrides(raw)).toThrow(/value/);
+  });
+
+  it('throws when top-level is not a plain object', () => {
+    expect(() => parseCloneAppOverrides('[]')).toThrow(/object/);
+  });
+});
+
+describe('resolveOverridesForClone', () => {
+  it('returns {} when sourceAppId has no entry', () => {
+    const overrides = parseCloneAppOverrides(
+      JSON.stringify({ app_a: { K: { type: 'static', value: 'v' } } }),
+    );
+    expect(resolveOverridesForClone(overrides, 'app_b')).toEqual({});
+  });
+
+  it('passes static values through verbatim', () => {
+    const overrides = parseCloneAppOverrides(
+      JSON.stringify({ app_a: { K: { type: 'static', value: 'v1' } } }),
+    );
+    expect(resolveOverridesForClone(overrides, 'app_a')).toEqual({ K: 'v1' });
+  });
+
+  it('mint_hex produces a hex string of 2*bytes chars', () => {
+    const overrides = parseCloneAppOverrides(
+      JSON.stringify({ app_a: { K: { type: 'mint_hex', bytes: 32 } } }),
+    );
+    const out = resolveOverridesForClone(overrides, 'app_a');
+    expect(out.K).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('mint_hex produces a fresh value on every call', () => {
+    const overrides = parseCloneAppOverrides(
+      JSON.stringify({ app_a: { K: { type: 'mint_hex', bytes: 32 } } }),
+    );
+    const a = resolveOverridesForClone(overrides, 'app_a').K;
+    const b = resolveOverridesForClone(overrides, 'app_a').K;
+    expect(a).not.toEqual(b);
+  });
+
+  it('returns the same value across every key in a single call', () => {
+    // mint_hex is resolved per (call, key). Two mint_hex keys in the same
+    // call must not share bytes — they are independent slots.
+    const overrides = parseCloneAppOverrides(
+      JSON.stringify({
+        app_a: {
+          K1: { type: 'mint_hex', bytes: 32 },
+          K2: { type: 'mint_hex', bytes: 32 },
+        },
+      }),
+    );
+    const out = resolveOverridesForClone(overrides, 'app_a');
+    expect(out.K1).not.toEqual(out.K2);
+  });
+});
+
+describe('getCloneAppOverrides singleton', () => {
+  beforeEach(() => __resetForTests());
+
+  it('reads process.env.CLONE_APP_ENV_OVERRIDES once', () => {
+    process.env.CLONE_APP_ENV_OVERRIDES = JSON.stringify({
+      app_x: { K: { type: 'static', value: 'v' } },
+    });
+    const a = getCloneAppOverrides();
+    process.env.CLONE_APP_ENV_OVERRIDES = JSON.stringify({});
+    const b = getCloneAppOverrides();
+    expect(a).toBe(b); // memoized
+    delete process.env.CLONE_APP_ENV_OVERRIDES;
+  });
+
+  it('returns {} when env var is unset', () => {
+    delete process.env.CLONE_APP_ENV_OVERRIDES;
+    expect(getCloneAppOverrides()).toEqual({});
+  });
+});

--- a/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
+++ b/services/control-api/src/services/__tests__/clone-replay-env-vars.test.ts
@@ -1,12 +1,61 @@
 import { describe, it, expect } from 'vitest';
 import { replayFunctions } from '../clone-replay.js';
-import { decrypt } from '../crypto.js';
+import { decrypt, encrypt } from '../crypto.js';
 import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/control-db.js';
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
 const describeDb = RUN_DB_TESTS ? describe : describe.skip;
 
 const noopLogger = { info() {}, warn() {} };
+const testLogger = noopLogger;
+
+// Single-region test topology: source and dest apps share one physical pool,
+// matching the naming used by the appOverrides test cases below (and by
+// durable-objects-clone-mint.test.ts's equivalent fixture).
+const sourceRuntimePool = runtimeDb;
+const destRuntimePool = runtimeDb;
+
+/**
+ * Shared fixture for appOverrides tests: seeds an owner + source/dest app
+ * pair and the given source functions, each with encrypted_env_vars declaring
+ * `envKeys` (placeholder values the override path is expected to replace on
+ * the dest). Caller is responsible for calling `cleanupFnFixture`.
+ */
+async function setupFnCloneFixture(opts: { functions: { name: string; envKeys: string[] }[] }) {
+  const { id: ownerId } = await seedUser(
+    `replay-fn-ovr-${Date.now()}-${Math.random().toString(36).slice(2)}@x.com`,
+  );
+  const srcId = `app_fn_ovr_src_${ownerId.slice(0, 8)}`;
+  const destId = `app_fn_ovr_dst_${ownerId.slice(0, 8)}`;
+  for (const id of [srcId, destId]) {
+    await runtimeDb.query(
+      `INSERT INTO apps (id, name, owner_id, db_name, region) VALUES ($1, $1, $2, $1, 'us-east-1')
+       ON CONFLICT (id) DO NOTHING`,
+      [id, ownerId],
+    );
+  }
+  for (const fn of opts.functions) {
+    const envObj = Object.fromEntries(fn.envKeys.map(k => [k, `placeholder-${k}`]));
+    const enc = encrypt(JSON.stringify(envObj), process.env.AUTH_ENCRYPTION_KEY!);
+    await runtimeDb.query(
+      `INSERT INTO app_functions (id, app_id, name, code, encrypted_env_vars, deployed_by)
+       VALUES (gen_random_uuid(), $1, $2, '/* code */', $3, $4)`,
+      [srcId, fn.name, enc, ownerId],
+    );
+  }
+
+  return {
+    sourceApp: { id: srcId, owner_id: ownerId },
+    destApp: { id: destId, owner_id: ownerId },
+  };
+}
+
+async function cleanupFnFixture(ownerId: string, srcId: string, destId: string) {
+  await runtimeDb.query(`DELETE FROM app_functions WHERE app_id IN ($1, $2)`, [srcId, destId]);
+  await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
+  await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
+  await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+}
 
 describeDb('replayFunctions with pending env vars', () => {
   it('writes provided values into the dest function encrypted_env_vars', async () => {
@@ -143,5 +192,98 @@ describeDb('replayFunctions with pending env vars', () => {
     await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
     await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
     await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+  });
+
+  it('layers appOverrides into a function that declares the key', async () => {
+    const { sourceApp, destApp } = await setupFnCloneFixture({
+      functions: [{ name: 'fn_a', envKeys: ['MY_SECRET'] }],
+    });
+
+    const result = await replayFunctions(
+      sourceRuntimePool,
+      destRuntimePool,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      testLogger,
+      { appOverrides: { MY_SECRET: 'v-from-override' } },
+    );
+
+    expect(result.overrideFilledFunctions.fn_a).toContain('MY_SECRET');
+    const encKey = process.env.AUTH_ENCRYPTION_KEY!;
+    const row = await destRuntimePool.query<{ encrypted_env_vars: string }>(
+      `SELECT encrypted_env_vars FROM app_functions WHERE app_id = $1 AND name = 'fn_a'`,
+      [destApp.id],
+    );
+    const decoded = JSON.parse(decrypt(row.rows[0].encrypted_env_vars, encKey));
+    expect(decoded.MY_SECRET).toEqual('v-from-override');
+    expect(result.unfilledEnvVars.fn_a ?? []).not.toContain('MY_SECRET');
+
+    await cleanupFnFixture(destApp.owner_id, sourceApp.id, destApp.id);
+  });
+
+  it('user-supplied pendingEnvVarValues wins over appOverrides', async () => {
+    const { sourceApp, destApp } = await setupFnCloneFixture({
+      functions: [{ name: 'fn_a', envKeys: ['MY_SECRET'] }],
+    });
+
+    const result = await replayFunctions(
+      sourceRuntimePool,
+      destRuntimePool,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      testLogger,
+      {
+        pendingEnvVarValues: { fn_a: { MY_SECRET: 'user-value' } },
+        appOverrides: { MY_SECRET: 'override-value' },
+      },
+    );
+
+    expect(result.overrideFilledFunctions.fn_a ?? []).not.toContain('MY_SECRET');
+    const decoded = JSON.parse(
+      decrypt(
+        (await destRuntimePool.query<{ encrypted_env_vars: string }>(
+          `SELECT encrypted_env_vars FROM app_functions WHERE app_id = $1 AND name = 'fn_a'`,
+          [destApp.id],
+        )).rows[0].encrypted_env_vars,
+        process.env.AUTH_ENCRYPTION_KEY!,
+      ),
+    );
+    expect(decoded.MY_SECRET).toEqual('user-value');
+
+    await cleanupFnFixture(destApp.owner_id, sourceApp.id, destApp.id);
+  });
+
+  it('shares the same override value across every function that declares it', async () => {
+    const { sourceApp, destApp } = await setupFnCloneFixture({
+      functions: [
+        { name: 'fn_a', envKeys: ['SHARED_SECRET'] },
+        { name: 'fn_b', envKeys: ['SHARED_SECRET'] },
+      ],
+    });
+    const sharedValue = 'ab'.repeat(32);
+    const result = await replayFunctions(
+      sourceRuntimePool,
+      destRuntimePool,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      testLogger,
+      { appOverrides: { SHARED_SECRET: sharedValue } },
+    );
+    expect(result.overrideFilledFunctions.fn_a).toContain('SHARED_SECRET');
+    expect(result.overrideFilledFunctions.fn_b).toContain('SHARED_SECRET');
+    const encKey = process.env.AUTH_ENCRYPTION_KEY!;
+    for (const name of ['fn_a', 'fn_b']) {
+      const row = await destRuntimePool.query<{ encrypted_env_vars: string }>(
+        `SELECT encrypted_env_vars FROM app_functions WHERE app_id = $1 AND name = $2`,
+        [destApp.id, name],
+      );
+      const decoded = JSON.parse(decrypt(row.rows[0].encrypted_env_vars, encKey));
+      expect(decoded.SHARED_SECRET).toEqual(sharedValue);
+    }
+
+    await cleanupFnFixture(destApp.owner_id, sourceApp.id, destApp.id);
   });
 });

--- a/services/control-api/src/services/__tests__/durable-objects-clone-mint.test.ts
+++ b/services/control-api/src/services/__tests__/durable-objects-clone-mint.test.ts
@@ -20,6 +20,11 @@ import { runtimeDb, controlDb, seedUser } from '../../__tests__/test-helpers/con
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
 const describeDb = RUN_DB_TESTS ? describe : describe.skip;
 
+// Single-region test topology: source and dest apps share one physical pool.
+// Named separately to match call-site semantics in the brief's test cases.
+const sourceRuntimePool = runtimeDb;
+const destRuntimePool = runtimeDb;
+
 // A minimally-valid DO class source — buildBundle re-extracts class_name via
 // regex from `export class Name extends DurableObject`, so this string is not
 // arbitrary. Matches the shape used by durable-objects.service.test.ts fixtures.
@@ -58,6 +63,35 @@ async function cleanup(ownerId: string, srcId: string, destId: string) {
   await runtimeDb.query(`DELETE FROM apps WHERE id IN ($1, $2)`, [srcId, destId]);
   await controlDb.query(`DELETE FROM platform_users WHERE id = $1`, [ownerId]);
   await controlDb.query(`DELETE FROM organizations WHERE owner_id = $1`, [ownerId]);
+}
+
+/**
+ * Shared fixture for appOverrides tests: seeds an owner + source/dest app
+ * pair and a single source DO ('chat'/ChatRoom) declaring the given DO env
+ * keys (each with a placeholder value that the override path is expected to
+ * replace on the dest). Both source and dest apps live in `runtimeDb`
+ * (single-region test topology), mirroring every other fixture in this file.
+ * Caller is responsible for calling `cleanup(destApp.owner_id, sourceApp.id,
+ * destApp.id)` afterwards.
+ */
+async function setupCloneFixture(opts: { sourceDoEnvKeys: string[] }) {
+  const { id: ownerId } = await seedUser(`do-mint-override-${Date.now()}-${Math.random().toString(36).slice(2)}@x.com`);
+  const srcId = `app_do_ovr_src_${ownerId.slice(0, 8)}`;
+  const destId = `app_do_ovr_dst_${ownerId.slice(0, 8)}`;
+  for (const id of [srcId, destId]) {
+    await runtimeDb.query(
+      `INSERT INTO apps (id, name, owner_id, db_name) VALUES ($1, $1, $2, $1)`,
+      [id, ownerId],
+    );
+  }
+  const envKeys = Object.fromEntries(opts.sourceDoEnvKeys.map((k) => [k, `placeholder-${k}`]));
+  await seedSourceDo(srcId, 'chat', 'ChatRoom', envKeys);
+
+  return {
+    sourceApp: { id: srcId, owner_id: ownerId },
+    destApp: { id: destId, owner_id: ownerId },
+    doName: 'chat',
+  };
 }
 
 describeDb('replayDurableObjectsForClone auto-mint into app_do_env_vars', () => {
@@ -197,7 +231,7 @@ describeDb('replayDurableObjectsForClone auto-mint into app_do_env_vars', () => 
       { sharedMintedKey: 'bb_sk_ignored' },
     );
 
-    expect(result).toEqual({ cloned: [], do_env_keys: [], auto_minted_keys: [] });
+    expect(result).toEqual({ cloned: [], do_env_keys: [], auto_minted_keys: [], override_filled_keys: [] });
 
     const destRows = await runtimeDb.query<{ key: string }>(
       `SELECT key FROM app_do_env_vars WHERE app_id = $1`,
@@ -242,5 +276,82 @@ describeDb('replayDurableObjectsForClone auto-mint into app_do_env_vars', () => 
       .toBe('bb_sk_second_mint');
 
     await cleanup(ownerId, srcId, destId);
+  });
+
+  it('layers appOverrides into declared DO env keys and writes the encrypted value', async () => {
+    const { sourceApp, destApp } = await setupCloneFixture({
+      // Fixture helper (already in this file) inserts a DO row on the source
+      // + an app_do_env_vars row for 'CUSTOM_SECRET' whose value is a
+      // placeholder that we expect the override to REPLACE on the dest.
+      sourceDoEnvKeys: ['CUSTOM_SECRET'],
+    });
+
+    const result = await replayDurableObjectsForClone(
+      sourceRuntimePool,
+      destRuntimePool,
+      controlDb,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      { appOverrides: { CUSTOM_SECRET: 'deadbeef'.repeat(8) } },
+    );
+
+    expect(result.override_filled_keys).toContain('CUSTOM_SECRET');
+    const row = await destRuntimePool.query<{ encrypted_value: string }>(
+      `SELECT encrypted_value FROM app_do_env_vars WHERE app_id = $1 AND key = $2`,
+      [destApp.id, 'CUSTOM_SECRET'],
+    );
+    const encKey = process.env.AUTH_ENCRYPTION_KEY!;
+    expect(decrypt(row.rows[0].encrypted_value, encKey)).toEqual('deadbeef'.repeat(8));
+
+    await cleanup(destApp.owner_id, sourceApp.id, destApp.id);
+  });
+
+  it('skips appOverride keys that the source DO does not declare', async () => {
+    const { sourceApp, destApp } = await setupCloneFixture({ sourceDoEnvKeys: ['ONLY_THIS'] });
+    const result = await replayDurableObjectsForClone(
+      sourceRuntimePool,
+      destRuntimePool,
+      controlDb,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      { appOverrides: { NOT_DECLARED: 'x'.repeat(64) } },
+    );
+    expect(result.override_filled_keys).toEqual([]);
+    const row = await destRuntimePool.query(
+      `SELECT 1 FROM app_do_env_vars WHERE app_id = $1 AND key = 'NOT_DECLARED'`,
+      [destApp.id],
+    );
+    expect(row.rowCount).toBe(0);
+
+    await cleanup(destApp.owner_id, sourceApp.id, destApp.id);
+  });
+
+  it('convention auto-mint wins over appOverrides for the same key', async () => {
+    const { sourceApp, destApp } = await setupCloneFixture({
+      sourceDoEnvKeys: ['BUTTERBASE_API_KEY'],
+    });
+    const result = await replayDurableObjectsForClone(
+      sourceRuntimePool,
+      destRuntimePool,
+      controlDb,
+      sourceApp.id,
+      destApp.id,
+      destApp.owner_id,
+      {
+        sharedMintedKey: 'bb_sk_from_mint',
+        appOverrides: { BUTTERBASE_API_KEY: 'bb_sk_from_override' },
+      },
+    );
+    expect(result.auto_minted_keys).toContain('BUTTERBASE_API_KEY');
+    expect(result.override_filled_keys).not.toContain('BUTTERBASE_API_KEY');
+    const row = await destRuntimePool.query<{ encrypted_value: string }>(
+      `SELECT encrypted_value FROM app_do_env_vars WHERE app_id = $1 AND key = 'BUTTERBASE_API_KEY'`,
+      [destApp.id],
+    );
+    expect(decrypt(row.rows[0].encrypted_value, process.env.AUTH_ENCRYPTION_KEY!)).toEqual('bb_sk_from_mint');
+
+    await cleanup(destApp.owner_id, sourceApp.id, destApp.id);
   });
 });

--- a/services/control-api/src/services/clone-app-overrides.ts
+++ b/services/control-api/src/services/clone-app-overrides.ts
@@ -1,0 +1,98 @@
+import { randomBytes } from 'node:crypto';
+
+// Layered onto function and DO env vars during clone replay. Populated from
+// the CLONE_APP_ENV_OVERRIDES env var (JSON blob) so tenant-specific defaults
+// never live in source. See docs/superpowers/specs/2026-07-16-clone-app-env-overrides-design.md.
+
+export type OverrideSpec =
+  | { type: 'mint_hex'; bytes: number }
+  | { type: 'static'; value: string };
+
+export type CloneAppOverrides = Record<string, Record<string, OverrideSpec>>;
+
+const MIN_BYTES = 16;
+const MAX_BYTES = 128;
+
+function assertSpec(sourceAppId: string, key: string, raw: unknown): OverrideSpec {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(
+      `CLONE_APP_ENV_OVERRIDES[${sourceAppId}][${key}] must be an object`,
+    );
+  }
+  const spec = raw as Record<string, unknown>;
+  if (spec.type === 'mint_hex') {
+    const bytes = spec.bytes;
+    if (typeof bytes !== 'number' || !Number.isInteger(bytes) || bytes < MIN_BYTES || bytes > MAX_BYTES) {
+      throw new Error(
+        `CLONE_APP_ENV_OVERRIDES[${sourceAppId}][${key}].bytes must be an integer in [${MIN_BYTES}, ${MAX_BYTES}]`,
+      );
+    }
+    return { type: 'mint_hex', bytes };
+  }
+  if (spec.type === 'static') {
+    if (typeof spec.value !== 'string') {
+      throw new Error(
+        `CLONE_APP_ENV_OVERRIDES[${sourceAppId}][${key}].value must be a string`,
+      );
+    }
+    return { type: 'static', value: spec.value };
+  }
+  throw new Error(
+    `CLONE_APP_ENV_OVERRIDES[${sourceAppId}][${key}]: unknown override type ${JSON.stringify(spec.type)}`,
+  );
+}
+
+export function parseCloneAppOverrides(raw: string | undefined): CloneAppOverrides {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`CLONE_APP_ENV_OVERRIDES: failed to parse JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`CLONE_APP_ENV_OVERRIDES: top-level must be a JSON object`);
+  }
+  const out: CloneAppOverrides = {};
+  for (const [sourceAppId, byKey] of Object.entries(parsed as Record<string, unknown>)) {
+    if (byKey === null || typeof byKey !== 'object' || Array.isArray(byKey)) {
+      throw new Error(`CLONE_APP_ENV_OVERRIDES[${sourceAppId}] must be an object`);
+    }
+    out[sourceAppId] = {};
+    for (const [key, raw] of Object.entries(byKey as Record<string, unknown>)) {
+      out[sourceAppId][key] = assertSpec(sourceAppId, key, raw);
+    }
+  }
+  return out;
+}
+
+export function resolveOverridesForClone(
+  overrides: CloneAppOverrides,
+  sourceAppId: string,
+): Record<string, string> {
+  const entry = overrides[sourceAppId];
+  if (!entry) return {};
+  const out: Record<string, string> = {};
+  for (const [key, spec] of Object.entries(entry)) {
+    if (spec.type === 'static') {
+      out[key] = spec.value;
+    } else {
+      out[key] = randomBytes(spec.bytes).toString('hex');
+    }
+  }
+  return out;
+}
+
+let cached: CloneAppOverrides | null = null;
+
+export function getCloneAppOverrides(): CloneAppOverrides {
+  if (cached === null) {
+    cached = parseCloneAppOverrides(process.env.CLONE_APP_ENV_OVERRIDES);
+  }
+  return cached;
+}
+
+/** Reset the memoized singleton. Test-only. */
+export function __resetForTests(): void {
+  cached = null;
+}

--- a/services/control-api/src/services/clone-replay.ts
+++ b/services/control-api/src/services/clone-replay.ts
@@ -36,6 +36,11 @@ export interface ReplayFunctionsEnvVarOpts {
    *  instead of minting a second one. Preserves "at most one shared key per
    *  clone." */
   preMintedSharedKey?: string | null;
+  /** Resolved per-clone overrides from CLONE_APP_ENV_OVERRIDES. For every
+   *  function whose source `encrypted_env_vars` declares one of these keys,
+   *  the value is layered into `merged` AFTER user-supplied pendingEnvVarValues
+   *  and CONVENTIONS auto-mint (both win), BEFORE static fills. */
+  appOverrides?: Record<string, string>;
 }
 
 /**
@@ -343,9 +348,11 @@ export async function replayRls(
  *                              `opts.pendingEnvVarValues` supplies user-provided
  *                              values; `opts.autoMintRequests` triggers bb_sk_*
  *                              key generation per function/key pair.
- * @returns `{ count, warnings, unfilledEnvVars }` — rows successfully inserted,
- *          warning strings, and a map of function name → source env var keys that
- *          were not covered by either provided values or auto-mint.
+ * @returns `{ count, warnings, unfilledEnvVars, overrideFilledFunctions }` — rows
+ *          successfully inserted, warning strings, a map of function name → source
+ *          env var keys that were not covered by either provided values or
+ *          auto-mint, and a map of function name → keys that were filled from
+ *          `opts.appOverrides` (non-empty entries only).
  */
 export async function replayFunctions(
   sourceRuntimePool: pg.Pool,
@@ -355,7 +362,12 @@ export async function replayFunctions(
   requestedByUserId: string,
   logger: ReplayLogger,
   opts?: ReplayFunctionsEnvVarOpts,
-): Promise<{ count: number; warnings: string[]; unfilledEnvVars: Record<string, string[]> }> {
+): Promise<{
+  count: number;
+  warnings: string[];
+  unfilledEnvVars: Record<string, string[]>;
+  overrideFilledFunctions: Record<string, string[]>;
+}> {
   const src = await sourceRuntimePool.query<{
     id: string;
     name: string;
@@ -379,6 +391,7 @@ export async function replayFunctions(
   const warnings: string[] = [];
   let inserted = 0;
   const unfilledEnvVars: Record<string, string[]> = {};
+  const overrideFilledFunctions: Record<string, string[]> = {};
 
   // Pre-compute "what env vars does each source function need" — we use this
   // to subtract filled (provided + auto-minted) keys and surface the rest.
@@ -526,11 +539,22 @@ export async function replayFunctions(
           }
         }
 
+        const srcKeysForFn = sourceKeysMap.get(f.name);
+
+        // appOverrides layer (below user-supplied + convention mint, above static fills).
+        if (opts?.appOverrides && srcKeysForFn) {
+          for (const [k, v] of Object.entries(opts.appOverrides)) {
+            if (!srcKeysForFn.has(k)) continue;
+            if (k in merged) continue; // user or convention already covered it
+            merged[k] = v;
+            (overrideFilledFunctions[f.name] ??= []).push(k);
+          }
+        }
+
         // Static fills: deterministic values the platform already knows. Only
         // applied when the source function actually used the key and the
         // caller didn't supply one explicitly.
         const staticFills = resolveStaticFills({ destAppId, apiBaseUrl: config.apiBaseUrl });
-        const srcKeysForFn = sourceKeysMap.get(f.name);
         if (srcKeysForFn) {
           for (const [k, v] of Object.entries(staticFills)) {
             if (srcKeysForFn.has(k) && !(k in merged)) merged[k] = v;
@@ -581,7 +605,7 @@ export async function replayFunctions(
     }
   }
 
-  return { count: inserted, warnings, unfilledEnvVars };
+  return { count: inserted, warnings, unfilledEnvVars, overrideFilledFunctions };
 }
 
 // ---------------------------------------------------------------------------

--- a/services/control-api/src/services/durable-objects.service.ts
+++ b/services/control-api/src/services/durable-objects.service.ts
@@ -662,28 +662,20 @@ export async function replayDurableObjectsForClone(
 
   const overrideFilledKeys: string[] = [];
   if (opts?.appOverrides && Object.keys(opts.appOverrides).length > 0) {
-    const encKey = process.env.AUTH_ENCRYPTION_KEY;
-    if (!encKey) {
-      // Same soft-fail shape as the convention path: log and continue so
-      // the rest of the clone finishes; the unfilled key surfaces to the
-      // dashboard banner via the standard do_env_keys path.
-      // (encKey missing is a boot-config problem that will affect many other
-      // paths too — no need to double-report here.)
-    } else {
-      for (const [key, value] of Object.entries(opts.appOverrides)) {
-        if (!doEnvKeys.includes(key)) continue;
-        if (autoMintedKeys.includes(key)) continue; // convention wins
-        const encrypted = encrypt(value, encKey);
-        await destDb.query(
-          `INSERT INTO app_do_env_vars (app_id, key, encrypted_value)
-           VALUES ($1, $2, $3)
-           ON CONFLICT (app_id, key) DO UPDATE
-             SET encrypted_value = EXCLUDED.encrypted_value,
-                 updated_at = now()`,
-          [destAppId, key, encrypted],
-        );
-        overrideFilledKeys.push(key);
-      }
+    const encKey = process.env.AUTH_ENCRYPTION_KEY!;
+    for (const [key, value] of Object.entries(opts.appOverrides)) {
+      if (!doEnvKeys.includes(key)) continue;
+      if (autoMintedKeys.includes(key)) continue; // convention wins
+      const encrypted = encrypt(value, encKey);
+      await destDb.query(
+        `INSERT INTO app_do_env_vars (app_id, key, encrypted_value)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (app_id, key) DO UPDATE
+           SET encrypted_value = EXCLUDED.encrypted_value,
+               updated_at = now()`,
+        [destAppId, key, encrypted],
+      );
+      overrideFilledKeys.push(key);
     }
   }
 

--- a/services/control-api/src/services/durable-objects.service.ts
+++ b/services/control-api/src/services/durable-objects.service.ts
@@ -536,6 +536,9 @@ export interface CloneReplayResult {
   /** DO env keys that received a value from the shared clone-minted bb_sk_*.
    *  Empty when no shared key was passed or no keys matched a convention. */
   auto_minted_keys: string[];
+  /** DO env keys that received a value from CLONE_APP_ENV_OVERRIDES. Empty
+   *  when no override matched a source-declared DO env key. */
+  override_filled_keys: string[];
 }
 
 export interface ReplayDurableObjectsCloneOpts {
@@ -547,6 +550,11 @@ export interface ReplayDurableObjectsCloneOpts {
   /** Extra DO env keys the caller explicitly asked to auto-fill with the
    *  shared minted key, beyond convention-matched keys. */
   explicitAutoMintKeys?: string[];
+  /** Resolved per-clone overrides from CLONE_APP_ENV_OVERRIDES. Values land
+   *  in app_do_env_vars for any key present in the source's DO env keys.
+   *  Skipped when the same key is already convention-auto-minted (precedence:
+   *  user > convention > override). */
+  appOverrides?: Record<string, string>;
 }
 
 /**
@@ -563,9 +571,11 @@ export interface ReplayDurableObjectsCloneOpts {
  * BB_SUBSTRATE_KEY): when `opts.sharedMintedKey` is provided, those keys are
  * filled with the shared minted bb_sk_* so DOs and functions on the cloned
  * app share the same intra-app credential without a manual set_env step.
+ * `opts.appOverrides` (resolved from CLONE_APP_ENV_OVERRIDES) then fills any
+ * remaining source-declared DO env key not already covered by convention.
  *
  * If the source has no active DOs, returns `{ cloned: [], do_env_keys: [],
- * auto_minted_keys: [] }` without deploying anything.
+ * auto_minted_keys: [], override_filled_keys: [] }` without deploying anything.
  */
 export async function replayDurableObjectsForClone(
   sourceDb: Pool,
@@ -595,7 +605,7 @@ export async function replayDurableObjectsForClone(
   const doEnvKeys = keysRes.rows.map((r) => r.key);
 
   if (src.rows.length === 0) {
-    return { cloned: [], do_env_keys: doEnvKeys, auto_minted_keys: [] };
+    return { cloned: [], do_env_keys: doEnvKeys, auto_minted_keys: [], override_filled_keys: [] };
   }
 
   // Insert every source class into the dest at status='BUILDING'. On conflict
@@ -650,6 +660,33 @@ export async function replayDurableObjectsForClone(
     }
   }
 
+  const overrideFilledKeys: string[] = [];
+  if (opts?.appOverrides && Object.keys(opts.appOverrides).length > 0) {
+    const encKey = process.env.AUTH_ENCRYPTION_KEY;
+    if (!encKey) {
+      // Same soft-fail shape as the convention path: log and continue so
+      // the rest of the clone finishes; the unfilled key surfaces to the
+      // dashboard banner via the standard do_env_keys path.
+      // (encKey missing is a boot-config problem that will affect many other
+      // paths too — no need to double-report here.)
+    } else {
+      for (const [key, value] of Object.entries(opts.appOverrides)) {
+        if (!doEnvKeys.includes(key)) continue;
+        if (autoMintedKeys.includes(key)) continue; // convention wins
+        const encrypted = encrypt(value, encKey);
+        await destDb.query(
+          `INSERT INTO app_do_env_vars (app_id, key, encrypted_value)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (app_id, key) DO UPDATE
+             SET encrypted_value = EXCLUDED.encrypted_value,
+                 updated_at = now()`,
+          [destAppId, key, encrypted],
+        );
+        overrideFilledKeys.push(key);
+      }
+    }
+  }
+
   try {
     await bundleAndDeploy(destDb, controlDb, destAppId);
   } catch (err) {
@@ -671,7 +708,12 @@ export async function replayDurableObjectsForClone(
     [insertedIds],
   );
 
-  return { cloned: src.rows.map((r) => r.name), do_env_keys: doEnvKeys, auto_minted_keys: autoMintedKeys };
+  return {
+    cloned: src.rows.map((r) => r.name),
+    do_env_keys: doEnvKeys,
+    auto_minted_keys: autoMintedKeys,
+    override_filled_keys: overrideFilledKeys,
+  };
 }
 
 // CF binding name pattern: identifier-like, uppercase by convention.

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -62,6 +62,10 @@ export function startNeonTaskWorker(
   dataPlaneDb: pg.Pool,
   logger: Logger,
 ): NodeJS.Timeout {
+  // Force eager parse so a malformed CLONE_APP_ENV_OVERRIDES blob fails the
+  // worker at startup, not mid-clone.
+  getCloneAppOverrides();
+
   let running = false;
 
   const interval = setInterval(async () => {

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -28,6 +28,7 @@ import { replayAppEnvVars } from './clone-app-env.js';
 import { decrypt } from './crypto.js';
 import { insertCloneAuditLog } from './audit/audit-events-service.js';
 import { enqueueWebhookDelivery } from './clone-webhook-store.js';
+import { getCloneAppOverrides, resolveOverridesForClone } from './clone-app-overrides.js';
 
 interface NeonTask {
   id: number;
@@ -764,6 +765,17 @@ async function executeClone(
         );
       }
 
+      // Resolve CLONE_APP_ENV_OVERRIDES once per clone. mint_hex specs produce
+      // a single value here that is threaded into BOTH replayDurableObjectsForClone
+      // and replayFunctions so DO signer + function verifiers share it.
+      const appOverrides = resolveOverridesForClone(getCloneAppOverrides(), job.source_app_id);
+      if (Object.keys(appOverrides).length > 0) {
+        logger.info(
+          { destAppId: resolvedDestAppId, sourceAppId: job.source_app_id, overrideKeys: Object.keys(appOverrides) },
+          '[clone] CLONE_APP_ENV_OVERRIDES matched source app',
+        );
+      }
+
       // Mint the shared bb_sk_ once if EITHER side (DOs or functions) needs
       // it. Detection scans:
       //   - source DO env keys      (auto-mint if any match a convention key)
@@ -832,7 +844,7 @@ async function executeClone(
           job.source_app_id,
           resolvedDestAppId,
           job.requested_by_user_id,
-          { sharedMintedKey },
+          { sharedMintedKey, appOverrides },
         );
         if (doResult.cloned.length > 0) {
           logger.info(
@@ -844,7 +856,10 @@ async function executeClone(
             },
             '[clone] durable objects replayed',
           );
-          const unfilled = doResult.do_env_keys.filter((k) => !doResult.auto_minted_keys.includes(k));
+          const overrideFilled = doResult.override_filled_keys;
+          const unfilled = doResult.do_env_keys.filter(
+            (k) => !doResult.auto_minted_keys.includes(k) && !overrideFilled.includes(k),
+          );
           if (unfilled.length > 0) {
             await appendCloneJobWarnings(controlDb, jobId, [
               `Durable Objects cloned: ${doResult.cloned.join(', ')}. Unfilled DO env keys (${unfilled.join(', ')}) are secrets that were not copied — set them via manage_durable_objects action=set_env after the clone completes.`,
@@ -881,6 +896,7 @@ async function executeClone(
           controlPool: controlDb,
           destAppOwnerId,
           preMintedSharedKey: sharedMintedKey,
+          appOverrides,
         },
       );
       if (fnResult.warnings.length > 0) {


### PR DESCRIPTION
## Summary

- Adds a control-api env var `CLONE_APP_ENV_OVERRIDES` — a JSON blob keyed by source `app_id` that carries per-clone env-var defaults. Two spec types: `mint_hex` (fresh N random bytes as hex, minted once per clone job and shared across every declaring slot) and `static` (literal value).
- Threaded through both replay paths: `replayDurableObjectsForClone` writes matching keys into `app_do_env_vars`, `replayFunctions` layers them into per-function `encrypted_env_vars`.
- Precedence: user-supplied `pendingEnvVarValues` > CONVENTIONS auto-mint (`BUTTERBASE_API_KEY` / `BB_SUBSTRATE_KEY`) > `CLONE_APP_ENV_OVERRIDES` > static fills > unfilled. User and CONVENTIONS layers always win; the override only fills what would otherwise be unfilled.
- Feature is off-by-default. Unset env var = empty resolved map = existing behavior unchanged.

## Motivation

`butter-support` needs an HMAC signing secret shared across one Durable Object signer and two verifier functions. Every clone must get a FRESH secret (not a copy of the source's) so a leak in one clone can't compromise others. Before this PR, cloning that app left `SUBSTRATE_OUTBOX_SECRET` unfilled — the operator had to run `set_env` on every declaring slot after the clone completed and hope nothing fired between clone-complete and set-env. Same for `DEFAULT_MODEL` / `HAIKU_MODEL` string defaults that cloners can't guess.

This mechanism generalizes: any operator-owned template can declare per-source-app defaults via Fly secrets without leaking tenant identifiers or secrets into the OSS repo.

## Design

Full design doc: see `docs/superpowers/specs/2026-07-16-clone-app-env-overrides-design.md` in the internal wrapper repo. Short version:

**Config shape (parsed at worker startup):**

\`\`\`json
{
  "<source_app_id>": {
    "<ENV_KEY>": { "type": "mint_hex", "bytes": 32 },
    "<ENV_KEY_2>": { "type": "static", "value": "..." }
  }
}
\`\`\`

Malformed JSON, unknown \`type\`, or \`bytes\` outside \`[16, 128]\` fails the worker at boot (post the fix in commit \`6c9a007\`).

**Code shape:**

- `clone-app-overrides.ts` — pure parser + resolver. `resolveOverridesForClone(overrides, sourceAppId)` returns `Record<string, string>` with `mint_hex` resolved ONCE at call time. Singleton memoizes the parsed config, NOT the resolved values.
- `neon-task-worker.ts` — orchestrator resolves the map ONCE per clone and threads the SAME `Record<string, string>` into both replay paths. mint_hex → same 64-char hex ends up in every declaring slot.
- `replayDurableObjectsForClone` — new `opts.appOverrides`; writes matching keys into `app_do_env_vars` after the CONVENTIONS auto-mint block. Returns `override_filled_keys: string[]` so the orchestrator can exclude them from the "unfilled DO env keys" warning.
- `replayFunctions` — new `opts.appOverrides`; layers into per-function `merged` after user-supplied and CONVENTIONS but BEFORE static fills. `!(k in merged)` guard enforces precedence.

## Tests

- `clone-app-overrides.test.ts` — 16 tests: parser (empty, malformed, unknown type, bytes range boundaries, static.value type, top-level shape) + resolver (mint_hex freshness across calls and across keys, static passthrough, unmatched app_id) + singleton memoization semantics.
- `durable-objects-clone-mint.test.ts` — 3 new cases: override written and decrypt round-trips; undeclared keys skipped; CONVENTIONS wins over override for the same key.
- `clone-replay-env-vars.test.ts` — 3 new cases: override applied when key declared; user-supplied wins over override; same value shared across N functions declaring the same key.

Focused runs (`durable-objects-clone-mint`, `clone-app-overrides`, `clone-replay-env-vars`): 24/24 pass. Typecheck clean.

## Test plan

- [x] Unit + integration tests pass locally (see above)
- [x] Live end-to-end smoke locally: set `CLONE_APP_ENV_OVERRIDES` in docker-compose, clone a source app with a function declaring `MY_SECRET`, invoke the dest function — returns a fresh 64-char hex string, different from source's value. `unfilled_env_vars: {}` on the completed clone job.
- [ ] Deploy to prod, set `CLONE_APP_ENV_OVERRIDES` in Fly secrets, clone butter-support, verify signer + verifiers agree.

## Rollout

Feature is off-by-default. Merge is safe — no schema changes, no behavioral change until the operator sets the env var.

After merge:
1. Bump submodule pin in the wrapper repo.
2. Deploy butterbase-platform (Fly).
3. \`fly secrets set CLONE_APP_ENV_OVERRIDES='...' --app butterbase-platform\` — single \`set\` call, not \`--stage\`.
4. Clone butter-support in prod and validate.

## Follow-ups (deferred, out of scope)

- Test coverage: NaN / non-integer bytes explicit case; missing-`AUTH_ENCRYPTION_KEY` soft-fail branch (mirrors CONVENTIONS path's existing untested behavior).
- Nice-to-haves: rename inner `raw` shadow in the parser loop; collapse the `testLogger`/pool aliases in the new fn-replay test file; factor `setupFnCloneFixture` out of the file's existing inline-setup style.
- Larger arc (separate spec): env-var schema on the source app declaring defaults at author time (e.g. `$butterbase.random_hex(32)` sentinels), plus a `mint_family` for sharing a value across differently-named keys. This PR is the tactical fix; that's the strategic direction.