### PR TITLE
fix: SDK expire() field mismatch and broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,7 @@ If you need these for self-host, implement against the interfaces in `packages/s
 - [`CHANGELOG.md`](./CHANGELOG.md) — release notes (latest: **v0.2.0**, 2026-05-25 — KV store)
 - [`ROADMAP.md`](./ROADMAP.md) — what's next
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contributor workflow and OSS scope
-- [`SUBDOMAIN_IMPLEMENTATION.md`](./SUBDOMAIN_IMPLEMENTATION.md) — tenant subdomain routing
-- [`docs/runbooks/local-e2e.md`](./docs/runbooks/local-e2e.md) — multi-region E2E stack
-- [`docs/runbooks`](./docs/runbooks) — operational runbooks
+- [`dispatch-worker/`](./dispatch-worker) — tenant subdomain routing
 - [`Examples/`](./Examples) — example apps (todo, grocery list)
 - Docs site (local): `http://localhost:4321` after `docker compose up`
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ This guide covers running the OSS stack on your machine with `docker-compose.loc
 | Node.js | 22+ |
 | npm | 10+ (comes with Node) |
 
-Optional for E2E / move-app tests: `libpq` (`pg_dump`, `psql`) — see [`docs/runbooks/local-e2e.md`](./docs/runbooks/local-e2e.md).
+Optional for E2E / move-app tests: `libpq` (`pg_dump`, `psql`).
 
 ## 1. Get the code
 
@@ -254,7 +254,7 @@ Multi-region integration tests:
 npm run e2e:all    # bootstrap compose + migrate + vitest
 ```
 
-See [`docs/runbooks/local-e2e.md`](./docs/runbooks/local-e2e.md).
+See the E2E config in `vitest.e2e.config.ts`.
 
 ## 10. Troubleshooting
 
@@ -339,6 +339,6 @@ In OSS mode, control-api logs: `No cloud overlays found, running in OSS mode (No
 - Explore [`Examples/`](./Examples) and deploy with [`packages/cli`](./packages/cli/README.md).
 - Use the SDK: [`packages/sdk`](./packages/sdk/README.md).
 - Read MCP tool docs via the butterbase MCP server or `services/mcp-server/src/docs/user-documentation.ts`.
-- Production deploy patterns: [`docs/runbooks`](./docs/runbooks), [`SECURITY.md`](./SECURITY.md).
+- Production deploy patterns: [`SECURITY.md`](./SECURITY.md).
 
 For issues, open a [bug report](https://github.com/butterbase-ai/butterbase/issues/new?template=bug.yml) with `docker compose ps` and relevant logs.

--- a/packages/sdk/src/kv.test.ts
+++ b/packages/sdk/src/kv.test.ts
@@ -232,8 +232,8 @@ describe('ctx.kv (shim)', () => {
 
   // ─── expire ───────────────────────────────────────────────────────────────
 
-  it('expire posts {ttl:null} and returns ok', async () => {
-    const { f, last } = makeSpy(200, { ok: true });
+  it('expire posts {ttl:null} and returns applied', async () => {
+    const { f, last } = makeSpy(200, { applied: true });
     const kv = makeKv({ appId: 'app_a', apiKey: 'k', baseUrl: BASE, fetch: f as any });
     const result = await kv.expire('k', null);
     expect(last().url).toBe(`${ROOT}/k/expire`);

--- a/packages/sdk/src/kv.ts
+++ b/packages/sdk/src/kv.ts
@@ -159,7 +159,7 @@ export function makeKv(opts: MakeKvOptions): KvShim {
     async expire(key: string, ttl: number | null): Promise<boolean> {
       const res = await call('POST', `${key}/expire`, { ttl });
       if (!res.ok) throwForStatus(res, await res.json().catch(() => null));
-      return (await res.json() as { ok: boolean }).ok;
+      return (await res.json() as { applied: boolean }).applied;
     },
 
     async mget<T>(keys: string[]): Promise<(T | null)[]> {


### PR DESCRIPTION
- Fix SDK kv.expire() reading { ok } instead of { applied } from server response — caused expire() to always return undefined
- Update SDK test to match corrected field name
- Fix broken documentation links to non-existent SUBDOMAIN_IMPLEMENTATION.md and docs/runbooks/