### PR TITLE
Add MiniMax router adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,11 @@ DASHBOARD_URL=http://localhost:3000
 
 # OpenRouter (AI Features)
 OPENROUTER_API_KEY=sk-or-v1-your_openrouter_key_here
+
+# MiniMax text models (global_en or cn_zh)
+MINIMAX_API_KEY=your_minimax_api_key_here
+MINIMAX_REGION=global_en
+
 # NEON_DATA_DATABASE_OWNER=  # Optional; default butterbase (role is auto-created on the branch if missing). Use neondb_owner to use Neon’s default role instead.
 
 # Deno Runtime URL (defaults to http://deno-runtime:7133 in local Docker)

--- a/.env.production.example
+++ b/.env.production.example
@@ -71,6 +71,8 @@ STRIPE_CONNECT_WEBHOOK_SECRET=<from-stripe-connect-webhook-endpoint>
 REDIS_URL=<upstash-redis-url-or-fly-redis>
 DASHBOARD_URL=https://dashboard.butterbase.ai
 OPENROUTER_API_KEY=<from-openrouter-dashboard>
+MINIMAX_API_KEY=<from-minimax-dashboard>
+MINIMAX_REGION=global_en
 
 # ---------------------------------------------------------------------------
 # Platform App -- Dashboard API (same Fly.io machine)

--- a/SETUP.md
+++ b/SETUP.md
@@ -327,6 +327,7 @@ CONTROL_DB_URL=postgresql://... npx tsx scripts/backfill-migrations.ts app_abc12
 | Feature | Env vars (see `.env.example`) |
 |---------|-------------------------------|
 | AI via OpenRouter | `OPENROUTER_API_KEY`, `AI_MARKUP_PERCENT` |
+| AI via MiniMax | `MINIMAX_API_KEY`, `MINIMAX_REGION`, `AI_MARKUP_PERCENT` |
 | Real AWS / R2 storage | `AWS_*`, `S3_*`, drop LocalStack endpoints |
 | Email (SES) | `SES_*`, `SES_FROM_EMAIL` |
 | Stripe billing | `STRIPE_*` (noop billing locally in OSS mode) |

