### PR TITLE
fix(people): probe every region for email-lookup nonces, and stop double-charging at resolve

### DIFF
--- a/services/control-api/src/routes/people-webhook.test.ts
+++ b/services/control-api/src/routes/people-webhook.test.ts
@@ -173,6 +173,7 @@ describe('POST /v1/webhooks/people/email', () => {
       method: 'POST',
       url: `/v1/webhooks/people/email?nonce=${NONCE}`,
       payload: { email: 'jane@example.com' },
+      headers: { 'x-cost': '1' },   // vendor-reported cost; no cost ⇒ no charge
     });
 
     expect(res.statusCode).toBe(200);
@@ -311,9 +312,10 @@ describe('POST /v1/webhooks/people/email', () => {
 
     const url = `/v1/webhooks/people/email?nonce=${NONCE}`;
     const payload = { email: 'jane@example.com' };
+    const headers = { 'x-cost': '1' };   // vendor-reported cost; no cost ⇒ no charge
 
-    const res1 = await app.inject({ method: 'POST', url, payload });
-    const res2 = await app.inject({ method: 'POST', url, payload });
+    const res1 = await app.inject({ method: 'POST', url, payload, headers });
+    const res2 = await app.inject({ method: 'POST', url, payload, headers });
 
     expect(res1.statusCode).toBe(200);
     expect(res1.json()).toEqual({ ok: true });
@@ -740,6 +742,7 @@ describe('POST /v1/webhooks/people/email — resolve-time billing target', () =>
       method: 'POST',
       url: `/v1/webhooks/people/email?nonce=${NONCE}`,
       payload: { email: 'jane@example.com' },
+      headers: { 'x-cost': '1' },
     });
 
     expect(deductCreditsBalance).toHaveBeenCalledWith(
@@ -762,8 +765,97 @@ describe('POST /v1/webhooks/people/email — resolve-time billing target', () =>
       method: 'POST',
       url: `/v1/webhooks/people/email?nonce=${NONCE}`,
       payload: { email: 'jane@example.com' },
+      headers: { 'x-cost': '1' },
     });
 
     expect(incrementUsage).toHaveBeenCalledWith(ORG_ID, USER_ID, 'people_credits', 1, APP_ID);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The callback is the provider calling US — it is not a billable request we
+// made, and it carries no credit-cost header.  Falling back to a per-action
+// credit count here invents a charge the vendor never reported: the queue call
+// already billed (and recorded) the real cost from its own response header, so
+// a fallback at resolve time bills the customer twice for one lookup.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /v1/webhooks/people/email — charges only vendor-reported credits', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getPeoplePricing).mockReturnValue({
+      baseUsdPerCredit: 0.0168,
+      markupPct: 20,
+      usdPerCredit: USD_PER_CREDIT,
+    });
+    vi.mocked(resolveOrganizationId).mockResolvedValue(USER_ID);
+    vi.mocked(resolveOrgFromApp).mockResolvedValue(ORG_ID);
+    vi.mocked(deductCreditsBalance).mockResolvedValue(0);
+    vi.mocked(incrementUsage).mockResolvedValue(undefined);
+    app = await buildTestApp();
+    vi.mocked(listRuntimeRegions).mockReturnValue(['local']);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('charges nothing when the callback reports no credit cost', async () => {
+    // fallbackCreditsPerAction is 1 in the mocked config and 3 in production —
+    // either way, an unreported cost must not become a charge.
+    const pool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },   // no x-cost header
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+    expect(deductCreditsBalance).not.toHaveBeenCalled();
+    expect(incrementUsage).not.toHaveBeenCalled();
+  });
+
+  it('records zero credits on the claim when the callback reports no cost', async () => {
+    const pool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    const claimCall = pool.query.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && (c[0] as string).includes("status = 'pending'"),
+    );
+    expect(claimCall).toBeDefined();
+    // params: [status, email, credits_consumed, id]
+    expect(claimCall![1][2]).toBe(0);
+  });
+
+  it('still charges the exact cost when the callback does report one', async () => {
+    const pool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+    vi.mocked(deductCreditsBalance).mockResolvedValue(4 * USD_PER_CREDIT);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+      headers: { 'x-cost': '4' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(deductCreditsBalance).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_ID,
+      4 * USD_PER_CREDIT,
+    );
   });
 });

