### PR TITLE
fix(auth): route auth hook to app home-region runtime

### DIFF
--- a/services/control-api/src/services/auth/__tests__/auth-hook-region.test.ts
+++ b/services/control-api/src/services/auth/__tests__/auth-hook-region.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { authHookRegionHeaders } from '../auth-hook-service.js';
+
+const ORIGINAL = process.env.BUTTERBASE_FLY_REGION_MAP;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.BUTTERBASE_FLY_REGION_MAP;
+  else process.env.BUTTERBASE_FLY_REGION_MAP = ORIGINAL;
+});
+
+describe('authHookRegionHeaders', () => {
+  it('maps the app home region to its Fly region as Fly-Prefer-Region', () => {
+    process.env.BUTTERBASE_FLY_REGION_MAP = 'iad:us-east-1,sjc:us-west-2';
+    expect(authHookRegionHeaders('us-west-2')).toEqual({ 'Fly-Prefer-Region': 'sjc' });
+    expect(authHookRegionHeaders('us-east-1')).toEqual({ 'Fly-Prefer-Region': 'iad' });
+  });
+
+  it('returns no header when the region map is unset (local dev / tests)', () => {
+    delete process.env.BUTTERBASE_FLY_REGION_MAP;
+    expect(authHookRegionHeaders('us-west-2')).toEqual({});
+  });
+
+  it('returns no header when no fly region maps to the home region', () => {
+    process.env.BUTTERBASE_FLY_REGION_MAP = 'iad:us-east-1';
+    expect(authHookRegionHeaders('eu-west-1')).toEqual({});
+  });
+
+  it('returns no header (never throws) when the region map is malformed', () => {
+    process.env.BUTTERBASE_FLY_REGION_MAP = 'this-is-not-valid';
+    expect(authHookRegionHeaders('us-west-2')).toEqual({});
+  });
+});

--- a/services/control-api/src/services/auth/auth-hook-service.ts
+++ b/services/control-api/src/services/auth/auth-hook-service.ts
@@ -1,6 +1,8 @@
 import type { Pool } from 'pg';
+import { butterbaseRegionToFlyRegion, parseFlyRegionMap } from '@butterbase/shared';
 import { config } from '../../config.js';
-import { getRuntimeDbForApp } from '../region-resolver.js';
+import { resolveAppHomeRegion } from '../region-resolver.js';
+import { getRuntimeDbPool } from '../runtime-db.js';
 import { notifyAuthHookFailed } from '../failure-notifications.service.js';
 
 interface AuthHookPayload {
@@ -17,6 +19,34 @@ interface AuthHookPayload {
 }
 
 /**
+ * Build the region-affinity header for the hook fetch.
+ *
+ * `config.runtimeUrl` is a Fly Anycast hostname (butterbase-runtime.fly.dev)
+ * that routes to the runtime instance nearest the *calling* control-api — not
+ * the app's home region. The deno-runtime's function-loader only queries its
+ * own instance-region runtime DB, so a hook for an app homed elsewhere resolves
+ * to zero rows and the runtime returns 404 "Function not found". Unlike the
+ * per-app data/function routes, the auth routes are not gated by
+ * `requiresAppRegion`, so the fly-replay plugin never bounces them to the home
+ * region. We compensate here by asking Fly to prefer the home region's runtime,
+ * mirroring the mapping the fly-replay plugin uses.
+ *
+ * Returns `{}` when the region map is unset (local dev / tests) or no fly region
+ * maps to the home region — in which case the fetch falls back to Anycast's
+ * nearest-instance behaviour, i.e. today's behaviour, so there is no regression.
+ */
+export function authHookRegionHeaders(homeRegion: string): Record<string, string> {
+  const mapRaw = process.env.BUTTERBASE_FLY_REGION_MAP;
+  if (!mapRaw) return {};
+  try {
+    const flyRegion = butterbaseRegionToFlyRegion(homeRegion, parseFlyRegionMap(mapRaw));
+    return flyRegion ? { 'Fly-Prefer-Region': flyRegion } : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Fire the post_auth hook for an app, if configured.
  * This is fire-and-forget: errors are logged but never propagated.
  */
@@ -28,7 +58,8 @@ export function fireAuthHook(
 ): void {
   void (async () => {
     try {
-      const runtimePool = await getRuntimeDbForApp(controlDb, appId);
+      const homeRegion = await resolveAppHomeRegion(controlDb, appId);
+      const runtimePool = getRuntimeDbPool(config.runtimeDb, homeRegion);
       const result = await runtimePool.query(
         'SELECT auth_hook_function FROM apps WHERE id = $1',
         [appId],
@@ -42,6 +73,8 @@ export function fireAuthHook(
           headers: {
             'Content-Type': 'application/json',
             'x-app-id': appId,
+            // Route to the app's home-region runtime — see authHookRegionHeaders.
+            ...authHookRegionHeaders(homeRegion),
           },
           body: JSON.stringify(payload),
         });


### PR DESCRIPTION
## Problem

Post-auth hooks (`auth-bootstrap-hook` etc.) intermittently 404 with `HTTP 404: {"error":"Function not found"}`, even though the hook function is deployed and active. Observed on `wsgr-support` (homed in us-west-2) — the app owner has been manually creating membership/allowlist rows to compensate (allowlist notes literally say *"platform auth-hook returns 404 for this app"*).

## Root cause

`fireAuthHook` invokes the hook via `config.runtimeUrl` = `https://butterbase-runtime.fly.dev`, a Fly **Anycast** host that routes to the runtime instance nearest the *calling* control-api. The deno-runtime's `function-loader` only queries **its own instance-region** runtime DB (`resolveInstanceRegion()` → `NEON_RUNTIME_PROJECT_ID_<region>`). So when an auth request lands on a control-api outside the app's home region, the co-located runtime queries the wrong region's DB, finds zero rows, and returns 404.

It's intermittent by design: login routed to the home region → hook 200; routed elsewhere → hook 404. Login itself always succeeds (the auth routes do explicit cross-region DB lookups), but the hook's side effect (e.g. membership bootstrap) silently gets skipped. Unlike the per-app data/function routes, auth routes are not gated by `requiresAppRegion`, so the `fly-replay` plugin never bounces them to the home region.

## Fix

Resolve the app's home region and set `Fly-Prefer-Region` on the hook fetch, so Fly's proxy routes it to the home-region runtime. Reuses the same `butterbaseRegionToFlyRegion` mapping the `fly-replay` plugin already uses. Falls back to today's nearest-instance behaviour when `BUTTERBASE_FLY_REGION_MAP` is unset (local/tests) or unmapped — no regression.

## Tests

- New unit test `auth-hook-region.test.ts` covers mapping, unset map, unmapped region, and malformed map (never throws).
- `tsc -b --force` clean; existing auth/region suites green.

## Deploy notes

- control-api only. No DB migration, no new env var (reads existing `BUTTERBASE_FLY_REGION_MAP`, already set in prod for fly-replay).
- Backward compatible during rolling deploy.