### PR TITLE
fix(ai-router): whitelist FLUX.2 family in openrouter image adapter

### DIFF
--- a/services/control-api/src/services/ai-router/adapters/openrouter.ts
+++ b/services/control-api/src/services/ai-router/adapters/openrouter.ts
@@ -35,6 +35,10 @@ const OPENROUTER_IMAGE_MODELS: ReadonlySet<string> = new Set([
   'google/gemini-3.1-flash-lite-image',
   'google/gemini-3.1-flash-image',
   'google/gemini-3-pro-image',
+  'black-forest-labs/flux.2-pro',
+  'black-forest-labs/flux.2-max',
+  'black-forest-labs/flux.2-flex',
+  'black-forest-labs/flux.2-klein-4b',
 ]);
 
 interface OpenRouterConfig {

--- a/services/control-api/src/services/ai-router/select.ts
+++ b/services/control-api/src/services/ai-router/select.ts
@@ -78,6 +78,10 @@ export const CANONICAL_IMAGE_MODEL_ROUTES: Readonly<Record<string, RouterName>> 
   'alibaba/wan-2.6-image':                 'provider-secondary',
   'prunaai/p-image':                       'provider-secondary',
   'prunaai/p-image-edit':                  'provider-secondary',
+  'black-forest-labs/flux.2-pro':          'openrouter',
+  'black-forest-labs/flux.2-max':          'openrouter',
+  'black-forest-labs/flux.2-flex':         'openrouter',
+  'black-forest-labs/flux.2-klein-4b':     'openrouter',
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `black-forest-labs/flux.2-{pro,max,flex,klein-4b}` to `OPENROUTER_IMAGE_MODELS`.
- Pins them in `CANONICAL_IMAGE_MODEL_ROUTES` to `openrouter`.

Without this the catalog advertised these models but `submitImage` returned unsupported → `MODEL_UNAVAILABLE 502` on every request.

Live-probed all four via `POST /api/v1/images/generations` with `{model, prompt, size: "1024x1024", n: 1}` — all 200s.

## Test plan
- [x] Unit tests pass (`npx vitest run services/control-api/src/services/ai-router`)
- [x] Live probe of all 4 FLUX variants via prod OpenRouter key
- [x] End-to-end: submitted flux.2-pro via `/v1/:appId/images/completions` on a local build with the parent overlay picking up this branch — HTTP 202, upstream_router=openrouter