### PR TITLE
docs(agents): correct remote MCP registration examples

### DIFF
--- a/services/docs/src/content/docs/api-reference/agents-api.md
+++ b/services/docs/src/content/docs/api-reference/agents-api.md
@@ -233,12 +233,38 @@ Public runs respect the agent's per-IP rate limits, daily budget, and max concur
 
 ```http
 POST /v1/{app_id}/mcp-servers
+Authorization: Bearer {token}
+Content-Type: application/json
+
 {
-  "name": "Stripe docs",
+  "name": "stripe_docs",
+  "transport": "streamable_http",
   "url": "https://mcp.stripe.com",
-  "auth": { "type": "bearer", "token": "sk_..." }
+  "auth_header": "Bearer <stripe-token>"
 }
 ```
+
+`Authorization` authenticates the request to Butterbase. `auth_header` is
+optional and, when set, is forwarded to the remote MCP server.
+
+For example, Parallel Search MCP needs no separate Parallel account, API key,
+OAuth flow, or `auth_header`:
+
+```http
+POST /v1/{app_id}/mcp-servers
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "name": "parallel_search",
+  "transport": "streamable_http",
+  "url": "https://search.parallel.ai/mcp"
+}
+```
+
+Probe the returned server ID to load its advertised tools. An agent can then
+expose `web_search` for current web search and `web_fetch` for extracting clean
+Markdown from a URL.
 
 Once registered, an agent can reference any of the server's advertised tools by listing them in `graph_spec.tools.mcp_servers`.
 


### PR DESCRIPTION
## Summary

The Agents API reference showed an MCP server registration body that did not match the current route schema. This corrects the authenticated example and adds an adjacent opt-in Parallel Search MCP example for live web search and URL fetching without additional provider credentials.

## Related issue

None; this is a focused documentation correction on an existing API surface.

## Test plan

- [ ] Unit / integration tests pass locally (`npm test`) — not run because no runtime code changed
- [x] Verified the change manually by parsing both JSON payloads and checking their exact keys, values, and accepted name format
- [x] Updated docs / examples if behavior changed
- [x] Built all 58 documentation pages with `npm run build --workspace=@butterbase/docs`
- [x] Ran `git diff --check`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, credentials, or internal-only references in the diff
- [x] Breaking changes called out in the description — no breaking changes

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.