--- a/services/control-api/src/routes/people-webhook.test.ts
+++ b/services/control-api/src/routes/people-webhook.test.ts
@@ -80,6 +80,9 @@ const NONCE = 'a'.repeat(64); // 64-char hex nonce (simulated)
 const LOOKUP_ID = 'lookup-uuid-1';
 const APP_ID = 'app_test123';
 const USER_ID = 'user-uuid-1';
+// Deliberately distinct from USER_ID: a team org's id never equals a member's
+// user id, which is why billing the user id silently charges nothing there.
+const ORG_ID = 'org-uuid-1';
 const NORMALIZED_URL = 'https://www.linkedin.com/in/jane-doe';
 const USD_PER_CREDIT = 0.02016;
 
@@ -87,6 +90,7 @@ const SAMPLE_LOOKUP_ROW = {
   id: LOOKUP_ID,
   app_id: APP_ID,
   user_id: USER_ID,
+  organization_id: ORG_ID,
   normalized_url: NORMALIZED_URL,
   provider_slot: 'primary',
 };
@@ -174,13 +178,13 @@ describe('POST /v1/webhooks/people/email', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ ok: true });
 
-    // credits deducted
+    // credits deducted from the org stamped on the lookup row
     expect(deductCreditsBalance).toHaveBeenCalledWith(
       expect.anything(), // controlDb
-      USER_ID,
+      ORG_ID,
       1 * USD_PER_CREDIT, // 1 credit × USD_PER_CREDIT
     );
