### PR TITLE
feat(substrate): realtime stream primitive — ctx.substrate.wsTicket, bb.substrate.stream, docs

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -45,6 +45,14 @@ export { AdminPlatformBillingClient } from './admin/platform-billing-client.js';
 // Realtime client
 export { RealtimeClient } from './realtime/realtime-client.js';
 
+// Substrate stream client
+export type {
+  SubstrateChangeEvent,
+  SubstrateStreamOptions,
+  SubstrateStreamSubscription,
+} from './substrate/types.js';
+export { buildSubstrateStreamUrl } from './substrate/substrate-client.js';
+
 // Error types
 export {
   ButterbaseError,

--- a/packages/sdk/src/lib/butterbase-client.ts
+++ b/packages/sdk/src/lib/butterbase-client.ts
@@ -10,6 +10,7 @@ import { AiClient } from '../ai/ai-client.js';
 import { BillingClient } from '../billing/billing-client.js';
 import { AdminClient } from '../admin/admin-client.js';
 import { RealtimeClient } from '../realtime/realtime-client.js';
+import { SubstrateStreamClient } from '../substrate/substrate-client.js';
 import { RagClient } from '../rag/rag-client.js';
 import { IntegrationsClient } from '../integrations/integrations-client.js';
 import { PartnersClient } from '../partners/partners-client.js';
@@ -30,6 +31,7 @@ export class ButterbaseClient {
   public readonly billing: BillingClient;
   public readonly admin: AdminClient;
   public readonly realtime: RealtimeClient;
+  public readonly substrate: SubstrateStreamClient;
   public readonly rag: RagClient;
   public readonly integrations: IntegrationsClient;
   public readonly partners: PartnersClient;
@@ -55,6 +57,7 @@ export class ButterbaseClient {
     this.billing = new BillingClient(this);
     this.admin = new AdminClient(this);
     this.realtime = new RealtimeClient(this);
+    this.substrate = new SubstrateStreamClient(this);
     this.rag = new RagClient(this);
     this.integrations = new IntegrationsClient(this);
     this.partners = new PartnersClient(this);

--- a/packages/sdk/src/substrate/substrate-client.test.ts
+++ b/packages/sdk/src/substrate/substrate-client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildSubstrateStreamUrl } from './substrate-client.js';
+import type { SubstrateChangeEvent } from './types.js';
+
+describe('buildSubstrateStreamUrl', () => {
+  it('uses wss, the /v1/me/substrate/stream path, and passes the ticket', () => {
+    const url = buildSubstrateStreamUrl('https://api.butterbase.ai', { ticket: 'wst_abc' });
+    expect(url).toBe('wss://api.butterbase.ai/v1/me/substrate/stream?ticket=wst_abc');
+  });
+
+  it('passes token and org_id when provided', () => {
+    const url = buildSubstrateStreamUrl('https://api.butterbase.ai', { token: 'bb_sk_x', orgId: 'org1' });
+    expect(url).toBe('wss://api.butterbase.ai/v1/me/substrate/stream?token=bb_sk_x&org_id=org1');
+  });
+
+  it('downgrades http origins to ws (local dev)', () => {
+    const url = buildSubstrateStreamUrl('http://localhost:4000', { ticket: 'wst_1' });
+    expect(url).toBe('ws://localhost:4000/v1/me/substrate/stream?ticket=wst_1');
+  });
+});
+
+import { SubstrateStreamClient } from './substrate-client.js';
+
+class FakeWS {
+  static last: FakeWS;
+  onopen?: () => void; onmessage?: (e: any) => void; onclose?: () => void; onerror?: () => void;
+  closed = false;
+  constructor(public url: string) { FakeWS.last = this; }
+  close() { this.closed = true; this.onclose?.(); }
+}
+
+describe('SubstrateStreamClient.stream', () => {
+  it('parses frames, skips hello, and stops on unsubscribe', () => {
+    (globalThis as any).WebSocket = FakeWS as any;
+    const client = { apiUrl: 'https://api.butterbase.ai' } as any;
+    const got: SubstrateChangeEvent[] = [];
+    const sub = new SubstrateStreamClient(client).stream({
+      ticket: 'wst_1',
+      onChange: (evt) => got.push(evt),
+    });
+    FakeWS.last.onopen?.();
+    FakeWS.last.onmessage?.({ data: JSON.stringify({ type: 'hello', ts: 1 }) });
+    FakeWS.last.onmessage?.({ data: JSON.stringify({ org: 'o1', op: 'insert', tbl: 'entities', id: 'e1' }) });
+    expect(got).toEqual([{ org: 'o1', op: 'insert', tbl: 'entities', id: 'e1' }]);
+    sub.unsubscribe();
+    expect(FakeWS.last.closed).toBe(true);
+  });
+});

--- a/packages/sdk/src/substrate/substrate-client.test.ts
+++ b/packages/sdk/src/substrate/substrate-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSubstrateStreamUrl } from './substrate-client.js';
+import { buildSubstrateStreamUrl, SubstrateStreamClient } from './substrate-client.js';
 import type { SubstrateChangeEvent } from './types.js';
 
 describe('buildSubstrateStreamUrl', () => {
@@ -8,9 +8,9 @@ describe('buildSubstrateStreamUrl', () => {
     expect(url).toBe('wss://api.butterbase.ai/v1/me/substrate/stream?ticket=wst_abc');
   });
 
-  it('passes token and org_id when provided', () => {
-    const url = buildSubstrateStreamUrl('https://api.butterbase.ai', { token: 'bb_sk_x', orgId: 'org1' });
-    expect(url).toBe('wss://api.butterbase.ai/v1/me/substrate/stream?token=bb_sk_x&org_id=org1');
+  it('passes token when provided', () => {
+    const url = buildSubstrateStreamUrl('https://api.butterbase.ai', { token: 'bb_sk_x' });
+    expect(url).toBe('wss://api.butterbase.ai/v1/me/substrate/stream?token=bb_sk_x');
   });
 
   it('downgrades http origins to ws (local dev)', () => {
@@ -18,8 +18,6 @@ describe('buildSubstrateStreamUrl', () => {
     expect(url).toBe('ws://localhost:4000/v1/me/substrate/stream?ticket=wst_1');
   });
 });
-
-import { SubstrateStreamClient } from './substrate-client.js';
 
 class FakeWS {
   static last: FakeWS;

--- a/packages/sdk/src/substrate/substrate-client.ts
+++ b/packages/sdk/src/substrate/substrate-client.ts
@@ -1,0 +1,70 @@
+import type { ButterbaseClient } from '../lib/butterbase-client.js';
+import type {
+  SubstrateStreamOptions,
+  SubstrateStreamSubscription,
+  SubstrateChangeEvent,
+} from './types.js';
+
+/** Pure: build the substrate stream WS URL from an API origin + auth opts. */
+export function buildSubstrateStreamUrl(
+  apiUrl: string,
+  opts: { token?: string; ticket?: string; orgId?: string },
+): string {
+  const wsBase = apiUrl.replace(/^http/, 'ws');
+  const params = new URLSearchParams();
+  if (opts.ticket) params.set('ticket', opts.ticket);
+  else if (opts.token) params.set('token', opts.token);
+  if (opts.orgId) params.set('org_id', opts.orgId);
+  const qs = params.toString();
+  return `${wsBase}/v1/me/substrate/stream${qs ? `?${qs}` : ''}`;
+}
+
+const MAX_BACKOFF_MS = 30_000;
+
+export class SubstrateStreamClient {
+  private client: ButterbaseClient;
+  constructor(client: ButterbaseClient) {
+    this.client = client;
+  }
+
+  /**
+   * Open an org-scoped substrate change stream. Provide either `token`
+   * (bb_sub_ / bb_sk_ prefixed) or a pre-minted `ticket`. Reconnects with backoff.
+   */
+  stream(opts: SubstrateStreamOptions): SubstrateStreamSubscription {
+    const apiUrl = (this.client as any).apiUrl as string;
+    let ws: WebSocket | null = null;
+    let stopped = false;
+    let backoffMs = 1000;
+
+    const connect = () => {
+      if (stopped) return;
+      opts.onStatus?.('connecting');
+      const url = buildSubstrateStreamUrl(apiUrl, {
+        token: opts.token,
+        ticket: opts.ticket,
+        orgId: opts.orgId,
+      });
+      ws = new WebSocket(url);
+      ws.onopen = () => { backoffMs = 1000; opts.onStatus?.('open'); };
+      ws.onmessage = (e) => {
+        let frame: unknown;
+        try { frame = JSON.parse((e as MessageEvent).data as string); } catch { return; }
+        if ((frame as any)?.type === 'hello') return;
+        opts.onChange(frame as SubstrateChangeEvent);
+      };
+      ws.onclose = () => {
+        opts.onStatus?.('closed');
+        if (stopped) return;
+        setTimeout(connect, backoffMs);
+        backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      };
+      ws.onerror = () => { /* close handler runs next */ };
+    };
+
+    connect();
+    return {
+      unsubscribe: () => { stopped = true; ws?.close(); },
+    };
+  }
+}

--- a/packages/sdk/src/substrate/substrate-client.ts
+++ b/packages/sdk/src/substrate/substrate-client.ts
@@ -8,13 +8,12 @@ import type {
 /** Pure: build the substrate stream WS URL from an API origin + auth opts. */
 export function buildSubstrateStreamUrl(
   apiUrl: string,
-  opts: { token?: string; ticket?: string; orgId?: string },
+  opts: { token?: string; ticket?: string },
 ): string {
   const wsBase = apiUrl.replace(/^http/, 'ws');
   const params = new URLSearchParams();
   if (opts.ticket) params.set('ticket', opts.ticket);
   else if (opts.token) params.set('token', opts.token);
-  if (opts.orgId) params.set('org_id', opts.orgId);
   const qs = params.toString();
   return `${wsBase}/v1/me/substrate/stream${qs ? `?${qs}` : ''}`;
 }
@@ -43,7 +42,6 @@ export class SubstrateStreamClient {
       const url = buildSubstrateStreamUrl(apiUrl, {
         token: opts.token,
         ticket: opts.ticket,
-        orgId: opts.orgId,
       });
       ws = new WebSocket(url);
       ws.onopen = () => { backoffMs = 1000; opts.onStatus?.('open'); };

--- a/packages/sdk/src/substrate/types.ts
+++ b/packages/sdk/src/substrate/types.ts
@@ -10,8 +10,6 @@ export interface SubstrateStreamOptions {
   token?: string;
   /** Pre-minted single-use wst_ ticket (browser/app on-ramp). */
   ticket?: string;
-  /** Scope to a specific org (defaults server-side to the caller's org). */
-  orgId?: string;
   onChange: (evt: SubstrateChangeEvent) => void;
   onStatus?: (status: 'connecting' | 'open' | 'closed') => void;
 }

--- a/packages/sdk/src/substrate/types.ts
+++ b/packages/sdk/src/substrate/types.ts
@@ -1,0 +1,21 @@
+export interface SubstrateChangeEvent {
+  org: string;
+  op: 'insert' | 'update' | 'delete';
+  tbl: string;
+  id: string;
+}
+
+export interface SubstrateStreamOptions {
+  /** Substrate API key (bb_sub_* / bb_sk_*) for direct/server consumers. */
+  token?: string;
+  /** Pre-minted single-use wst_ ticket (browser/app on-ramp). */
+  ticket?: string;
+  /** Scope to a specific org (defaults server-side to the caller's org). */
+  orgId?: string;
+  onChange: (evt: SubstrateChangeEvent) => void;
+  onStatus?: (status: 'connecting' | 'open' | 'closed') => void;
+}
+
+export interface SubstrateStreamSubscription {
+  unsubscribe: () => void;
+}

--- a/services/deno-runtime/worker-executor.ts
+++ b/services/deno-runtime/worker-executor.ts
@@ -951,6 +951,14 @@ export function buildWorkerCode(
         if (!res.ok) throw new Error('substrate.getEntity failed: ' + res.status);
         return await res.json();
       },
+      async wsTicket() {
+        const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/ws-ticket', {
+          method: 'POST',
+          headers: { 'x-butterbase-internal-secret': ${JSON.stringify(Deno.env.get("BUTTERBASE_INTERNAL_SECRET") || '')} },
+        });
+        if (!res.ok) throw new Error('substrate.wsTicket failed: ' + res.status + ' ' + await res.text());
+        return await res.json();
+      },
       async findEntities(filter) {
         const res = await fetch(${JSON.stringify(Deno.env.get("CONTROL_API_URL") || Deno.env.get("API_BASE_URL") || "http://control-api:4000")} + '/internal/substrate/apps/' + ${JSON.stringify(metadata.app_id)} + '/entities:find', {
           method: 'POST',

--- a/services/docs/src/content/docs/api-reference/substrate-api.md
+++ b/services/docs/src/content/docs/api-reference/substrate-api.md
@@ -616,18 +616,40 @@ Or as a fallback query string:
 wss://api.butterbase.ai/v1/me/substrate/stream?token=bb_sub_…
 ```
 
+### App-function flow
+
+An app linked to an org can mint a ticket for its own users **without** ever putting a substrate key in the browser. Inside a deployed function, call:
+
+```ts
+const { ticket, expires_in } = await ctx.substrate.wsTicket();
+```
+
+It returns a 60s single-use ticket scoped to the app's linked org (server-to-server, over the internal bridge). Return it to the browser, which opens the stream with `?ticket=`. This is the recommended pattern for end-user-facing apps — see the [browser example](/core-concepts/substrate/#8-stream-live-updates-to-a-ui).
+
 ### Frames
 
 ```json
 // First frame on open:
 { "type": "hello", "ts": 1780198304 }
 
-// Subsequent frames, one per change:
-{ "tbl": "action_ledger",          "op": "insert", "id": "act_…", "user": "…" }
-{ "tbl": "entities",               "op": "update", "id": "ent_…", "user": "…" }
-{ "tbl": "attention_rules",        "op": "update", "id": "rule_…", "user": "…" }
-{ "tbl": "attention_rule_firings", "op": "insert", "id": "fire_…", "user": "…" }
+// Subsequent frames, one per change — envelope only, no row payload:
+{ "tbl": "entities",               "op": "insert", "id": "ent_…",  "org": "…" }
+{ "tbl": "action_ledger",          "op": "insert", "id": "act_…",  "org": "…" }
+{ "tbl": "decisions",              "op": "insert", "id": "dec_…",  "org": "…" }
+{ "tbl": "commitments",            "op": "update", "id": "com_…",  "org": "…" }
+{ "tbl": "learnings",              "op": "insert", "id": "lrn_…",  "org": "…" }
+{ "tbl": "attention_rules",        "op": "update", "id": "rule_…", "org": "…" }
+{ "tbl": "attention_rule_firings", "op": "insert", "id": "fire_…", "org": "…" }
 ```
+
+Each change frame is `{ org, op, tbl, id }`:
+
+| Field | Meaning |
+|---|---|
+| `org` | The substrate organization the change belongs to. The stream is **org-scoped** — a connection only ever receives changes for the org bound to its ticket or key. |
+| `op` | `insert`, `update`, or `delete`. |
+| `tbl` | The physical table that changed (e.g. `entities`, `action_ledger`, `decisions`). |
+| `id` | The changed row's id. |
 
 The stream does not include payloads — clients are expected to re-fetch the affected row by id.
 

--- a/services/docs/src/content/docs/core-concepts/realtime.md
+++ b/services/docs/src/content/docs/core-concepts/realtime.md
@@ -141,3 +141,7 @@ The function response is returned:
 - Tables must exist before enabling realtime
 - The full row is sent on each change (no column filtering yet)
 - Events during LISTEN reconnection may be lost — clients should re-fetch state on reconnect
+
+## Substrate changes
+
+This page covers realtime for your app's **database tables**. If your data lives in the [Substrate](/core-concepts/substrate/) (entities, the action ledger, decisions/commitments/learnings), it has a sibling stream — org-scoped, envelope-only frames — documented under [Substrate → Stream live updates to a UI](/core-concepts/substrate/#8-stream-live-updates-to-a-ui) and the SDK's `bb.substrate.stream`.

--- a/services/docs/src/content/docs/core-concepts/substrate.md
+++ b/services/docs/src/content/docs/core-concepts/substrate.md
@@ -18,7 +18,7 @@ It plugs into Butterbase the same way [Functions](/core-concepts/functions/) and
 | **Attention rules** | Scheduled rules that run on a snapshot of your substrate and propose actions when their conditions match. |
 | **Outbox targets** | HMAC-signed webhooks that fire when actions execute (e.g. send the email draft to an external system). |
 | **Settings** | Per-user toggles — `yolo_mode` for auto-approval, etc. |
-| **WebSocket stream** | Live push of every ledger / entity / rule / firing change. |
+| **WebSocket stream** | Live push of every entity, ledger, memory (decision / commitment / learning), rule, and firing change — so UIs update without polling. |
 
 ## How agents use it
 
@@ -298,25 +298,70 @@ Every webhook delivery is signed with `X-Butterbase-Signature: sha256=…` using
 
 ### 8. Stream live updates to a UI
 
-Browsers can't put a Bearer token in a WebSocket handshake, so the substrate uses a single-use ticket exchange. Your dashboard (or any browser client) does:
+Every substrate write emits a change over a WebSocket, so your UI updates the instant an agent or another user changes something — no polling, no refresh. The stream carries **envelope-only** frames — `{ org, op, tbl, id }`, no row payload — and you re-fetch the affected row by `id` (the same model as [Realtime](/core-concepts/realtime/)).
+
+What streams today: `entities`, `action_ledger`, `decisions`, `commitments`, `learnings`, `attention_rules`, and `attention_rule_firings`. The stream is **org-scoped** — a connection only receives changes for the org bound to its credential.
+
+There are three ways to connect, depending on what credential the client holds.
+
+**a) Server / script (has a substrate key).** Use the SDK's `bb.substrate.stream` — it handles the WebSocket, reconnects with backoff, and skips the `hello` frame for you:
 
 ```typescript
-// 1. Get a one-shot ticket (60s, single-use). Cookies/Cognito auth here.
+import { createClient } from '@butterbase/sdk';
+const bb = createClient({ apiUrl: 'https://api.butterbase.ai', /* … */ });
+
+const sub = bb.substrate.stream({
+  token: process.env.BUTTERBASE_SUBSTRATE_KEY, // bb_sub_… or bb_sk_…
+  onChange: (evt) => {
+    // evt = { org, op: 'insert' | 'update' | 'delete', tbl, id }
+    if (evt.tbl === 'entities') refetchEntity(evt.id);
+  },
+  onStatus: (s) => console.log('substrate stream', s), // 'connecting' | 'open' | 'closed'
+});
+
+// later
+sub.unsubscribe();
+```
+
+**b) End-user app in the browser (no substrate key).** A browser must never hold a substrate key, so mint a **single-use ticket** through one of your app's functions, then open the stream with it. In the function:
+
+```typescript
+// app function: substrate-proxy
+export async function handler(req, ctx) {
+  const { op } = await req.json();
+  if (op === 'ws_ticket') {
+    return Response.json(await ctx.substrate.wsTicket()); // { ticket, expires_in }
+  }
+  // … other ops
+}
+```
+
+In the browser:
+
+```typescript
+// 1. Ask your function for a 60s single-use ticket.
+const { ticket } = await bb.functions.invoke('substrate-proxy', { op: 'ws_ticket' });
+
+// 2. Open the stream, then re-fetch on each change.
+const ws = new WebSocket(`wss://api.butterbase.ai/v1/me/substrate/stream?ticket=${ticket}`);
+ws.onmessage = (evt) => {
+  const change = JSON.parse(evt.data);
+  if (change.type === 'hello') return;
+  // change = { org, op, tbl, id } — e.g. invalidate your query cache by id
+};
+```
+
+**c) Dashboard / cookie-authenticated browser.** If the browser already has a Cognito session, mint the ticket directly (no proxy function needed):
+
+```typescript
 const { ticket } = await fetch('/v1/me/substrate/ws-ticket', {
   method: 'POST',
   credentials: 'include',
 }).then(r => r.json());
-
-// 2. Open the WS with the ticket in the URL.
 const ws = new WebSocket(`wss://api.butterbase.ai/v1/me/substrate/stream?ticket=${ticket}`);
-
-ws.onmessage = (evt) => {
-  const change = JSON.parse(evt.data);
-  // { tbl: 'action_ledger', op: 'insert', id: 'act_…', user: '…' }
-};
 ```
 
-The server pushes a `{type: 'hello'}` frame on connect, then one message per change. Reconnect with backoff and fetch a fresh ticket on each reconnect — tickets are single-use.
+In every case the server pushes a `{ type: 'hello' }` frame on connect, then one frame per change. **Tickets are single-use and expire after 60s** — mint a fresh one on each (re)connect, and reconnect with backoff (the SDK's `bb.substrate.stream` already does this).
 
 ## See also
 

--- a/services/docs/src/content/docs/sdks-and-tools/typescript-sdk.md
+++ b/services/docs/src/content/docs/sdks-and-tools/typescript-sdk.md
@@ -182,6 +182,26 @@ const { data, error } = await butterbase.functions.invoke('my-function', {
 });
 ```
 
+## Substrate stream
+
+Subscribe to live [substrate](/core-concepts/substrate/) changes over a WebSocket. `bb.substrate.stream` opens the connection, reconnects with backoff, and delivers one callback per change. Frames are envelope-only (`{ org, op, tbl, id }`) — re-fetch the affected row by `id`.
+
+```typescript
+const sub = butterbase.substrate.stream({
+  token: process.env.BUTTERBASE_SUBSTRATE_KEY, // bb_sub_… or bb_sk_…
+  onChange: (evt) => {
+    // evt: { org, op: 'insert' | 'update' | 'delete', tbl, id }
+    if (evt.tbl === 'entities') refetchEntity(evt.id);
+  },
+  onStatus: (s) => console.log(s), // 'connecting' | 'open' | 'closed'
+});
+
+// stop listening
+sub.unsubscribe();
+```
+
+Provide **either** `token` (a substrate-scoped key, for server/script clients) **or** `ticket` (a one-shot `wst_…` minted for a browser — see [Stream live updates to a UI](/core-concepts/substrate/#8-stream-live-updates-to-a-ui)). The stream is org-scoped to the credential.
+
 ## Integrations
 
 Connect end-user accounts (Gmail, Slack, GitHub, etc.) and execute tools on their behalf. See the [integrations concept page](/core-concepts/integrations) for the platform model.


### PR DESCRIPTION
Productizes the substrate WebSocket streaming primitive so apps/clients can receive live substrate changes.

## What's here (paired with butterbase-internal changes: listener `evt.org` fix, `037` NOTIFY triggers, internal-bridge `ws-ticket` op)

- **`ctx.substrate.wsTicket()`** (`services/deno-runtime/worker-executor.ts`) — app functions mint a 60s single-use stream ticket for their linked org via the internal bridge. This is the browser on-ramp (browsers never hold a substrate key).
- **`bb.substrate.stream(...)`** (`packages/sdk/src/substrate/*`) — new SDK client mirroring `bb.realtime`: opens the WS, reconnects with backoff, skips the `hello` frame, delivers `{ org, op, tbl, id }` envelopes. Accepts a `token` (bb_sub_/bb_sk_) or a pre-minted `ticket`. Wired as `bb.substrate`, exported from `index.ts`.
- **Docs** (`services/docs/*`) — corrected the stale substrate-stream docs (frame was `user`, now `org`), documented all three consumer patterns (SDK/server, app-via-proxy, dashboard/cookie) with examples, added the newly-streaming tables, and a Realtime↔Substrate cross-link.

## Context / why
The substrate stream existed ("Phase 6b") but was dead in prod: the DB NOTIFY trigger emits `{org,…}` while the listener read `evt.user`, dropping every event. The internal repo fixes the listener + extends trigger coverage; this PR adds the client-side surface and the app on-ramp.

## Testing
- SDK: unit tests (URL builder + fake-WebSocket frame dispatch), `tsc -b` clean.
- End-to-end against a full local stack: real HTTP `ws-ticket` + real WebSocket to control-api + real `propose upsert_entity` → change frame delivered over the wire; also verified live via the real MCP (`manage_substrate propose` → WS frame).
- Docs: `astro build` passes (58 pages).

## Deploy note
Ships with the internal control-api + substrate-plane `037` migration. Order: apply `037` → deploy control-api (listener fix) + deno-runtime (`wsTicket`) → this SDK/docs.