### PR TITLE
fix(admin): PATCH org plan writes to real subscriptions schema

### DIFF
--- a/services/control-api/src/routes/admin/organizations.test.ts
+++ b/services/control-api/src/routes/admin/organizations.test.ts
@@ -567,6 +567,9 @@ describe('PATCH /admin/organizations/:id/plan', () => {
         subscriptionSelects.push(params);
         return { rows: [] };
       }
+      if (sql.includes('SELECT owner_id FROM organizations')) {
+        return { rows: [{ owner_id: 'owner-uid' }] };
+      }
       if (sql.includes('INSERT INTO subscriptions')) {
         subscriptionInserts.push(params);
         return { rows: [{ id: 'sub-1' }] };
@@ -596,7 +599,7 @@ describe('PATCH /admin/organizations/:id/plan', () => {
 
     expect(subscriptionSelects).toHaveLength(1);
     expect(subscriptionInserts).toHaveLength(1);
-    expect(subscriptionInserts[0]).toEqual(['org-1', 'enterprise-acme', 'price_123']);
+    expect(subscriptionInserts[0]).toEqual(['owner-uid', 'org-1', 'enterprise-acme']);
     expect(subscriptionUpdates).toHaveLength(0);
 
     expect(billingEventInserts).toHaveLength(1);

--- a/services/control-api/src/routes/admin/organizations.ts
+++ b/services/control-api/src/routes/admin/organizations.ts
@@ -485,24 +485,38 @@ const organizationsRoutes: FastifyPluginAsync = async (fastify) => {
       // has no UNIQUE constraint (migration 075 only added the column), so ON CONFLICT
       // isn't available here — do a manual SELECT then UPDATE-or-INSERT. FOR UPDATE
       // serializes concurrent admins racing a plan change for the same org.
+      //
+      // subscriptions has no stripe_price_id column — the picked enterprise price is
+      // captured in the billing_events audit metadata below. subscriptions.user_id is
+      // NOT NULL; for a fresh INSERT we anchor it to the org owner.
       const existingSub = await client.query(
         `SELECT id FROM subscriptions WHERE organization_id = $1 LIMIT 1 FOR UPDATE`,
         [id]
       );
       if (existingSub.rows.length === 0) {
+        const ownerRes = await client.query(
+          `SELECT owner_id FROM organizations WHERE id = $1`,
+          [id]
+        );
+        const ownerId = ownerRes.rows[0]?.owner_id;
+        if (!ownerId) {
+          await client.query('ROLLBACK');
+          reply.code(500).send({ error: 'organization_owner_not_found' });
+          return;
+        }
         await client.query(
-          `INSERT INTO subscriptions (organization_id, plan_id, status, stripe_price_id, created_at)
-           VALUES ($1, $2, 'active', $3, now())`,
-          [id, plan_id, stripe_price_id ?? null]
+          `INSERT INTO subscriptions (user_id, organization_id, plan_id, status, created_at)
+           VALUES ($1, $2, $3, 'active', now())`,
+          [ownerId, id, plan_id]
         );
       } else {
         await client.query(
           `UPDATE subscriptions
               SET plan_id = $1,
-                  stripe_price_id = coalesce($2, stripe_price_id),
-                  status = 'active'
-            WHERE organization_id = $3`,
-          [plan_id, stripe_price_id ?? null, id]
+                  status = 'active',
+                  updated_at = now()
+            WHERE organization_id = $2`,
+          [plan_id, id]
         );
       }
 


### PR DESCRIPTION
## Summary

Second bug in `PATCH /admin/organizations/:id/plan` (surfaced after #96 unblocked the audit insert): the handler writes to a nonexistent `subscriptions.stripe_price_id` column and omits the NOT NULL `subscriptions.user_id`. Every plan-assign now 500s with `column "stripe_price_id" does not exist` (verified in prod fly logs).

## Changes

- Drop `stripe_price_id` from both subscription writes. Real schema has `stripe_customer_id` / `stripe_subscription_id` only; the picked price is already captured in `billing_events.metadata` for audit.
- INSERT branch: fetch `organizations.owner_id` and use it for `subscriptions.user_id` (NOT NULL).
- UPDATE branch: add `updated_at = now()` to match the pattern used elsewhere in this codebase.
- Tests updated for the new positional params.

## Deploy

Target: `butterbase-platform` only. No migrations. Direct follow-up to #96.