### PR TITLE
fix(mcp): let org members see shared apps + surface repo status auth errors

### DIFF
--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -7,7 +7,7 @@ import { requireUserId } from '../utils/require-auth.js';
 import { quotaErrors } from '../utils/quota-errors.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
 import { getDataProjectIdForRegion } from '../services/neon-projects.js';
-import { addOrgAppIndex, removeOrgAppIndex, listUserApps } from '../services/org-app-index.js';
+import { addOrgAppIndex, removeOrgAppIndex, listUserApps, listAppsForUserAcrossOrgs } from '../services/org-app-index.js';
 import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
 import { checkProjectQuota } from '../services/project-quota.js';
 import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
@@ -46,22 +46,26 @@ export async function initRoutes(app: FastifyInstance) {
   app.get('/apps', async (request) => {
     const ownerId = requireUserId(request);
     // Scope to the caller's active org (Plan 07 org-scoped auth):
-    //   - bb_sk_* API keys carry their own organization_id → that's the scope.
-    //   - JWT callers may set x-organization-id (populated on request.auth) to
-    //     pick an org they belong to; otherwise fall back to the personal org.
-    // Cross-org apps are only visible with a key/session scoped to that org —
-    // this preserves the per-key strict scoping model.
-    const activeOrgId = request.auth?.organizationId
-      ?? await resolveOrganizationId(app.controlDb, ownerId);
-    const indexRows = await listUserApps(app.controlDb, activeOrgId);
+    //   - bb_sk_* API keys carry their own organization_id → strict single-org listing.
+    //   - JWT callers that sent x-organization-id (populated on request.auth) → same.
+    //   - JWT callers WITHOUT an explicit active org → fan out over every org the
+    //     user is a member of, so a team-org member can discover shared apps
+    //     without a chicken-and-egg dance around x-organization-id.
+    // The strict per-key scoping model is preserved: bb_sk_* keys never see
+    // cross-org apps, only unscoped JWT sessions do.
+    const activeOrgId = request.auth?.organizationId ?? null;
+    const indexRows = activeOrgId
+      ? await listUserApps(app.controlDb, activeOrgId)
+      : await listAppsForUserAcrossOrgs(app.controlDb, ownerId);
     if (indexRows.length === 0) return { apps: [] };
 
-
-    // Fetch runtime rows for the exact app-ids resolved by the org-scoped
-    // org_app_index — do NOT re-filter by owner_id, since org-shared apps
-    // are owned by the org's owner, not the caller. Group by region.
+    // Fetch runtime rows for the exact app-ids resolved above — do NOT re-filter
+    // by owner_id, since org-shared apps are owned by the org's owner, not the
+    // caller. Group by region.
+    const orgByAppId = new Map<string, string>();
     const idsByRegion = new Map<string, string[]>();
     for (const r of indexRows) {
+      orgByAppId.set(r.app_id, r.organization_id);
       const list = idsByRegion.get(r.region) ?? [];
       list.push(r.app_id);
       idsByRegion.set(r.region, list);
@@ -72,7 +76,13 @@ export async function initRoutes(app: FastifyInstance) {
         'SELECT id, name, subdomain, db_name, db_provisioned, provisioning_status, region, visibility, listed, template_source_app_id, fork_count, substrate_organization_id, substrate_autopropagate, created_at FROM apps WHERE id = ANY($1::text[]) ORDER BY created_at DESC',
         [appIds]
       );
-      allRows.push(...rows);
+      for (const row of rows) {
+        // Surface the owning org so callers can group/filter without a second
+        // round-trip. Runtime apps.organization_id may lag behind the control
+        // index during backfill; org_app_index is the authoritative pointer.
+        row.organization_id = orgByAppId.get(row.id) ?? row.organization_id ?? null;
+        allRows.push(row);
+      }
     }
     allRows.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
     return { apps: allRows };

--- a/services/control-api/src/routes/mcp.ts
+++ b/services/control-api/src/routes/mcp.ts
@@ -31,8 +31,12 @@ async function handleMcp(
       process.env.BUTTERBASE_E2E === '1' && typeof rawTestUid === 'string' && rawTestUid.length > 0
         ? rawTestUid
         : undefined;
+    // Forward x-organization-id so JWT MCP callers can pick which of their
+    // orgs tool calls resolve against. bb_sk_* keys ignore this downstream.
+    const rawOrgId = request.headers['x-organization-id'];
+    const organizationId = typeof rawOrgId === 'string' && rawOrgId.length > 0 ? rawOrgId : undefined;
 
-    await runWithRequestAuth({ authorizationHeader, testUserId }, async () => {
+    await runWithRequestAuth({ authorizationHeader, testUserId, organizationId }, async () => {
       await transport.handleRequest(request.raw, reply.raw, request.body);
     });
   } catch (error) {

--- a/services/control-api/src/services/org-app-index.ts
+++ b/services/control-api/src/services/org-app-index.ts
@@ -57,3 +57,25 @@ export async function listUserApps(controlPool: pg.Pool, organizationId: string)
   return r.rows;
 }
 
+/**
+ * List every app in every org the user is a member of. Used by JWT sessions
+ * that haven't picked an explicit active org — otherwise a user in multiple
+ * orgs sees only their personal-org apps and can't even discover the ids of
+ * team-org apps to switch context to. bb_sk_* API keys never call this — they
+ * carry an explicit organization_id and stay strictly scoped via listUserApps.
+ */
+export async function listAppsForUserAcrossOrgs(
+  controlPool: pg.Pool,
+  userId: string,
+): Promise<OrgAppIndexRow[]> {
+  const r = await controlPool.query<OrgAppIndexRow>(
+    `SELECT i.app_id, i.organization_id, i.region, i.subdomain, i.app_name, i.created_at, i.updated_at
+     FROM org_app_index i
+     JOIN organization_members m ON m.organization_id = i.organization_id
+     WHERE m.user_id = $1
+     ORDER BY i.created_at DESC`,
+    [userId],
+  );
+  return r.rows;
+}
+

--- a/services/mcp-server/src/api-client.ts
+++ b/services/mcp-server/src/api-client.ts
@@ -1,4 +1,4 @@
-import { getRequestAuthorizationHeader, getRequestTestUserId } from './request-auth-context.js';
+import { getRequestAuthorizationHeader, getRequestTestUserId, getRequestOrganizationId } from './request-auth-context.js';
 
 // On Fly (production), default to the public Fly-anycast URL so that
 // auto-CRUD/storage/function requests for cross-region apps pass through
@@ -46,6 +46,14 @@ export function getHeaders(): HeadersInit {
   const testUserId = getRequestTestUserId();
   if (testUserId) {
     (headers as Record<string, string>)['x-test-user-id'] = testUserId;
+  }
+
+  // Forward the caller-selected org scope for JWT MCP sessions. control-api's
+  // auth plugin verifies membership before honoring it; unauthorized values
+  // are silently dropped there.
+  const orgId = getRequestOrganizationId();
+  if (orgId) {
+    (headers as Record<string, string>)['x-organization-id'] = orgId;
   }
 
   return headers;

--- a/services/mcp-server/src/request-auth-context.ts
+++ b/services/mcp-server/src/request-auth-context.ts
@@ -6,6 +6,12 @@ interface RequestAuthContext {
   // the inbound /mcp route AND the downstream control-api. Lets the
   // existing x-test-user-id auth bypass flow through MCP tool wrappers.
   testUserId?: string;
+  // Optional org scope for JWT MCP sessions — the client sends
+  // x-organization-id on the /mcp POST to pick which org (of the user's
+  // memberships) tool calls run against. Forwarded verbatim to control-api,
+  // which validates membership before honoring it. bb_sk_* keys ignore this
+  // (their org is baked into the key).
+  organizationId?: string;
 }
 
 const requestAuthStorage = new AsyncLocalStorage<RequestAuthContext>();
@@ -23,7 +29,7 @@ export async function runWithRequestAuthorizationHeader<T>(
  * (non-E2E) traffic this is identical to runWithRequestAuthorizationHeader.
  */
 export async function runWithRequestAuth<T>(
-  ctx: { authorizationHeader?: string; testUserId?: string },
+  ctx: { authorizationHeader?: string; testUserId?: string; organizationId?: string },
   callback: () => Promise<T>
 ): Promise<T> {
   return requestAuthStorage.run(ctx, callback);
@@ -35,4 +41,8 @@ export function getRequestAuthorizationHeader(): string | undefined {
 
 export function getRequestTestUserId(): string | undefined {
   return requestAuthStorage.getStore()?.testUserId;
+}
+
+export function getRequestOrganizationId(): string | undefined {
+  return requestAuthStorage.getStore()?.organizationId;
 }

--- a/services/mcp-server/src/tools/manage-repo.ts
+++ b/services/mcp-server/src/tools/manage-repo.ts
@@ -73,15 +73,29 @@ Auth matrix: writes (push, wipe) require app owner. Reads (pull_latest, status, 
           return text(res);
         }
         case 'status': {
-          // No "working tree" on the server; return what we can.
-          let remoteLatest: string | null = null;
-          let fileCount = 0;
-          try {
-            const latest = await apiGet<{ snapshot_id: string; manifest: Manifest }>(`/v1/${args.app_id}/repo/snapshots/latest`);
-            remoteLatest = latest.snapshot_id;
-            fileCount = latest.manifest.files.length;
-          } catch { /* no snapshots yet */ }
-          return text({ app_id: args.app_id, remote_latest_snapshot_id: remoteLatest, file_count: fileCount });
+          // No "working tree" on the server; return what we can. Use the list
+          // endpoint (200 + empty array when no snapshots) rather than
+          // /latest (404 when no snapshots) so we can distinguish
+          //   "app has no snapshots yet"  (empty list, safe to report)
+          //   from
+          //   "you cannot see this app"   (401/403/404 from auth) — must surface
+          // The previous try/catch on /latest swallowed the auth 404 and
+          // returned {remote_latest_snapshot_id: null, file_count: 0}, making
+          // access-denied indistinguishable from an empty repo.
+          const list = await apiGet<{ snapshots: { snapshot_id: string; created_at: string }[] }>(
+            `/v1/${args.app_id}/repo/snapshots`
+          );
+          if (list.snapshots.length === 0) {
+            return text({ app_id: args.app_id, remote_latest_snapshot_id: null, file_count: 0 });
+          }
+          const latest = await apiGet<{ snapshot_id: string; manifest: Manifest }>(
+            `/v1/${args.app_id}/repo/snapshots/latest`
+          );
+          return text({
+            app_id: args.app_id,
+            remote_latest_snapshot_id: latest.snapshot_id,
+            file_count: latest.manifest.files.length,
+          });
         }
         case 'wipe': {
           const res = await apiDelete(`/v1/${args.app_id}/repo`);


### PR DESCRIPTION
## Summary
Two related MCP visibility bugs surfaced when a user is a non-owner member of a shared org:

- `GET /apps` (used by `manage_app list`) only returned apps from the caller's single active org. JWT MCP sessions without an explicit `x-organization-id` were pinned to their personal org and silently missed team-org apps — a chicken-and-egg with the header. Now: unscoped JWT sessions fan out over `organization_members`; `bb_sk_*` API keys keep strict single-org scoping (Plan 07 unchanged). Response also carries `organization_id` per row so callers can group/filter without a second round-trip.
- `manage_repo action=status` wrapped `/repo/snapshots/latest` in a bare `try/catch` and returned `{remote_latest_snapshot_id: null, file_count: 0}` on any error, making an auth-denied 404 indistinguishable from an empty repo. Now probes `/repo/snapshots` first (200 + `[]` when empty; 404 on auth) so access errors propagate.
- MCP transport now forwards `x-organization-id` so JWT MCP sessions can target a specific member-of org; control-api's existing auth plugin still enforces membership before honoring it.

## Files
- `services/control-api/src/routes/init.ts` — fan-out `GET /apps`, emit `organization_id`
- `services/control-api/src/services/org-app-index.ts` — new `listAppsForUserAcrossOrgs`
- `services/control-api/src/routes/mcp.ts` — forward `x-organization-id` inbound
- `services/mcp-server/src/request-auth-context.ts` + `api-client.ts` — propagate + forward `x-organization-id`
- `services/mcp-server/src/tools/manage-repo.ts` — `status` uses list endpoint, no swallow

## Test plan
- [x] `tsc --noEmit` on both `services/control-api` and `services/mcp-server`
- [x] Local docker rebuild + healthy boot for the full stack
- [x] Reproduced Bug #2 fix locally: user B (member of team-org, no `x-organization-id`) sees team-shared-app in `GET /apps` with `organization_id` populated; stranger C sees `[]`
- [x] Reproduced Bug #1 fix locally through real `/mcp` transport: member with empty repo → `{remote_latest_snapshot_id: null, file_count: 0}`; stranger → `isError: true` + `RESOURCE_NOT_FOUND` (previously would have been the same fake empty payload)
- [ ] Verify against prod after deploy: list a shared-org app as a member, and repo status against a non-owned app returns a real error