### PR TITLE
fix(admin): billing_events INSERTs use correct columns + include user_id

### DIFF
--- a/services/control-api/src/routes/__tests__/admin-apps-orgs.test.ts
+++ b/services/control-api/src/routes/__tests__/admin-apps-orgs.test.ts
@@ -399,14 +399,16 @@ describe('POST /admin/apps/:id/transfer', () => {
     const inEvent = insertCalls.find((c) => c.sql.includes('app_transferred_in'));
     const outEvent = insertCalls.find((c) => c.sql.includes('app_transferred_out'));
     expect(inEvent).toBeDefined();
-    expect(inEvent.params[0]).toBe('org-dest');
-    expect(inEvent.params[1]).toContain('app-team-1');
-    expect(inEvent.params[1]).toContain('org-team');
+    expect(inEvent.params[0]).toBe('admin-uid');
+    expect(inEvent.params[1]).toBe('org-dest');
+    expect(inEvent.params[2]).toContain('app-team-1');
+    expect(inEvent.params[2]).toContain('org-team');
 
     expect(outEvent).toBeDefined();
-    expect(outEvent.params[0]).toBe('org-team');
-    expect(outEvent.params[1]).toContain('app-team-1');
-    expect(outEvent.params[1]).toContain('org-dest');
+    expect(outEvent.params[0]).toBe('admin-uid');
+    expect(outEvent.params[1]).toBe('org-team');
+    expect(outEvent.params[2]).toContain('app-team-1');
+    expect(outEvent.params[2]).toContain('org-dest');
   });
 
   it('409 when app already in destination org', async () => {

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -1254,7 +1254,8 @@ export async function adminRoutes(app: FastifyInstance) {
   // Body: { destination_organization_id: string }
   // Returns: { app_id, from_organization_id, to_organization_id }
   app.post('/admin/apps/:id/transfer', { config: { public: true } }, async (request, reply) => {
-    if (!(await checkAdmin(request, reply))) return;
+    const adminUserId = await requireAdmin(app, request, reply);
+    if (!adminUserId) return;
 
     const { id } = request.params as { id: string };
     const { destination_organization_id } = request.body as { destination_organization_id?: string };
@@ -1303,14 +1304,14 @@ export async function adminRoutes(app: FastifyInstance) {
         [destination_organization_id, id]
       );
       await client.query(
-        `INSERT INTO billing_events (organization_id, event_type, payload, created_at)
-         VALUES ($1, 'app_transferred_in', $2::jsonb, now())`,
-        [destination_organization_id, JSON.stringify({ app_id: id, from: fromOrgId })]
+        `INSERT INTO billing_events (user_id, organization_id, event_type, metadata, created_at)
+         VALUES ($1, $2, 'app_transferred_in', $3::jsonb, now())`,
+        [adminUserId, destination_organization_id, JSON.stringify({ app_id: id, from: fromOrgId })]
       );
       await client.query(
-        `INSERT INTO billing_events (organization_id, event_type, payload, created_at)
-         VALUES ($1, 'app_transferred_out', $2::jsonb, now())`,
-        [fromOrgId, JSON.stringify({ app_id: id, to: destination_organization_id })]
+        `INSERT INTO billing_events (user_id, organization_id, event_type, metadata, created_at)
+         VALUES ($1, $2, 'app_transferred_out', $3::jsonb, now())`,
+        [adminUserId, fromOrgId, JSON.stringify({ app_id: id, to: destination_organization_id })]
       );
       await client.query('COMMIT');
     } catch (err) {

--- a/services/control-api/src/routes/admin/organizations.test.ts
+++ b/services/control-api/src/routes/admin/organizations.test.ts
@@ -600,9 +600,10 @@ describe('PATCH /admin/organizations/:id/plan', () => {
     expect(subscriptionUpdates).toHaveLength(0);
 
     expect(billingEventInserts).toHaveLength(1);
-    expect(billingEventInserts[0][0]).toBe('org-1');
-    const payload = JSON.parse(billingEventInserts[0][1] as string);
-    expect(payload).toEqual({ plan_id: 'enterprise-acme', stripe_price_id: 'price_123' });
+    expect(billingEventInserts[0][0]).toBe('admin-uid');
+    expect(billingEventInserts[0][1]).toBe('org-1');
+    const metadata = JSON.parse(billingEventInserts[0][2] as string);
+    expect(metadata).toEqual({ plan_id: 'enterprise-acme', stripe_price_id: 'price_123' });
   });
 
   it('200 assigns plan and updates the existing subscription row (no INSERT)', async () => {

--- a/services/control-api/src/routes/admin/organizations.ts
+++ b/services/control-api/src/routes/admin/organizations.ts
@@ -507,9 +507,9 @@ const organizationsRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       await client.query(
-        `INSERT INTO billing_events (organization_id, event_type, payload, created_at)
-         VALUES ($1, 'plan_assigned_admin', $2::jsonb, now())`,
-        [id, JSON.stringify({ plan_id, stripe_price_id: stripe_price_id ?? null })]
+        `INSERT INTO billing_events (user_id, organization_id, event_type, metadata, created_at)
+         VALUES ($1, $2, 'plan_assigned_admin', $3::jsonb, now())`,
+        [user.id, id, JSON.stringify({ plan_id, stripe_price_id: stripe_price_id ?? null })]
       );
 
       await client.query('COMMIT');


### PR DESCRIPTION
## Summary

Two `/admin/*` handlers were writing `billing_events` with a non-existent `payload` column (real schema uses `metadata`) and omitting the `NOT NULL` `user_id` column. Every attempt to assign an org plan or transfer an app between orgs raised `column "payload" does not exist` at the last INSERT, rolled the transaction back, and surfaced as a 500 to the admin dashboard (shown there as `Error: [object Object]`).

Reported live from the admin dashboard against `PATCH https://api.butterbase.ai/admin/organizations/28c077e9-.../plan` — the org update itself succeeded logically but the trailing audit insert killed the whole transaction.

## Changes

- `services/control-api/src/routes/admin/organizations.ts` — `PATCH /admin/organizations/:id/plan`: rename `payload` → `metadata`, include `user_id` (the acting admin from `requireAdmin`).
- `services/control-api/src/routes/admin.ts` — `POST /admin/apps/:id/transfer`: same fix, applied to both `app_transferred_in` and `app_transferred_out` audit rows. Replaced `checkAdmin` boolean helper with a direct `requireAdmin` call so we can capture `adminUserId` for the inserts.
- Tests updated to reflect the new positional params order.

## Root cause verified

```
$ psql "$CONTROL_DB_URL" -c "\d billing_events"
     Column      |  Nullable  | Notes
-----------------+------------+-------
 user_id         | not null   | ← handler omitted this
 event_type      | not null
 metadata        | nullable   | ← handler wrote to nonexistent `payload`
 organization_id | not null
 ...
```

## Test plan

- [x] `pnpm test src/routes/admin/organizations.test.ts` → 26/26 pass
- [x] `pnpm test src/routes/__tests__/admin-apps-orgs.test.ts` → all transfer + org-enrichment tests pass. (The 3 unrelated `PATCH /admin/billing/users/:id/plan (shim → organizations)` failures are pre-existing on `main` — the shim route lives in a cloud overlay not registered in that test's setup.)
- [x] `pnpm build` (tsc) clean
- [ ] After internal submodule bump + deploy: retry plan assignment on Moyi Tech org from the admin dashboard.

## Follow-up (separate PR)

Admin dashboard's `adminMutate` should stringify server error bodies properly instead of coercing the response object to `String`, so a future 500 shows the real error field instead of `[object Object]`.