### PR TITLE
feat(dashboard-agent): scope manage_app list to the active org

### DIFF
--- a/services/control-api/src/routes/dashboard-agent.ts
+++ b/services/control-api/src/routes/dashboard-agent.ts
@@ -73,6 +73,14 @@ function isEnabled(): boolean {
   return process.env.DASHBOARD_ASSISTANT_ENABLED === '1';
 }
 
+// The dashboard forwards the user's active org as `x-organization-id`. The
+// agent loop uses it to scope app-discovery tooling (manage_app list) to the
+// current org. Absent / non-string → null (loop falls back to unscoped).
+function readOrgId(request: { headers: Record<string, unknown> }): string | null {
+  const raw = request.headers['x-organization-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
 // ---------------------------------------------------------------------------
 // Helper: calculate usage cost (Plan 3e Task 16)
 // ---------------------------------------------------------------------------
@@ -419,6 +427,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
         userMessage: message,
         model,
         pool: app.controlDb,
+        organizationId: readOrgId(request),
       });
 
       for await (const event of gen) {
@@ -595,6 +604,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
         userMessage: userMessageToReplay,
         model: conversation.model,
         pool: app.controlDb,
+        organizationId: readOrgId(request),
       });
 
       for await (const event of gen) {
@@ -999,6 +1009,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
         userMessage: '',
         model,
         pool: app.controlDb,
+        organizationId: readOrgId(request),
       });
 
       for await (const event of gen) {

--- a/services/control-api/src/services/dashboard-agent/__tests__/scope-app-list.test.ts
+++ b/services/control-api/src/services/dashboard-agent/__tests__/scope-app-list.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { scopeAppListToOrg } from '../loop.js';
+
+// The dashboard agent scopes `manage_app` action:"list" results to the active
+// org. `/apps` deliberately fans out across every org the user belongs to;
+// scopeAppListToOrg narrows the MCP result envelope to a single org, and MUST
+// fail open (return the input untouched) on any unexpected shape so scoping can
+// never break the tool call.
+
+/** Build the MCP tool-result envelope manage_app list returns. */
+function envelope(apps: Array<{ id: string; organization_id: string | null }>) {
+  return { content: [{ type: 'text', text: JSON.stringify({ apps }, null, 2) }] };
+}
+
+function appsFrom(result: unknown): Array<{ id: string; organization_id: string | null }> {
+  const text = (result as { content: Array<{ text: string }> }).content[0].text;
+  return JSON.parse(text).apps;
+}
+
+describe('scopeAppListToOrg', () => {
+  it('keeps only apps in the target org', () => {
+    const result = envelope([
+      { id: 'app_a', organization_id: 'org_1' },
+      { id: 'app_b', organization_id: 'org_2' },
+      { id: 'app_c', organization_id: 'org_1' },
+    ]);
+    const scoped = scopeAppListToOrg(result, 'org_1');
+    expect(appsFrom(scoped).map((a) => a.id)).toEqual(['app_a', 'app_c']);
+  });
+
+  it('preserves other top-level keys in the payload', () => {
+    const result = { content: [{ type: 'text', text: JSON.stringify({ apps: [{ id: 'app_a', organization_id: 'org_1' }], note: 'hi' }) }] };
+    const scoped = scopeAppListToOrg(result, 'org_2');
+    const parsed = JSON.parse((scoped as { content: Array<{ text: string }> }).content[0].text);
+    expect(parsed.apps).toEqual([]);
+    expect(parsed.note).toBe('hi');
+  });
+
+  it('drops rows with a null / missing organization_id (no accidental leak)', () => {
+    const result = envelope([
+      { id: 'app_a', organization_id: 'org_1' },
+      { id: 'app_b', organization_id: null },
+    ]);
+    const scoped = scopeAppListToOrg(result, 'org_1');
+    expect(appsFrom(scoped).map((a) => a.id)).toEqual(['app_a']);
+  });
+
+  it('fails open on a non-envelope shape', () => {
+    const weird = { unexpected: true };
+    expect(scopeAppListToOrg(weird, 'org_1')).toBe(weird);
+  });
+
+  it('fails open when the text is not valid JSON', () => {
+    const result = { content: [{ type: 'text', text: 'not json' }] };
+    expect(scopeAppListToOrg(result, 'org_1')).toBe(result);
+  });
+
+  it('fails open when there is no apps array', () => {
+    const result = { content: [{ type: 'text', text: JSON.stringify({ something: 1 }) }] };
+    expect(scopeAppListToOrg(result, 'org_1')).toBe(result);
+  });
+});

--- a/services/control-api/src/services/dashboard-agent/loop.ts
+++ b/services/control-api/src/services/dashboard-agent/loop.ts
@@ -389,6 +389,35 @@ const TOOL_RETRY_LIMIT = process.env.DASHBOARD_AGENT_TOOL_RETRY_LIMIT
   ? Number.parseInt(process.env.DASHBOARD_AGENT_TOOL_RETRY_LIMIT, 10)
   : 3;
 
+/**
+ * Narrow a `manage_app` action:"list" MCP result to a single org. The tool
+ * returns `{ content: [{ type: 'text', text: <json> }] }` where the JSON is
+ * `{ apps: [{ ..., organization_id }] }` (each row already carries its owning
+ * org — see routes/init.ts `/apps`). We parse that text, keep only rows whose
+ * `organization_id` matches, and re-serialize. Any shape mismatch or parse
+ * error returns the original result unchanged, so scoping can never break the
+ * tool call — it only ever removes cross-org rows.
+ */
+export function scopeAppListToOrg(result: unknown, orgId: string): unknown {
+  try {
+    const envelope = result as { content?: Array<{ type?: string; text?: string }> };
+    const content = envelope?.content;
+    if (!Array.isArray(content)) return result;
+    const idx = content.findIndex((c) => c?.type === 'text' && typeof c.text === 'string');
+    if (idx === -1) return result;
+    const parsed = JSON.parse(content[idx].text as string) as {
+      apps?: Array<{ organization_id?: string | null }>;
+    };
+    if (!parsed || !Array.isArray(parsed.apps)) return result;
+    const apps = parsed.apps.filter((a) => a?.organization_id === orgId);
+    const nextText = JSON.stringify({ ...parsed, apps }, null, 2);
+    const nextContent = content.map((c, i) => (i === idx ? { ...c, text: nextText } : c));
+    return { ...envelope, content: nextContent };
+  } catch {
+    return result;
+  }
+}
+
 export async function* runAgentTurn(
   input: {
     conversationId: string;
@@ -397,6 +426,10 @@ export async function* runAgentTurn(
     userMessage: string;
     model: string;
     pool: pg.Pool;
+    // Active org (from the dashboard's `x-organization-id` header). When set,
+    // the agent's app-discovery tooling (manage_app list) is scoped to it so
+    // the model only sees apps in the org the user is currently working in.
+    organizationId?: string | null;
   },
   depsOverride?: Partial<LoopDeps>,
 ): AsyncGenerator<LoopEvent> {
@@ -863,7 +896,21 @@ export async function* runAgentTurn(
 
         // ---- Default: MCP tool -------------------------------------------
         toolCallsCount++;
-        const call = await callMcpTool(tc.name, tc.args, input.jwt);
+        const call = await callMcpTool(tc.name, tc.args, input.jwt, input.organizationId);
+        // Scope app discovery to the active org. The shared `/apps` endpoint
+        // deliberately fans out across every org the user belongs to; here —
+        // and only on the dashboard-agent path — we narrow `manage_app` list
+        // results to the org the user is currently working in so the model
+        // isn't shown apps from unrelated orgs. Best-effort: any parse miss
+        // leaves the result untouched.
+        if (
+          call.ok &&
+          tc.name === 'manage_app' &&
+          (tc.args as { action?: string } | null)?.action === 'list' &&
+          input.organizationId
+        ) {
+          call.result = scopeAppListToOrg(call.result, input.organizationId);
+        }
         const resultPayload = call.ok ? { result: call.result } : { error: call.error };
         toolCallResults.push({ id: tc.id, ...resultPayload });
         yield { type: 'tool_result', id: tc.id, ...resultPayload };

--- a/services/control-api/src/services/dashboard-agent/mcp-client.ts
+++ b/services/control-api/src/services/dashboard-agent/mcp-client.ts
@@ -45,12 +45,15 @@ function normalizeToolArgs(args: unknown): unknown {
  * @param name - The MCP tool name (e.g., 'manage_app')
  * @param args - Tool arguments as an object
  * @param jwt - Cognito Bearer JWT token
+ * @param orgId - Optional active org; forwarded as `x-organization-id` so the
+ *   MCP server carries the caller's org context into downstream API calls.
  * @returns Result object with ok flag, result, or error
  */
 export async function callMcpTool(
   name: string,
   args: unknown,
   jwt: string,
+  orgId?: string | null,
 ): Promise<McpCallResult> {
   const url = `${process.env.MCP_SERVER_URL ?? 'http://localhost:3010'}/mcp`;
   const normalizedArgs = normalizeToolArgs(args);
@@ -64,6 +67,7 @@ export async function callMcpTool(
         // (rejects with 406 Not Acceptable otherwise).
         accept: 'application/json, text/event-stream',
         authorization: `Bearer ${jwt}`,
+        ...(orgId ? { 'x-organization-id': orgId } : {}),
       },
       body: JSON.stringify({
         jsonrpc: '2.0',


### PR DESCRIPTION
## What

The dashboard assistant agent's app discovery (`manage_app` action:\"list\") returned **every** app across **all** orgs the user belongs to. This scopes it to the org the user is currently working in.

## How

- The dashboard forwards the user's active org as `x-organization-id` on every dashboard-agent request. `routes/dashboard-agent.ts` reads it and threads it into all three `runAgentTurn` callsites.
- `callMcpTool` forwards it downstream; the loop narrows `manage_app` list results to that org via a new `scopeAppListToOrg` helper.
- The shared `/apps` endpoint is **unchanged** — it still intentionally fans out across every org (member-based reads). Scoping happens **only** on the dashboard-agent path.
- `scopeAppListToOrg` fails open: any unexpected shape returns the result untouched, so scoping can never break the tool call — it only ever removes cross-org rows.

## Tests

- New `scope-app-list.test.ts` — 6 cases incl. null-org drop + fail-open paths. All pass.
- control-api typechecks clean.

Paired with the internal-repo dashboard change (submodule bump + `x-organization-id` client header).