### PR TITLE
chore(release): @butterbase/sdk 2.9.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butterbase/sdk",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Universal TypeScript SDK for Butterbase",
   "license": "Apache-2.0",
   "homepage": "https://butterbase.ai",


### PR DESCRIPTION
Version bump to match the published npm release `@butterbase/sdk@2.9.0` (adds `bb.substrate.stream`, from #105). Repo `main` was at 2.8.1 while npm had 2.8.2 published without a matching commit; this lands 2.9.0 so repo and npm agree.