--- a/services/control-api/src/__tests__/config.test.ts
+++ b/services/control-api/src/__tests__/config.test.ts
@@ -7,6 +7,7 @@ describe('config.aiRouter', () => {
     vi.resetModules();
     delete process.env.AI_ROUTER_PRESENCE_MODE;
     delete process.env.AI_ROUTER_DEFAULT_REGION;
+    delete process.env.MINIMAX_REGION;
   });
 
   afterEach(() => {
@@ -37,5 +38,17 @@ describe('config.aiRouter', () => {
     vi.resetModules();
     const mod = await import('../config.js');
     expect(mod.config.aiRouter.defaultRegion).toBe('eu-west-1');
+  });
+
+  it('minimaxRegion defaults to global_en', async () => {
+    const mod = await import('../config.js');
+    expect(mod.config.aiRouter.minimaxRegion).toBe('global_en');
+  });
+
+  it('minimaxRegion accepts cn_zh', async () => {
+    process.env.MINIMAX_REGION = 'cn_zh';
+    vi.resetModules();
+    const mod = await import('../config.js');
+    expect(mod.config.aiRouter.minimaxRegion).toBe('cn_zh');
   });
 });

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -77,6 +77,8 @@ export const config = {
       markupPct,
       platformDefaultModel: process.env.PLATFORM_DEFAULT_MODEL ?? 'anthropic/claude-sonnet-4.6',
       openrouterApiKey: process.env.OPENROUTER_API_KEY ?? '',
+      minimaxApiKey: process.env.MINIMAX_API_KEY ?? '',
+      minimaxRegion: (process.env.MINIMAX_REGION === 'cn_zh' ? 'cn_zh' : 'global_en') as 'global_en' | 'cn_zh',
       providerPrimaryApiKey: process.env.AI_PROVIDER_PRIMARY_API_KEY ?? '',
       providerPrimaryBaseUrl: process.env.AI_PROVIDER_PRIMARY_BASE_URL || undefined,
       providerSecondaryApiKey: process.env.AI_PROVIDER_SECONDARY_API_KEY ?? '',

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -2143,6 +2143,7 @@ export async function adminRoutes(app: FastifyInstance) {
       const { getRedisClient } = await import('../services/redis.js');
       const { config } = await import('../config.js');
       const { openrouterAdapter } = await import('../services/ai-router/adapters/openrouter.js');
+      const { minimaxAdapter } = await import('../services/ai-router/adapters/minimax.js');
       // Provider-primary / provider-secondary adapters live in the cloud overlay;
       // OSS builds boot without them.
       let providerPrimaryAdapter: any = null;
@@ -2159,6 +2160,12 @@ export async function adminRoutes(app: FastifyInstance) {
       const adapters = [];
       if (config.aiRouter.openrouterApiKey) {
         adapters.push(openrouterAdapter({ apiKey: config.aiRouter.openrouterApiKey }));
+      }
+      if (config.aiRouter.minimaxApiKey) {
+        adapters.push(minimaxAdapter({
+          apiKey: config.aiRouter.minimaxApiKey,
+          region: config.aiRouter.minimaxRegion,
+        }));
       }
       if (providerPrimaryAdapter && config.aiRouter.providerPrimaryApiKey) {
         adapters.push(providerPrimaryAdapter({
@@ -2208,6 +2215,7 @@ export async function adminRoutes(app: FastifyInstance) {
     const { config } = await import('../config.js');
     const adapters = [
       { name: 'openrouter', configured: !!config.aiRouter.openrouterApiKey },
+      { name: 'minimax', configured: !!config.aiRouter.minimaxApiKey },
       { name: 'provider-primary', configured: !!config.aiRouter.providerPrimaryApiKey },
       { name: 'provider-secondary', configured: !!config.aiRouter.providerSecondaryApiKey },
       { name: 'provider-tertiary', configured: !!config.aiRouter.providerTertiaryApiKey },

--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -23,6 +23,7 @@ import { AppResolver, AppNotFoundError } from '../services/app-resolver.js';
 import { getRedisClient } from '../services/redis.js';
 import { routeChatCompletion, routeEmbedding, RouterError, InsufficientCreditsError } from '../services/ai-router/router.js';
 import { openrouterAdapter } from '../services/ai-router/adapters/openrouter.js';
+import { minimaxAdapter } from '../services/ai-router/adapters/minimax.js';
 import { listCatalogModels, readCatalogEntry } from '../services/ai-router/catalog.js';
 import type { RouterAdapter } from '../services/ai-router/adapters/types.js';
 import type { RouterName } from '../services/ai-router/normalize.js';
@@ -70,6 +71,10 @@ async function getAppDefaultModel(runtimePool: pg.Pool, appId: string): Promise<
 async function buildAdapters(): Promise<Map<RouterName, RouterAdapter>> {
   const m = new Map<RouterName, RouterAdapter>();
   if (config.aiRouter.openrouterApiKey) m.set('openrouter', openrouterAdapter({ apiKey: config.aiRouter.openrouterApiKey }));
+  if (config.aiRouter.minimaxApiKey) m.set('minimax', minimaxAdapter({
+    apiKey: config.aiRouter.minimaxApiKey,
+    region: config.aiRouter.minimaxRegion,
+  }));
   try {
     // @ts-expect-error — overlay path resolved at runtime
     const overlay = await import('../../../../cloud-overlays/dist/cloud-overlays/bootstrap.js');
@@ -86,7 +91,7 @@ async function buildAdapters(): Promise<Map<RouterName, RouterAdapter>> {
       apiKey: config.aiRouter.providerTertiaryApiKey,
       baseUrl: config.aiRouter.providerTertiaryBaseUrl,
     }));
-  } catch { /* OSS mode: only openrouter is available */ }
+  } catch { /* OSS mode: direct adapters remain available */ }
   return m;
 }
 
@@ -482,6 +487,10 @@ export async function aiConfigRoutes(app: FastifyInstance) {
             modality,
             prompt_price_per_mtok: isTokenPriced && firstRouter ? firstRouter.promptPricePerMtok : null,
             completion_price_per_mtok: isTokenPriced && firstRouter ? firstRouter.completionPricePerMtok : null,
+            cache_read_price_per_mtok: isTokenPriced && firstRouter ? firstRouter.cacheReadPricePerMtok ?? null : null,
+            cache_write_price_per_mtok: isTokenPriced && firstRouter ? firstRouter.cacheWritePricePerMtok ?? null : null,
+            input_modalities: firstRouter?.inputModalities ?? null,
+            thinking: firstRouter?.thinking ?? null,
             raw_pricing: !isTokenPriced && firstRouter ? firstRouter.rawPricing ?? null : null,
           };
         });

--- a/services/control-api/src/routes/gateway.test.ts
+++ b/services/control-api/src/routes/gateway.test.ts
@@ -625,6 +625,8 @@ vi.mock('../config.js', async (orig) => {
       ...actual.config,
       aiRouter: {
         ...actual.config.aiRouter,
+        minimaxApiKey: 'key-minimax',
+        minimaxRegion: 'cn_zh',
         providerPrimaryApiKey: 'key-primary',
         providerPrimaryBaseUrl: 'https://primary.example.com',
         providerSecondaryApiKey: 'key-secondary',
@@ -638,6 +640,11 @@ vi.mock('../config.js', async (orig) => {
 });
 
 describe('Fix 6 — buildAdapters passes baseUrl and catalogUrl to adapter constructors', () => {
+  it('registers the MiniMax adapter in the OSS gateway', async () => {
+    const adapters = await buildAdapters();
+    expect(adapters.get('minimax')?.name).toBe('minimax');
+  });
+
   it('13. provider-primary adapter receives baseUrl', async () => {
     primaryAdapterArgs.length = 0;
     await buildAdapters();

--- a/services/control-api/src/routes/gateway.ts
+++ b/services/control-api/src/routes/gateway.ts
@@ -12,6 +12,7 @@ import { listCatalogModels, readCatalogEntry, readEnabledRouters } from '../serv
 import { rankRoutersForModel } from '../services/ai-router/select.js';
 import { applyMarkup } from '../services/ai-router/markup.js';
 import { openrouterAdapter } from '../services/ai-router/adapters/openrouter.js';
+import { minimaxAdapter } from '../services/ai-router/adapters/minimax.js';
 import type { RouterAdapter } from '../services/ai-router/adapters/types.js';
 import { AdapterError } from '../services/ai-router/adapters/types.js';
 import type { RouterName } from '../services/ai-router/normalize.js';
@@ -40,13 +41,17 @@ async function resolveGatewayOrg(controlDb: pg.Pool, userId: string): Promise<st
 export async function buildAdapters(): Promise<Map<RouterName, RouterAdapter>> {
   const m = new Map<RouterName, RouterAdapter>();
   if (config.aiRouter.openrouterApiKey) m.set('openrouter', openrouterAdapter({ apiKey: config.aiRouter.openrouterApiKey }));
+  if (config.aiRouter.minimaxApiKey) m.set('minimax', minimaxAdapter({
+    apiKey: config.aiRouter.minimaxApiKey,
+    region: config.aiRouter.minimaxRegion,
+  }));
   try {
     // @ts-expect-error — overlay path resolved at runtime
     const overlay = await import('../../../../cloud-overlays/dist/cloud-overlays/bootstrap.js');
     if (config.aiRouter.providerPrimaryApiKey) m.set('provider-primary', overlay.providerPrimaryAdapter({ apiKey: config.aiRouter.providerPrimaryApiKey, baseUrl: config.aiRouter.providerPrimaryBaseUrl }));
     if (config.aiRouter.providerSecondaryApiKey) m.set('provider-secondary', overlay.providerSecondaryAdapter({ apiKey: config.aiRouter.providerSecondaryApiKey, baseUrl: config.aiRouter.providerSecondaryBaseUrl, catalogUrl: config.aiRouter.providerSecondaryCatalogUrl }));
     if (config.aiRouter.providerTertiaryApiKey) m.set('provider-tertiary', overlay.providerTertiaryAdapter({ apiKey: config.aiRouter.providerTertiaryApiKey, baseUrl: config.aiRouter.providerTertiaryBaseUrl }));
-  } catch { /* OSS mode: only openrouter is available */ }
+  } catch { /* OSS mode: direct adapters remain available */ }
   return m;
 }
 

--- a/services/control-api/src/services/ai-router/adapters/minimax.test.ts
+++ b/services/control-api/src/services/ai-router/adapters/minimax.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import { minimaxAdapter } from './minimax.js';
+
+describe('minimax adapter', () => {
+  it('lists the configured models with exact capabilities and pricing', async () => {
+    const adapter = minimaxAdapter({ apiKey: 'test-key' });
+    await expect(adapter.listModels()).resolves.toEqual([
+      {
+        upstreamId: 'MiniMax-M3',
+        displayName: 'MiniMax-M3',
+        promptPricePerMtok: 0.6,
+        completionPricePerMtok: 2.4,
+        cacheReadPricePerMtok: 0.12,
+        cacheWritePricePerMtok: null,
+        contextLength: 1_000_000,
+        inputModalities: ['text', 'image', 'video'],
+        thinking: ['adaptive', 'disabled'],
+        modality: 'chat',
+      },
+      {
+        upstreamId: 'MiniMax-M2.7',
+        displayName: 'MiniMax-M2.7',
+        promptPricePerMtok: 0.3,
+        completionPricePerMtok: 1.2,
+        cacheReadPricePerMtok: 0.06,
+        cacheWritePricePerMtok: 0.375,
+        contextLength: 204_800,
+        inputModalities: ['text'],
+        thinking: ['always_on'],
+        modality: 'chat',
+      },
+    ]);
+  });
+
+  it('routes chat completions to the global OpenAI-compatible endpoint', async () => {
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe('https://api.minimax.io/v1/chat/completions');
+      expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer test-key');
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('MiniMax-M3');
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+      expect(body.reasoning_effort).toBeUndefined();
+      expect(body.session_id).toBeUndefined();
+      return new Response(JSON.stringify({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 10,
+          prompt_tokens_details: { cached_tokens: 8 },
+        },
+        base_resp: { status_code: 0, status_msg: '' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const adapter = minimaxAdapter({ apiKey: 'test-key', fetch: fetcher });
+    const result = await adapter.chatCompletion({
+      model: 'minimax/MiniMax-M3',
+      messages: [{ role: 'user', content: 'hello' }],
+      reasoning_effort: 'high',
+      session_id: 'session-1',
+    }, 'MiniMax-M3');
+
+    expect(result.status).toBe(200);
+    expect(result.usage).toMatchObject({
+      promptTokens: 20,
+      completionTokens: 10,
+      cache_read_input_tokens: 8,
+    });
+  });
+
+  it('routes chat completions to the China OpenAI-compatible endpoint', async () => {
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toBe('https://api.minimaxi.com/v1/chat/completions');
+      return new Response(JSON.stringify({
+        choices: [],
+        usage: { prompt_tokens: 0, completion_tokens: 0 },
+        base_resp: { status_code: 0, status_msg: '' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const adapter = minimaxAdapter({ apiKey: 'test-key', region: 'cn_zh', fetch: fetcher });
+    await adapter.chatCompletion({
+      model: 'minimax/MiniMax-M2.7',
+      messages: [{ role: 'user', content: 'hello' }],
+    }, 'MiniMax-M2.7');
+  });
+
+  it('forces streaming usage on the OpenAI-compatible path', async () => {
+    const fetcher = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.stream_options).toEqual({ include_usage: true });
+      return new Response('data: [DONE]\n\n', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = minimaxAdapter({ apiKey: 'test-key', fetch: fetcher });
+    const result = await adapter.chatCompletion({
+      model: 'minimax/MiniMax-M3',
+      messages: [{ role: 'user', content: 'hello' }],
+      stream: true,
+    }, 'MiniMax-M3');
+    expect(result.stream).toBeDefined();
+  });
+
+  it('routes native messages to the selected Anthropic-compatible endpoint', async () => {
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe('https://api.minimaxi.com/anthropic/v1/messages');
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer test-key');
+      expect(headers['anthropic-version']).toBe('2023-06-01');
+      expect(headers['anthropic-beta']).toBe('prompt-caching-2024-07-31');
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('MiniMax-M3');
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+      return new Response(JSON.stringify({
+        id: 'message-1',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        usage: {
+          input_tokens: 12,
+          output_tokens: 4,
+          cache_read_input_tokens: 6,
+          cache_creation_input_tokens: 2,
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const adapter = minimaxAdapter({ apiKey: 'test-key', region: 'cn_zh', fetch: fetcher });
+    const result = await adapter.nativeMessages!({
+      model: 'minimax/MiniMax-M3',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'enabled', budget_tokens: 1000 },
+    }, 'MiniMax-M3', {
+      anthropicVersion: '2023-06-01',
+      anthropicBeta: 'prompt-caching-2024-07-31',
+    });
+
+    expect(result.usage).toMatchObject({
+      promptTokens: 12,
+      completionTokens: 4,
+      cache_read_input_tokens: 6,
+      cache_creation_input_tokens: 2,
+    });
+  });
+
+  it('maps canonical ids and enables native messages only for owned models', () => {
+    const adapter = minimaxAdapter({ apiKey: 'test-key' });
+    expect(adapter.toUpstreamId('minimax/MiniMax-M3')).toBe('MiniMax-M3');
+    expect(adapter.toUpstreamId('minimax/MiniMax-M2.7')).toBe('MiniMax-M2.7');
+    expect(adapter.capabilities.supportsNativeMessages('minimax/MiniMax-M3')).toBe(true);
+    expect(adapter.capabilities.supportsNativeMessages('minimax/unknown')).toBe(false);
+  });
+
+  it('classifies body-level insufficient balance errors', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify({
+      base_resp: { status_code: 1008, status_msg: 'insufficient balance' },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    const adapter = minimaxAdapter({ apiKey: 'test-key', fetch: fetcher });
+
+    await expect(adapter.chatCompletion({
+      model: 'minimax/MiniMax-M3',
+      messages: [{ role: 'user', content: 'hello' }],
+    }, 'MiniMax-M3')).rejects.toMatchObject({
+      name: 'AdapterError',
+      kind: 'insufficient_credits',
+      router: 'minimax',
+    });
+  });
+});

--- a/services/control-api/src/services/ai-router/adapters/minimax.ts
+++ b/services/control-api/src/services/ai-router/adapters/minimax.ts
@@ -1,0 +1,335 @@
+import type { MessagesRequest } from '../messages-schema.js';
+import { extractReasoningTokens } from '../reasoning.js';
+import {
+  AdapterError,
+  isUpstreamCreditExhaustionBody,
+  type AdapterErrorKind,
+  type AdapterResult,
+  type ChatCompletionRequest,
+  type RouterAdapter,
+  type UpstreamModel,
+} from './types.js';
+
+export type MiniMaxRegion = 'global_en' | 'cn_zh';
+
+export interface MiniMaxConfig {
+  apiKey: string;
+  region?: MiniMaxRegion;
+  fetch?: typeof fetch;
+}
+
+const ENDPOINTS: Record<MiniMaxRegion, { openai: string; anthropic: string }> = {
+  global_en: {
+    openai: 'https://api.minimax.io/v1',
+    anthropic: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai: 'https://api.minimaxi.com/v1',
+    anthropic: 'https://api.minimaxi.com/anthropic',
+  },
+};
+
+const MODELS: readonly UpstreamModel[] = [
+  {
+    upstreamId: 'MiniMax-M3',
+    displayName: 'MiniMax-M3',
+    promptPricePerMtok: 0.6,
+    completionPricePerMtok: 2.4,
+    cacheReadPricePerMtok: 0.12,
+    cacheWritePricePerMtok: null,
+    contextLength: 1_000_000,
+    inputModalities: ['text', 'image', 'video'],
+    thinking: ['adaptive', 'disabled'],
+    modality: 'chat',
+  },
+  {
+    upstreamId: 'MiniMax-M2.7',
+    displayName: 'MiniMax-M2.7',
+    promptPricePerMtok: 0.3,
+    completionPricePerMtok: 1.2,
+    cacheReadPricePerMtok: 0.06,
+    cacheWritePricePerMtok: 0.375,
+    contextLength: 204_800,
+    inputModalities: ['text'],
+    thinking: ['always_on'],
+    modality: 'chat',
+  },
+];
+
+const CANONICAL_TO_UPSTREAM = new Map(
+  MODELS.map(model => ['minimax/' + model.upstreamId, model.upstreamId]),
+);
+
+function classifyHttp(status: number): AdapterErrorKind {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 402) return 'insufficient_credits';
+  if (status === 404) return 'model_not_available';
+  if (status === 429) return 'rate_limit';
+  if (status >= 500) return 'transport';
+  if (status >= 400) return 'bad_request';
+  return 'unknown';
+}
+
+function classifyMiniMaxCode(code: number): AdapterErrorKind {
+  if (code === 1001 || code === 1013) return 'transport';
+  if (code === 1002) return 'rate_limit';
+  if (code === 1004) return 'auth';
+  if (code === 1008) return 'insufficient_credits';
+  if (code === 1039 || code === 2013) return 'bad_request';
+  return 'unknown';
+}
+
+function throwIfErrorBody(status: number, body: unknown): void {
+  if (isUpstreamCreditExhaustionBody(body)) {
+    throw new AdapterError(
+      'minimax',
+      status,
+      'insufficient_credits',
+      'upstream provider is out of credits',
+    );
+  }
+  if (!body || typeof body !== 'object') return;
+  const baseResp = (body as { base_resp?: unknown }).base_resp;
+  if (!baseResp || typeof baseResp !== 'object') return;
+  const code = (baseResp as { status_code?: unknown }).status_code;
+  if (typeof code !== 'number' || code === 0) return;
+  throw new AdapterError(
+    'minimax',
+    status,
+    classifyMiniMaxCode(code),
+    'MiniMax API error ' + code,
+  );
+}
+
+function parseJsonText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function toOpenAiBody(req: ChatCompletionRequest, upstreamId: string): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    ...(req as unknown as Record<string, unknown>),
+    model: upstreamId,
+  };
+  delete body.session_id;
+  delete body.cache_control;
+
+  const thinking = body.thinking as { type?: unknown } | undefined;
+  const reasoning = body.reasoning as { effort?: unknown } | undefined;
+  const reasoningEffort = body.reasoning_effort;
+  if (thinking?.type === 'enabled') {
+    body.thinking = { type: 'adaptive' };
+  } else if (
+    body.thinking === undefined
+    && (
+      reasoningEffort === 'low'
+      || reasoningEffort === 'medium'
+      || reasoningEffort === 'high'
+      || reasoning?.effort === 'low'
+      || reasoning?.effort === 'medium'
+      || reasoning?.effort === 'high'
+    )
+  ) {
+    body.thinking = { type: 'adaptive' };
+  }
+  delete body.reasoning_effort;
+  delete body.reasoning;
+
+  if (body.stream === true) {
+    const streamOptions = body.stream_options;
+    body.stream_options = {
+      ...(streamOptions && typeof streamOptions === 'object' ? streamOptions : {}),
+      include_usage: true,
+    };
+  }
+  return body;
+}
+
+function toAnthropicBody(req: MessagesRequest, upstreamId: string): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    ...(req as unknown as Record<string, unknown>),
+    model: upstreamId,
+  };
+  const thinking = body.thinking as { type?: unknown } | undefined;
+  if (thinking?.type === 'enabled') {
+    body.thinking = { type: 'adaptive' };
+  } else if (thinking?.type === 'adaptive' || thinking?.type === 'disabled') {
+    body.thinking = { type: thinking.type };
+  }
+  return body;
+}
+
+export function minimaxAdapter(cfg: MiniMaxConfig): RouterAdapter {
+  const endpoints = ENDPOINTS[cfg.region ?? 'global_en'];
+  const fetcher = cfg.fetch ?? fetch;
+
+  async function call(url: string, init: RequestInit): Promise<Response> {
+    try {
+      return await fetcher(url, init);
+    } catch (err) {
+      throw new AdapterError(
+        'minimax',
+        502,
+        'transport',
+        err instanceof Error ? err.message : 'MiniMax transport error',
+      );
+    }
+  }
+
+  async function parseResponse(res: Response): Promise<unknown> {
+    const text = await res.text().catch(() => '');
+    const body = parseJsonText(text);
+    if (!res.ok) {
+      throwIfErrorBody(res.status, body);
+      throw new AdapterError(
+        'minimax',
+        res.status,
+        classifyHttp(res.status),
+        'MiniMax HTTP ' + res.status,
+      );
+    }
+    if (typeof body === 'string') {
+      throw new AdapterError('minimax', 502, 'transport', 'MiniMax returned invalid JSON');
+    }
+    throwIfErrorBody(res.status, body);
+    return body;
+  }
+
+  async function listModels(): Promise<UpstreamModel[]> {
+    return MODELS.map(model => ({
+      ...model,
+      inputModalities: model.inputModalities ? [...model.inputModalities] : undefined,
+      thinking: model.thinking ? [...model.thinking] : undefined,
+    }));
+  }
+
+  async function chatCompletion(
+    req: ChatCompletionRequest,
+    upstreamId: string,
+  ): Promise<AdapterResult> {
+    const res = await call(endpoints.openai + '/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + cfg.apiKey,
+      },
+      body: JSON.stringify(toOpenAiBody(req, upstreamId)),
+    });
+    if (!res.ok) {
+      await parseResponse(res);
+    }
+    if (req.stream && res.headers.get('content-type')?.includes('text/event-stream')) {
+      if (!res.body) {
+        throw new AdapterError('minimax', 502, 'transport', 'MiniMax stream response had no body');
+      }
+      return {
+        status: res.status,
+        stream: res.body,
+        usage: null,
+        providerCostUsd: null,
+      };
+    }
+
+    const json = await parseResponse(res) as {
+      usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        prompt_tokens_details?: {
+          cached_tokens?: number;
+          cache_write_tokens?: number;
+        };
+        completion_tokens_details?: Record<string, unknown>;
+      };
+    };
+    const usage = json.usage;
+    const reasoningTokens = usage
+      ? extractReasoningTokens(usage as unknown as Record<string, unknown>)
+      : 0;
+    return {
+      status: res.status,
+      body: json,
+      usage: usage ? {
+        promptTokens: usage.prompt_tokens ?? 0,
+        completionTokens: usage.completion_tokens ?? 0,
+        totalCost: null,
+        cache_read_input_tokens: usage.prompt_tokens_details?.cached_tokens,
+        cache_creation_input_tokens: usage.prompt_tokens_details?.cache_write_tokens,
+        reasoningTokens: reasoningTokens > 0 ? reasoningTokens : undefined,
+      } : null,
+      providerCostUsd: null,
+    };
+  }
+
+  async function nativeMessages(
+    req: MessagesRequest,
+    upstreamId: string,
+    headers: { anthropicVersion?: string; anthropicBeta?: string },
+  ): Promise<AdapterResult> {
+    const requestHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + cfg.apiKey,
+    };
+    if (headers.anthropicVersion) {
+      requestHeaders['anthropic-version'] = headers.anthropicVersion;
+    }
+    if (headers.anthropicBeta) {
+      requestHeaders['anthropic-beta'] = headers.anthropicBeta;
+    }
+
+    const res = await call(endpoints.anthropic + '/v1/messages', {
+      method: 'POST',
+      headers: requestHeaders,
+      body: JSON.stringify(toAnthropicBody(req, upstreamId)),
+    });
+    if (!res.ok) {
+      await parseResponse(res);
+    }
+    if (req.stream && res.headers.get('content-type')?.includes('text/event-stream')) {
+      if (!res.body) {
+        throw new AdapterError('minimax', 502, 'transport', 'MiniMax stream response had no body');
+      }
+      return {
+        status: res.status,
+        stream: res.body,
+        usage: null,
+        providerCostUsd: null,
+      };
+    }
+
+    const json = await parseResponse(res) as {
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      };
+    };
+    const usage = json.usage;
+    return {
+      status: res.status,
+      body: json,
+      usage: usage ? {
+        promptTokens: usage.input_tokens ?? 0,
+        completionTokens: usage.output_tokens ?? 0,
+        totalCost: null,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+      } : null,
+      providerCostUsd: null,
+    };
+  }
+
+  return {
+    name: 'minimax',
+    capabilities: {
+      supportsNativeMessages: canonicalId => CANONICAL_TO_UPSTREAM.has(canonicalId),
+    },
+    toUpstreamId: canonicalId => CANONICAL_TO_UPSTREAM.get(canonicalId) ?? canonicalId,
+    listModels,
+    chatCompletion,
+    nativeMessages,
+  };
+}

--- a/services/control-api/src/services/ai-router/adapters/types.ts
+++ b/services/control-api/src/services/ai-router/adapters/types.ts
@@ -5,13 +5,19 @@ import type {
 } from '../schemas.js';
 
 export type Modality = 'chat' | 'embedding' | 'image' | 'video' | 'audio';
+export type InputModality = 'text' | 'image' | 'video';
+export type ThinkingMode = 'adaptive' | 'disabled' | 'always_on';
 
 export interface UpstreamModel {
   upstreamId: string;
   displayName: string;
   promptPricePerMtok: number;
   completionPricePerMtok: number;
+  cacheReadPricePerMtok?: number;
+  cacheWritePricePerMtok?: number | null;
   contextLength: number;
+  inputModalities?: InputModality[];
+  thinking?: ThinkingMode[];
   // Defaults to 'chat' when omitted. Non-chat modalities (image/video/audio)
   // surface for future media-router integration; chat-completion selection
   // should filter by modality === 'chat'.

--- a/services/control-api/src/services/ai-router/catalog.test.ts
+++ b/services/control-api/src/services/ai-router/catalog.test.ts
@@ -3,8 +3,56 @@ import { Redis } from 'ioredis';
 import {
   readCatalogEntry, listCatalogModels, writeCatalog, readEnabledRouters,
   tryAcquireRefreshLock, releaseRefreshLock, recordUnknownId,
+  refreshCatalog,
   type CatalogEntry,
 } from './catalog.js';
+import { minimaxAdapter } from './adapters/minimax.js';
+
+describe('catalog refresh metadata', () => {
+  it('preserves MiniMax cache pricing, input modalities, and thinking modes', async () => {
+    const values = new Map<string, string>();
+    const redis = {
+      get: async (key: string) => values.get(key) ?? null,
+      multi: () => {
+        const operations: Array<() => void> = [];
+        const pipeline = {
+          del: (key: string) => {
+            operations.push(() => { values.delete(key); });
+            return pipeline;
+          },
+          set: (key: string, value: string) => {
+            operations.push(() => { values.set(key, value); });
+            return pipeline;
+          },
+          exec: async () => {
+            for (const operation of operations) operation();
+            return [];
+          },
+        };
+        return pipeline;
+      },
+    } as unknown as Redis;
+
+    const result = await refreshCatalog(redis, [minimaxAdapter({ apiKey: 'test-key' })]);
+    expect(result.modelCount).toBe(2);
+
+    const m3 = JSON.parse(values.get('ai_catalog:model:minimax/MiniMax-M3')!);
+    expect(m3.routers[0]).toMatchObject({
+      cacheReadPricePerMtok: 0.12,
+      cacheWritePricePerMtok: null,
+      inputModalities: ['text', 'image', 'video'],
+      thinking: ['adaptive', 'disabled'],
+    });
+
+    const m27 = JSON.parse(values.get('ai_catalog:model:minimax/MiniMax-M2.7')!);
+    expect(m27.routers[0]).toMatchObject({
+      cacheReadPricePerMtok: 0.06,
+      cacheWritePricePerMtok: 0.375,
+      inputModalities: ['text'],
+      thinking: ['always_on'],
+    });
+  });
+});
 
 const RUN_REDIS_TESTS = process.env.RUN_REDIS_TESTS === '1' || process.env.RUN_DB_TESTS === '1';
 const describeRedis = RUN_REDIS_TESTS ? describe : describe.skip;

--- a/services/control-api/src/services/ai-router/catalog.ts
+++ b/services/control-api/src/services/ai-router/catalog.ts
@@ -146,7 +146,11 @@ export async function refreshCatalog(
           upstreamId: m.upstreamId,
           promptPricePerMtok: m.promptPricePerMtok,
           completionPricePerMtok: m.completionPricePerMtok,
+          cacheReadPricePerMtok: m.cacheReadPricePerMtok,
+          cacheWritePricePerMtok: m.cacheWritePricePerMtok,
           contextLength: m.contextLength,
+          inputModalities: m.inputModalities,
+          thinking: m.thinking,
           modality: m.modality,
           rawPricing: m.rawPricing,
         });

--- a/services/control-api/src/services/ai-router/normalize.test.ts
+++ b/services/control-api/src/services/ai-router/normalize.test.ts
@@ -45,6 +45,11 @@ describe('canonicalizeUpstreamId', () => {
     expect(canonicalizeUpstreamId('provider-primary', 'seed-2-0-pro-260328')).toBe('bytedance-seed/seed-2-0-pro-260328');
   });
 
+  it('canonicalizes MiniMax adapter model ids without changing their case', () => {
+    expect(canonicalizeUpstreamId('minimax', 'MiniMax-M3')).toBe('minimax/MiniMax-M3');
+    expect(canonicalizeUpstreamId('minimax', 'MiniMax-M2.7')).toBe('minimax/MiniMax-M2.7');
+  });
+
   it('passes through slash-prefixed vendor ids (lowercases the vendor)', () => {
     // AI Provider Primary publishes PixVerse and similar with explicit vendor prefix.
     expect(canonicalizeUpstreamId('provider-primary', 'PixVerse/v6')).toBe('pixverse/v6');
@@ -64,10 +69,11 @@ describe('canonicalizeUpstreamId', () => {
 });
 
 describe('RouterName type', () => {
-  it('accepts the three known routers', () => {
+  it('accepts the known routers', () => {
     const a: RouterName = 'openrouter';
     const b: RouterName = 'provider-primary';
     const c: RouterName = 'provider-secondary';
-    expect([a, b, c]).toHaveLength(3);
+    const d: RouterName = 'minimax';
+    expect([a, b, c, d]).toHaveLength(4);
   });
 });

--- a/services/control-api/src/services/ai-router/normalize.ts
+++ b/services/control-api/src/services/ai-router/normalize.ts
@@ -1,6 +1,6 @@
 import overridesRaw from './normalize-overrides.json' with { type: 'json' };
 
-export type RouterName = 'openrouter' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary';
+export type RouterName = 'openrouter' | 'minimax' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary';
 
 const overrides = overridesRaw as unknown as Record<RouterName, Record<string, string>>;
 

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -36,7 +36,7 @@ const FALLBACK_KINDS: ReadonlySet<string> = new Set(['transport', 'rate_limit', 
  * slot-cooldown MGET stays O(known-slots) instead of scanning Redis keys.
  * Extend when adding new named slots.
  */
-const KNOWN_ROUTER_SLOTS = ['provider-primary', 'provider-secondary', 'provider-tertiary', 'openrouter'] as const;
+const KNOWN_ROUTER_SLOTS = ['provider-primary', 'provider-secondary', 'provider-tertiary', 'minimax', 'openrouter'] as const;
 
 /**
  * Pick the active ranker. Waterfall wins over presence-mode when both are

--- a/services/control-api/src/services/ai-router/select.test.ts
+++ b/services/control-api/src/services/ai-router/select.test.ts
@@ -190,7 +190,7 @@ describe('estimateWorstCaseUsd', () => {
 });
 
 describe('rankRoutersPresenceMode', () => {
-  const mk = (name: 'openrouter' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary'): CatalogRouter => ({
+  const mk = (name: 'openrouter' | 'minimax' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary'): CatalogRouter => ({
     name: name as any,
     upstreamId: `${name}-id`,
     promptPricePerMtok: 1,
@@ -271,6 +271,15 @@ describe('rankRoutersPresenceMode', () => {
   it('OR only', () => {
     const r = rankRoutersPresenceMode(entry([mk('openrouter')]), allEnabled, () => 0);
     expect(r.map(x => x.name)).toEqual(['openrouter']);
+  });
+
+  it('keeps the MiniMax slot eligible ahead of the generic fallback', () => {
+    const r = rankRoutersPresenceMode(
+      entry([mk('openrouter'), mk('minimax')]),
+      new Set(['openrouter', 'minimax']),
+      () => 0,
+    );
+    expect(r.map(x => x.name)).toEqual(['minimax', 'openrouter']);
   });
 
   it('ER disabled in enabled-set is filtered out before tiebreak', () => {

--- a/services/control-api/src/services/ai-router/select.ts
+++ b/services/control-api/src/services/ai-router/select.ts
@@ -1,12 +1,16 @@
 import type { RouterName } from './normalize.js';
-import type { Modality } from './adapters/types.js';
+import type { InputModality, Modality, ThinkingMode } from './adapters/types.js';
 
 export interface CatalogRouter {
   name: RouterName;
   upstreamId: string;
   promptPricePerMtok: number;
   completionPricePerMtok: number;
+  cacheReadPricePerMtok?: number;
+  cacheWritePricePerMtok?: number | null;
   contextLength: number;
+  inputModalities?: InputModality[];
+  thinking?: ThinkingMode[];
   // Defaults to 'chat' for entries written before this field existed.
   modality?: Modality;
   // Router-native pricing for non-chat modalities. See UpstreamModel.rawPricing.
@@ -196,6 +200,7 @@ export function rankRoutersPresenceMode(
   const er = available.find(r => r.name === 'provider-primary');
   const ir = available.find(r => r.name === 'provider-secondary');
   const tr = available.find(r => r.name === 'provider-tertiary');
+  const mm = available.find(r => r.name === 'minimax');
   const or = available.find(r => r.name === 'openrouter');
 
   const head: CatalogRouter[] = [];
@@ -210,6 +215,7 @@ export function rankRoutersPresenceMode(
   // The PREFERRED_ROUTER_BY_MODEL hook can still promote it to the head when
   // applicable; this default keeps it routable for non-preferred models too.
   if (tr) head.push(tr);
+  if (mm) head.push(mm);
   if (or) head.push(or);
   return promotePreferred(entry.canonicalId, head);
 }


### PR DESCRIPTION
Reason: Add first-class MiniMax routing with exact model metadata and regional compatible endpoints.

Summary:
- Add a MiniMax RouterAdapter with static MiniMax-M3 and MiniMax-M2.7 catalog entries.
- Route Chat Completions and native Messages requests through the selected global or China endpoint.
- Preserve context length, token and cache pricing, input modalities, and thinking modes in the catalog and model response.
- Register MiniMax in gateway construction, catalog refresh, cooldown handling, and adapter status reporting.

Checks:
- `npm run test --workspace=@butterbase/control-api -- src/services/ai-router/adapters/minimax.test.ts src/services/ai-router/normalize.test.ts src/services/ai-router/select.test.ts src/services/ai-router/catalog.test.ts src/__tests__/config.test.ts src/routes/gateway.test.ts src/routes/ai-config.models.test.ts`
- `npm run test --workspace=@butterbase/control-api -- src/services/ai-router/messages.test.ts src/routes/gateway.messages.test.ts`
- `npm run build --workspace=@butterbase/control-api`