-    expect(incrementUsage).toHaveBeenCalledWith(USER_ID, USER_ID, 'people_credits', 1, APP_ID);
+    expect(incrementUsage).toHaveBeenCalledWith(ORG_ID, USER_ID, 'people_credits', 1, APP_ID);
 
     // audit log written
     const auditCall = pool.query.mock.calls.find(
@@ -543,10 +547,10 @@ describe('POST /v1/webhooks/people/email', () => {
       // 7 credits from header, not 9 from fallback
       expect(deductCreditsBalance).toHaveBeenCalledWith(
         expect.anything(),
-        USER_ID,
+        ORG_ID,
         7 * USD_PER_CREDIT,
       );
-      expect(incrementUsage).toHaveBeenCalledWith(USER_ID, USER_ID, 'people_credits', 7, APP_ID);
+      expect(incrementUsage).toHaveBeenCalledWith(ORG_ID, USER_ID, 'people_credits', 7, APP_ID);
 
       // Audit row records provider_slot='secondary'
       const auditCall = pool.query.mock.calls.find(
@@ -579,9 +583,187 @@ describe('POST /v1/webhooks/people/email', () => {
 
     expect(deductCreditsBalance).toHaveBeenCalledWith(
       expect.anything(),
-      USER_ID,
+      ORG_ID,
       5 * USD_PER_CREDIT, // 5 credits from header
     );
-    expect(incrementUsage).toHaveBeenCalledWith(USER_ID, USER_ID, 'people_credits', 5, APP_ID);
+    expect(incrementUsage).toHaveBeenCalledWith(ORG_ID, USER_ID, 'people_credits', 5, APP_ID);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Multi-region nonce dispatch.
+//
+// people_email_lookups rows live in the runtime DB of the app's OWN region.
+// A receiver that probes only listRuntimeRegions()[0] can never find a nonce
+// belonging to an app homed in any other region — it answers 200 { ignored },
+// the provider treats the callback as delivered and never retries, and the row
+// stays 'pending' forever.  That is what stranded 596 us-west-2 lookups.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /v1/webhooks/people/email — multi-region nonce dispatch', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getPeoplePricing).mockReturnValue({
+      baseUsdPerCredit: 0.0168,
+      markupPct: 20,
+      usdPerCredit: USD_PER_CREDIT,
+    });
+    vi.mocked(resolveOrganizationId).mockResolvedValue(USER_ID);
+    vi.mocked(resolveOrgFromApp).mockResolvedValue(ORG_ID);
+    vi.mocked(deductCreditsBalance).mockResolvedValue(1 * USD_PER_CREDIT);
+    vi.mocked(incrementUsage).mockResolvedValue(undefined);
+    app = await buildTestApp();
+    vi.mocked(listRuntimeRegions).mockReturnValue(['us-east-1', 'us-west-2']);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('claims a nonce that lives in a non-first region', async () => {
+    const eastPool = makeRuntimePool({ findRow: null });          // nonce absent here
+    const westPool = makeRuntimePool();                            // nonce lives here
+    vi.mocked(runtimePoolFor).mockImplementation((region: string) =>
+      (region === 'us-east-1' ? eastPool : westPool) as any,
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+
+    // The claim UPDATE must run against the region that actually holds the row.
+    const westClaim = westPool.query.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && (c[0] as string).includes("status = 'pending'"),
+    );
+    expect(westClaim).toBeDefined();
+    const eastClaim = eastPool.query.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && (c[0] as string).includes("status = 'pending'"),
+    );
+    expect(eastClaim).toBeUndefined();
+  });
+
+  it('stops probing regions once the nonce is found', async () => {
+    const eastPool = makeRuntimePool();                            // found in the first region
+    const westPool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockImplementation((region: string) =>
+      (region === 'us-east-1' ? eastPool : westPool) as any,
+    );
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(westPool.query).not.toHaveBeenCalled();
+  });
+
+  it('answers 503 when a region probe errors, so the provider retries', async () => {
+    // A transient DB failure means "we do not know whether this nonce exists".
+    // Answering 200 there would discard a resolvable callback exactly like the
+    // cross-region bug did.
+    const eastPool = { query: vi.fn().mockRejectedValue(new Error('ECONNRESET')) };
+    const westPool = makeRuntimePool({ findRow: null });
+    vi.mocked(runtimePoolFor).mockImplementation((region: string) =>
+      (region === 'us-east-1' ? eastPool : westPool) as any,
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('answers 200 { ignored } when every region cleanly reports the nonce absent', async () => {
+    const pool = makeRuntimePool({ findRow: null });
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ignored: true });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resolve-time billing targets the organization that was charged at queue time.
+//
+// people.ts stamps the app's owning org onto people_email_lookups.organization_id
+// when the lookup is queued.  The receiver must bill that same org.  Passing
+// user_id where deductCreditsBalance expects an organization id matches zero
+// rows and silently charges nothing for every team org.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /v1/webhooks/people/email — resolve-time billing target', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getPeoplePricing).mockReturnValue({
+      baseUsdPerCredit: 0.0168,
+      markupPct: 20,
+      usdPerCredit: USD_PER_CREDIT,
+    });
+    vi.mocked(resolveOrganizationId).mockResolvedValue(USER_ID);
+    vi.mocked(resolveOrgFromApp).mockResolvedValue(ORG_ID);
+    vi.mocked(deductCreditsBalance).mockResolvedValue(1 * USD_PER_CREDIT);
+    vi.mocked(incrementUsage).mockResolvedValue(undefined);
+    app = await buildTestApp();
+    vi.mocked(listRuntimeRegions).mockReturnValue(['local']);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it("deducts from the lookup row's organization, not the user id", async () => {
+    const pool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(deductCreditsBalance).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_ID,
+      1 * USD_PER_CREDIT,
+    );
+    expect(deductCreditsBalance).not.toHaveBeenCalledWith(
+      expect.anything(),
+      USER_ID,
+      expect.anything(),
+    );
+  });
+
+  it("meters usage against the lookup row's organization", async () => {
+    const pool = makeRuntimePool();
+    vi.mocked(runtimePoolFor).mockReturnValue(pool as any);
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/webhooks/people/email?nonce=${NONCE}`,
+      payload: { email: 'jane@example.com' },
+    });
+
+    expect(incrementUsage).toHaveBeenCalledWith(ORG_ID, USER_ID, 'people_credits', 1, APP_ID);
   });
 });

--- a/services/control-api/src/routes/people-webhook.ts
+++ b/services/control-api/src/routes/people-webhook.ts
@@ -23,8 +23,10 @@
 //   body.email → body.work_email → body.result.email → null
 //
 // Credit-cost source:
-//   config.people.providers[slot].creditCostHeader (per-slot header name, if present and finite >= 0)
-//   → config.people.providers[slot].fallbackCreditsPerAction (default: 1)
+//   config.people.providers[slot].creditCostHeader (per-slot header name, if present
+//   and finite >= 0) → otherwise 0.  There is deliberately NO fallbackCreditsPerAction
+//   here: the queue call already charged the real cost from its own response header,
+//   so charging a per-action default at resolve time double-bills a single lookup.
 
 import type { FastifyInstance } from 'fastify';
 import { listRuntimeRegions, runtimePoolFor } from '../services/runtime-pool-registry.js';
@@ -132,11 +134,14 @@ export async function peopleWebhookRoutes(app: FastifyInstance) {
 
     // Resolve slot and parse credit count from the inbound header BEFORE the claim
     // UPDATE so we can write the real value in a single atomic operation.
+    //
+    // Bill ONLY what this callback actually reports.  There is deliberately no
+    // per-action fallback here: the callback is the provider calling us, not a
+    // billable request we made.  The queue call already charged the real cost
+    // read from its own response header, so inventing a cost at resolve time
+    // bills the customer twice for a single lookup.
     const slot = (lookupRow.provider_slot as ProviderSlot) ?? 'primary';
     const providerCfg = config.people.providers[slot];
-    if (!providerCfg?.creditCostHeader && !providerCfg?.apiKey) {
-      console.error(`[people-webhook] slot=${slot} has no configured provider; charging fallback`);
-    }
     const creditHeader = providerCfg?.creditCostHeader;
     const rawHeaderCredits = creditHeader
       ? req.headers[creditHeader.toLowerCase()]
@@ -146,7 +151,7 @@ export async function peopleWebhookRoutes(app: FastifyInstance) {
     const credits =
       Number.isFinite(headerCredits) && headerCredits >= 0
         ? headerCredits
-        : (providerCfg?.fallbackCreditsPerAction ?? 1);
+        : 0;
 
     // Atomic idempotent claim: the AND status='pending' predicate guarantees only
     // one concurrent webhook call transitions the row.  0 rows returned → already

--- a/services/control-api/src/routes/people-webhook.ts
+++ b/services/control-api/src/routes/people-webhook.ts
@@ -5,15 +5,19 @@
 // when an async email lookup completes.  The nonce is the security gate —
 // this route carries NO auth header by design.
 //
-// ALWAYS returns HTTP 200 (with a JSON body) so People stops retrying.
+// Responses — 200 means "settled, stop retrying":
 //   { ok: true }                  — claim succeeded; credits charged, audit row written.
 //   { ok: true, billing: 'deferred' } — claim succeeded but post-claim billing/audit threw.
-//   { ignored: true }             — unknown/already-claimed nonce, null body, or any error.
+//   { ignored: true }             — unknown/already-claimed nonce, null body, or a fault
+//                                   that a retry cannot fix.
+//   503                           — a runtime region was unreadable, so "unknown nonce"
+//                                   could not be established.  Ask the provider to redeliver
+//                                   rather than silently drop a resolvable callback.
 //
-// Cross-region limitation (v1, Option C):
-//   people_email_lookups rows live in the runtime DB tier.  This receiver
-//   queries only the first configured runtime region (listRuntimeRegions()[0]).
-//   Multi-region dispatch will require a control-plane nonce index (Option B).
+// Multi-region dispatch:
+//   people_email_lookups rows live in the runtime DB of the app's OWN region, so
+//   this receiver probes every region in listRuntimeRegions() until the nonce is
+//   found.  Nonces are 32 random bytes, so the first hit owns the row.
 //
 // Email-field fallback chain (vendor shape unverified against live traffic):
 //   body.email → body.work_email → body.result.email → null
@@ -24,10 +28,8 @@
 
 import type { FastifyInstance } from 'fastify';
 import { listRuntimeRegions, runtimePoolFor } from '../services/runtime-pool-registry.js';
-import { resolveOrgFromApp } from '../services/app-org-resolver.js';
 import { getPeoplePricing } from '../services/people/pricing.js';
 import { deductCreditsBalance, incrementUsage } from '../services/usage-metering.js';
-import { resolveOrganizationId } from '../services/org-resolver.js';
 import { config } from '../config.js';
 import type { ProviderSlot } from '../services/people/types.js';
 
@@ -50,54 +52,72 @@ export async function peopleWebhookRoutes(app: FastifyInstance) {
       return reply.code(200).send({ ignored: true });
     }
 
-    // Option C: single-region lookup (v1 limitation documented above).
     const regions = listRuntimeRegions();
     if (regions.length === 0) {
       req.log.warn('[people-webhook] no runtime regions configured — ignoring');
       return reply.code(200).send({ ignored: true });
     }
 
-    // Fix 1: runtimePoolFor can throw (uninitialized pool, misconfigured region).
-    // Wrap it so a throw returns 200 before any idempotent claim fires — stopping
-    // People retries without leaving a dangling pending row.
-    let runtimePool: ReturnType<typeof runtimePoolFor>;
-    try {
-      runtimePool = runtimePoolFor(regions[0]);
-    } catch (err) {
-      req.log.error({ err }, '[people-webhook] runtimePoolFor failed — ignoring');
-      return reply.code(200).send({ ignored: true });
-    }
-
-    // Locate the pending lookup row by nonce.  Include provider_slot so we can
-    // parse the credit header before the atomic claim UPDATE.
-    let lookupRow: {
+    // Probe every runtime region for the nonce, not just the first.
+    // people_email_lookups rows are written to the runtime DB of the app's OWN
+    // region, so a single-region probe strands every lookup belonging to an app
+    // homed anywhere else: the nonce is never found, we answer 200, the provider
+    // treats the callback as delivered, and the row stays 'pending' forever.
+    // Nonces are 32 random bytes, so the first region reporting a hit owns it.
+    interface LookupRow {
       id: string;
       app_id: string;
       user_id: string;
+      organization_id: string;
       normalized_url: string;
       provider_slot: string;
-    } | null = null;
+    }
 
-    try {
-      const find = await runtimePool.query<{
-        id: string;
-        app_id: string;
-        user_id: string;
-        normalized_url: string;
-        provider_slot: string;
-      }>(
-        `SELECT id, app_id, user_id, normalized_url, provider_slot
+    const SELECT_BY_NONCE = `SELECT id, app_id, user_id, organization_id, normalized_url, provider_slot
            FROM people_email_lookups
-           WHERE nonce = $1`,
-        [nonce],
-      );
-      if (find.rows.length === 0) {
-        req.log.info({ nonce }, '[people-webhook] unknown nonce — ignoring');
-        return reply.code(200).send({ ignored: true });
+           WHERE nonce = $1`;
+
+    let runtimePool: ReturnType<typeof runtimePoolFor> | null = null;
+    let lookupRow: LookupRow | null = null;
+    // Tracks regions we could not read.  A region that errored may well hold the
+    // nonce, so "not found" is only trustworthy once every region answered.
+    let unreadableRegion = false;
+
+    for (const region of regions) {
+      // runtimePoolFor throws on a misconfigured/uninitialized region. That is a
+      // deployment fault rather than a transient one — retrying will not fix it,
+      // so skip the region without forcing the provider into a retry loop.
+      let pool: ReturnType<typeof runtimePoolFor>;
+      try {
+        pool = runtimePoolFor(region);
+      } catch (err) {
+        req.log.error({ err, region }, '[people-webhook] runtimePoolFor failed — skipping region');
+        continue;
       }
-      lookupRow = find.rows[0];
-    } catch (err) {
-      req.log.error({ err, nonce }, '[people-webhook] DB nonce lookup failed — ignoring');
+
+      try {
+        const find = await pool.query<LookupRow>(SELECT_BY_NONCE, [nonce]);
+        if (find.rows.length > 0) {
+          runtimePool = pool;
+          lookupRow = find.rows[0];
+          break;
+        }
+      } catch (err) {
+        // Transient read failure: we genuinely do not know if this region holds
+        // the nonce, so we must not conclude "unknown" from its silence.
+        unreadableRegion = true;
+        req.log.error({ err, nonce, region }, '[people-webhook] DB nonce lookup failed — region inconclusive');
+      }
+    }
+
+    if (!lookupRow || !runtimePool) {
+      if (unreadableRegion) {
+        // Answering 200 here would discard a resolvable callback exactly the way
+        // the cross-region bug did.  503 asks the provider to deliver it again.
+        req.log.warn({ nonce }, '[people-webhook] nonce unresolved with an unreadable region — asking for retry');
+        return reply.code(503).send({ error: 'lookup_unavailable' });
+      }
+      req.log.info({ nonce }, '[people-webhook] unknown nonce in every region — ignoring');
       return reply.code(200).send({ ignored: true });
     }
 
@@ -169,14 +189,17 @@ export async function peopleWebhookRoutes(app: FastifyInstance) {
         : 0;
       let usdCharged = 0;
 
+      // Bill the org stamped on the lookup row at queue time — the app's owning
+      // org.  deductCreditsBalance keys on organizations.id, so passing a user id
+      // matches zero rows and silently charges nothing for every team org.
+      const organizationId = lookupRow.organization_id;
+
       if (usdCost > 0) {
-        usdCharged = await deductCreditsBalance(app.controlDb, lookupRow.user_id, usdCost);
-        const organizationId = await resolveOrganizationId(app.controlDb, lookupRow.user_id);
+        usdCharged = await deductCreditsBalance(app.controlDb, organizationId, usdCost);
         await incrementUsage(organizationId, lookupRow.user_id, 'people_credits', credits, lookupRow.app_id);
       }
 
       // Audit row.  Use actual key_type from the lookup row (not hardcoded 'platform').
-      const organizationId = await resolveOrgFromApp(runtimePool, lookupRow.app_id);
       await runtimePool.query(
         `INSERT INTO people_usage_logs
            (app_id, organization_id, user_id, action, credits_consumed, usd_cost, usd_charged,


### PR DESCRIPTION
## What was broken

Async People email lookups never completed for any app homed outside the first configured runtime region. In production that is **596 lookups stranded in `us-west-2`, zero ever resolved, going back to 2026-07-16**, while `us-east-1` resolved normally (177 resolved / 160 failed / 0 pending).

`people_email_lookups` rows are written to the runtime DB of the app's **own** region, but the webhook receiver only ever queried `listRuntimeRegions()[0]`. So the nonce was never found, we answered `200 {ignored}`, the provider treated the callback as delivered and never retried, and the row stayed `pending` forever — after the queue call had already charged the customer.

Customer impact traced: `app_0lt2lsv9kpl7` queued 263 lookups, got 0 emails, and was billed $15.91.

## Fixes

**1. Probe every region for the nonce.** Nonces are 32 random bytes, so the first region reporting a hit owns the row.

**2. Distinguish "absent" from "unreadable".** A region that errors may well hold the nonce, so concluding "unknown nonce" from its silence is what discards a resolvable callback. Now:
- found → claim it in the region that holds it
- cleanly absent everywhere → `200 {ignored}` (unchanged)
- any region unreadable → **503**, so the provider redelivers
- region that cannot be constructed → deployment fault, not transient; skipped without forcing a retry loop

**3. Stop double-charging at resolve time.** The webhook fell back to `fallbackCreditsPerAction` when the callback carried no credit-cost header. The callback is the provider calling us — not a billable request we made — and it never carries that header, so the fallback fired on every resolve. The queue call already charges the real cost from its own response header (3 credits, the vendor's published price), so customers were billed 6 credits for one 3-credit lookup. Production confirms it: every webhook-path row is exactly 3 credits, never a header-derived value.

**4. Bill the right org.** Resolve-time billing passed `user_id` into `deductCreditsBalance(db, organizationId, …)`, which matches zero rows and silently charges nothing for every team org. It now bills the `organization_id` stamped on the lookup row at queue time, consistent with `people.ts`.

Fixes 3 and 4 must land together: the org-id bug was masking the double-charge, so correcting the billing target alone would have switched on a real 2x overcharge for every team org.

## Testing

- 9 new tests, each written before the fix and watched fail for the right reason.
- `people-webhook.test.ts`: 24/24.
- Per-commit: 21/21 at the region fix, 24/24 at the billing fix — each commit green on its own surface.
- Routes suite unchanged against baseline: 17 pre-existing failures before and after, passing 272 -> 281.
- `tsc --noEmit` clean; production image builds; container boots with runtime-table audits passing; the changed route was exercised in a real container and correctly probed both configured regions.

Four existing tests leaned on the phantom fallback to produce any charge at all. They were given an explicit `x-cost` header rather than weakened, so they still test org targeting and single-charge-under-concurrency.

## Follow-up (not in this PR)

- 596 stranded rows need re-queuing (391 distinct URLs after dedup); the original callbacks are gone.
- $36.05 in credits to refund across three orgs.
- Open question: whether the vendor refunds the 3 credits on a lookup that resolves to no email. We charge full price at queue for those (161 rows in us-east-1). Needs their API logs to settle.