### PR TITLE
fix(mcp): manage_app.link_substrate must forward organization_id

### DIFF
--- a/services/mcp-server/src/tools/manage-app.ts
+++ b/services/mcp-server/src/tools/manage-app.ts
@@ -80,7 +80,7 @@ Common errors:
       source_app_id: z.string().optional().describe('Required for "clone" and "preview_clone_env_vars". The id of the public app to clone.'),
       name: z.string().optional().describe('Optional for "clone". A name for the new app; defaults to `Clone of <source_app_id>`.'),
       region: z.string().optional().describe('Optional for "clone". The region for the new app; defaults to the source app\'s region.'),
-      organization_id: z.string().min(1).optional().describe('Optional for "clone". Organization to create the destination app under. Requires membership. Defaults to the caller\'s personal org.'),
+      organization_id: z.string().min(1).optional().describe('Optional for "clone" and "link_substrate". For "clone", the org to create the destination app under (requires membership; defaults to caller\'s personal org). For "link_substrate", the org whose substrate the app should be linked to (requires caller membership; server 403s otherwise; defaults to caller\'s active/personal org).'),
       env_var_values: z.record(z.string(), z.record(z.string(), z.string())).optional()
         .describe('Optional for "clone". Per-function env var values: { fn_name: { KEY: "value" } }. Use preview_clone_env_vars to see what keys the source needs.'),
       auto_mint_api_key: z.array(z.object({
@@ -253,7 +253,10 @@ Common errors:
         case 'link_substrate': {
           const err = need(args.app_id, '"app_id" is required for this action.');
           if (err) return err;
-          const result = await apiPost(`/v1/me/apps/${args.app_id}/substrate-link`, {});
+          const body = args.organization_id
+            ? { organization_id: args.organization_id }
+            : {};
+          const result = await apiPost(`/v1/me/apps/${args.app_id}/substrate-link`, body);
           return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
         }
         case 'unlink_substrate': {


### PR DESCRIPTION
## Summary
- Extend `organization_id` schema on `manage_app` to also cover `link_substrate` (was clone-only).
- Forward `{ organization_id }` in the POST body when the caller provides it.

## Why
Previously `link_substrate` posted `{}` and its schema restricted `organization_id` to `clone`, so callers who explicitly asked to link an app to a specific org's substrate had their choice silently dropped. The server would resolve the caller's active/personal org and write that instead — from the caller's perspective the tool returned `linked: true` with the wrong `organization_id`, breaking any multi-org substrate topology.

Pairs with the internal overlay change that adds a membership check + 403 on non-member targets, so passing a foreign org yields a clear error rather than a silent no-op.

## Test plan
- [ ] Call `manage_app action=link_substrate app_id=<A> organization_id=<orgB>` with a key whose caller is a member of both orgs → app rebinds to orgB.
- [ ] Same call with a caller who is not a member of orgB → 403 (from the paired overlay change).
- [ ] Omit `organization_id` → behavior unchanged (falls back to caller's active/personal org).