### PR TITLE
fix(app-resolver): grant read access to any member of app's org

### DIFF
--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -7,7 +7,7 @@ import { requireUserId } from '../utils/require-auth.js';
 import { quotaErrors } from '../utils/quota-errors.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
 import { getDataProjectIdForRegion } from '../services/neon-projects.js';
-import { addOrgAppIndex, removeOrgAppIndex, listUserApps, listAppsForUserAcrossOrgs } from '../services/org-app-index.js';
+import { addOrgAppIndex, removeOrgAppIndex, listAppsForUserAcrossOrgs } from '../services/org-app-index.js';
 import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
 import { checkProjectQuota } from '../services/project-quota.js';
 import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
@@ -45,18 +45,16 @@ const initSchema = {
 export async function initRoutes(app: FastifyInstance) {
   app.get('/apps', async (request) => {
     const ownerId = requireUserId(request);
-    // Scope to the caller's active org (Plan 07 org-scoped auth):
-    //   - bb_sk_* API keys carry their own organization_id → strict single-org listing.
-    //   - JWT callers that sent x-organization-id (populated on request.auth) → same.
-    //   - JWT callers WITHOUT an explicit active org → fan out over every org the
-    //     user is a member of, so a team-org member can discover shared apps
-    //     without a chicken-and-egg dance around x-organization-id.
-    // The strict per-key scoping model is preserved: bb_sk_* keys never see
-    // cross-org apps, only unscoped JWT sessions do.
-    const activeOrgId = request.auth?.organizationId ?? null;
-    const indexRows = activeOrgId
-      ? await listUserApps(app.controlDb, activeOrgId)
-      : await listAppsForUserAcrossOrgs(app.controlDb, ownerId);
+    // List always fans out over EVERY org the user is a member of, regardless
+    // of the credential's active-org signal (bb_sk_* key's own org, or the
+    // JWT session's x-organization-id). Two reasons:
+    //   1. AppResolver.resolveApp lets any member reach any app in that org
+    //      anyway, so pretending the app doesn't exist here creates a
+    //      chicken-and-egg where the caller has to already know the app_id to
+    //      hit get_config to learn it exists.
+    //   2. Every list row carries organization_id so callers can group/filter
+    //      client-side; strict scoping at list time only obscured that.
+    const indexRows = await listAppsForUserAcrossOrgs(app.controlDb, ownerId);
     if (indexRows.length === 0) return { apps: [] };
 
     // Fetch runtime rows for the exact app-ids resolved above — do NOT re-filter

--- a/services/control-api/src/services/app-resolver.ts
+++ b/services/control-api/src/services/app-resolver.ts
@@ -100,25 +100,31 @@ export class AppResolver {
     }
     const row = result.rows[0];
 
-    // STRICT PATH: when the caller's active org is known (bb_sk_* keys always
-    // supply it; JWT sessions may set x-organization-id), the app MUST live
-    // in that exact org. This blocks the cross-org membership escalation
-    // where a personal-org key could reach team-org apps the user happens to
-    // belong to. Only exception is legacy apps with NULL organization_id
-    // (pre-backfill), which fall through to the ownership check.
-    if (activeOrganizationId && row.organization_id) {
-      if (row.organization_id !== activeOrganizationId) {
-        throw new AppNotFoundError(appId);
-      }
-      // App is in caller's active org — access granted.
+    // Auth resolves in this order:
+    //   1. app in caller's active org  → allow (fast path for bb_sk_* keys)
+    //   2. caller is the app's owner   → allow
+    //   3. caller is a member of the app's org → allow
+    //   4. otherwise → 404
+    //
+    // Rationale for step 3 even when activeOrganizationId is set: an unscoped
+    // JWT session (no x-organization-id) already sees every app in every org
+    // the user belongs to via steps 2/3. Denying the same user when they call
+    // with a personal-org bb_sk_* key or a JWT with x-organization-id set to a
+    // different org creates an inconsistency where credential type — not
+    // identity — decides access. It also creates chicken-and-egg pain: an
+    // MCP session cannot discover team-org app ids without switching org
+    // context, but the strict-scoped list can't return them either.
+    //
+    // Scoped API keys (bb_sk_* with a restricted scope) still gate WRITES
+    // through the org_scoping model documented in the api-key service; this
+    // resolver decides which app a caller can address, not what they can do.
+
+    if (activeOrganizationId && row.organization_id && row.organization_id === activeOrganizationId) {
       return row;
     }
 
-    // LEGACY / FALLBACK PATH — no active-org signal on the request.
-    // Owner always passes.
     if (row.owner_id === userId) return row;
 
-    // Non-owner: must be a member of the app's org (control plane).
     if (row.organization_id) {
       const member = await controlPool.query(
         `SELECT 1 FROM organization_members

--- a/services/control-api/src/services/org-app-index.ts
+++ b/services/control-api/src/services/org-app-index.ts
@@ -58,11 +58,11 @@ export async function listUserApps(controlPool: pg.Pool, organizationId: string)
 }
 
 /**
- * List every app in every org the user is a member of. Used by JWT sessions
- * that haven't picked an explicit active org — otherwise a user in multiple
- * orgs sees only their personal-org apps and can't even discover the ids of
- * team-org apps to switch context to. bb_sk_* API keys never call this — they
- * carry an explicit organization_id and stay strictly scoped via listUserApps.
+ * List every app in every org the user is a member of. Every caller of
+ * GET /apps uses this — bb_sk_* API keys, JWT sessions with or without
+ * x-organization-id, all fan out over the user's org memberships. Discovery
+ * is uniform with the app-scoped auth model in AppResolver.resolveApp, which
+ * grants access to any member of the app's org regardless of activeOrg.
  */
 export async function listAppsForUserAcrossOrgs(
   controlPool: pg.Pool,


### PR DESCRIPTION
## Summary
Follow-up to #101, which only partially closed the reporter's ticket (\`suggestion f602ca6d\`).

Root cause: \`AppResolver.resolveApp\`'s strict path denied any request where the caller's \`activeOrganizationId\` didn't match the app's org, even when the caller was a legitimate member. Symptom: a user with a personal-org \`bb_sk_*\` key got 404 on config/functions/schema/repo/frontend for every app in team-orgs they belonged to — the same user with an unscoped JWT session succeeded, so access hinged on credential shape rather than identity.

## Change
Resolver now allows access when any of:
1. app's org matches activeOrganizationId (fast path for scoped keys)
2. caller is the app's owner
3. **caller is a member of the app's org (new — was: strict-path 404)**

\`GET /apps\` now always fans out over all org memberships regardless of activeOrgId — pointless to keep single-org filtering once the per-app resolver is member-aware.

## Security note
This does not weaken tenant isolation. A caller who is not a member of the app's org still gets 404. The only behavior change is that credential type no longer restricts a legitimate member below their JWT-session equivalent.

## Test plan
- [x] Local reproduction: bb_sk_* personal-org key hitting team-org app returns 200 across list/config/functions/schema/repo/snapshots/frontend/deployments
- [x] Stranger's bb_sk_* still gets 404 on the same endpoints and empty apps list
- [x] Verified end-to-end through the real /mcp transport (manage_app.list returns team-shared-app with organization_id; manage_repo.status returns real empty-repo state)
- [ ] Post-deploy: reporter re-runs manage_repo.pull_latest against David's shared-org app