### PR TITLE
Operator: let it deploy the functions it writes

### DIFF
--- a/services/control-api/src/services/dashboard-agent/__tests__/function-http.test.ts
+++ b/services/control-api/src/services/dashboard-agent/__tests__/function-http.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `function-http.ts` — the operator's function-deploy transport.
+ *
+ * Two things are being pinned, and only one of them is the happy path.
+ *
+ * The FUNCTIONAL half: the single call `deploy-function.ts` makes must reach
+ * `POST /v1/:appId/functions` with `app_id` lifted into the path and the rest
+ * of the payload intact. The pass-through is the part with teeth — the route's
+ * `deployFunctionSchema` already accepts `envVars`, `timeoutMs`,
+ * `memoryLimitMb` and the SINGULAR `trigger` under exactly those names, so any
+ * "helpful" reshaping here would fight a shim the route already performs.
+ *
+ * The SECURITY half: this object routes around `turnMcp`, the loop's policy
+ * gate. Its safety rests entirely on being narrow — one tool. If it ever
+ * answers a second thing, it stops being a deploy transport and becomes a
+ * general-purpose hole through which any caller reaches any tool with the
+ * org's key and no policy check. That test is not ceremony; it is the control.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createHttpFunctionMcp } from '../function-http.js';
+
+const JWT = 'bb_sk_test';
+const APP = 'app_1234';
+
+function fakeFetch(respond: (url: string, init: any) => { status?: number; body?: unknown } = () => ({})) {
+  const calls: { url: string; method: string; body: any; auth: string | undefined }[] = [];
+  const impl = vi.fn(async (url: any, init: any = {}) => {
+    const r = respond(String(url), init);
+    calls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      body: init.body ? JSON.parse(init.body) : undefined,
+      auth: init.headers?.authorization,
+    });
+    const status = r.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (r.body === undefined ? '' : JSON.stringify(r.body)),
+    } as unknown as Response;
+  });
+  return { impl, calls };
+}
+
+const ARGS = {
+  app_id: APP,
+  name: 'conflicts_check',
+  code: 'export async function handler() {}',
+  trigger: { type: 'http', config: { method: 'POST', auth: 'none' } },
+};
+
+describe('deploy_function over HTTP', () => {
+  it('posts to the app-scoped functions route with the org credential', async () => {
+    const { impl, calls } = fakeFetch(() => ({ body: { id: 'fn_1', url: 'https://api/fn/conflicts_check' } }));
+    const mcp = createHttpFunctionMcp({ baseUrl: 'https://api.test', fetchImpl: impl });
+
+    const out = (await mcp.call('deploy_function', ARGS, JWT)) as any;
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(`https://api.test/v1/${APP}/functions`);
+    expect(calls[0].auth).toBe(`Bearer ${JWT}`);
+    // `deploy-function.ts` reads exactly these two fields off the result.
+    expect(out).toEqual({ id: 'fn_1', url: 'https://api/fn/conflicts_check' });
+  });
+
+  it('lifts app_id into the path and passes everything else through untouched', async () => {
+    const { impl, calls } = fakeFetch(() => ({ body: { id: 'fn_1' } }));
+    const mcp = createHttpFunctionMcp({ baseUrl: 'https://api.test', fetchImpl: impl });
+
+    await mcp.call('deploy_function', { ...ARGS, envVars: { A: '1' }, timeoutMs: 5000, memoryLimitMb: 256 }, JWT);
+
+    expect(calls[0].body).toEqual({
+      name: 'conflicts_check',
+      code: ARGS.code,
+      // Singular `trigger` survives: the ROUTE shims it to a one-element
+      // `triggers` array, and doing it here too would be a second shim to keep
+      // in sync.
+      trigger: ARGS.trigger,
+      envVars: { A: '1' },
+      timeoutMs: 5000,
+      memoryLimitMb: 256,
+    });
+    expect(calls[0].body).not.toHaveProperty('app_id');
+  });
+
+  it('surfaces the status and body when the route rejects the deploy', async () => {
+    const { impl } = fakeFetch(() => ({ status: 400, body: { error: 'entry file not found' } }));
+    const mcp = createHttpFunctionMcp({ baseUrl: 'https://api.test', fetchImpl: impl });
+
+    // Must throw rather than return a falsy result: `deploy-function.ts` wraps
+    // this in try/catch to produce {ok:false,error}, and a silent success would
+    // report a function as live that was never deployed.
+    await expect(mcp.call('deploy_function', ARGS, JWT)).rejects.toThrow(/400.*entry file not found/);
+  });
+
+  it('requires app_id, rather than posting to a malformed path', async () => {
+    const { impl, calls } = fakeFetch();
+    const mcp = createHttpFunctionMcp({ baseUrl: 'https://api.test', fetchImpl: impl });
+
+    await expect(mcp.call('deploy_function', { name: 'x', code: 'y' }, JWT)).rejects.toThrow(/app_id is required/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('the blast radius', () => {
+  /**
+   * The control for the whole file. This transport carries the org's key and
+   * performs no policy check, so "one tool only" is the entire security
+   * argument.
+   */
+  it.each(['manage_app', 'deploy_frontend', 'manage_repo', 'manage_substrate'])(
+    'refuses %s — it serves deploy_function only',
+    async (tool) => {
+      const { impl, calls } = fakeFetch();
+      const mcp = createHttpFunctionMcp({ baseUrl: 'https://api.test', fetchImpl: impl });
+
+      await expect(mcp.call(tool, { app_id: APP }, JWT)).rejects.toThrow(/serves deploy_function only/);
+      expect(calls).toHaveLength(0);
+    },
+  );
+});

--- a/services/control-api/src/services/dashboard-agent/function-http.ts
+++ b/services/control-api/src/services/dashboard-agent/function-http.ts
@@ -1,0 +1,121 @@
+/**
+ * The function deployer's transport, for AUTONOMOUS OPERATOR turns.
+ *
+ * THE BUG THIS EXISTS TO FIX
+ * --------------------------
+ * `deploy-function.ts` reaches the deploy pipeline through the `deploy_function`
+ * MCP tool. On an operator turn that goes through `turnMcp` (loop.ts), which
+ * admits only an 'allow' verdict — and `deploy_function` sits at 'approval' in
+ * the operator tool table. So the call is refused.
+ *
+ * Refused at EVERY setting of `yolo_mode`, which is the part that makes this
+ * hard to spot. `yolo_mode` promotes 'approval' to 'allow' only where a context
+ * is supplied, and `turnMcp` deliberately does not supply one. So the operator
+ * could be fully pre-authorised and this would still fail.
+ *
+ * The shape of the failure is worth stating, because it reads as a policy
+ * decision rather than a bug: the OUTER tool the model calls,
+ * `deploy_function_from_workspace`, is itself 'approval' and IS promoted at the
+ * dispatch site — so it runs, gets as far as `functionDeployer.deploy`, and
+ * only then hits the strict wrapper on the inner call. The model sees
+ * `Tool "deploy_function" is not permitted for the autonomous operator` in
+ * response to a tool it never named.
+ *
+ * Observed in production 2026-08-10: an operator read the firm's tickets,
+ * wrote a conflicts check, and could not deploy it — twice in one turn.
+ *
+ * WHY THIS SHAPE — an `Mcp`-shaped adapter rather than a policy change
+ * -------------------------------------------------------------------
+ * This is the third instance of one bug. `repo-http.ts` did it for
+ * `manage_repo`, `frontend-http.ts` for `manage_frontend`, and this file for
+ * `deploy_function`; all three are deliberately the same shape so they read as
+ * one pattern rather than three ad-hoc escapes. The fix is NOT to widen the
+ * policy — `deploy_function` stays at 'approval', `turnMcp` is untouched — but
+ * to stop needing MCP for what is really an internal step of an already
+ * approved action.
+ *
+ * `deploy-function.ts` is not modified: it keeps calling
+ * `mcp.call('deploy_function', …)`, and this object answers over HTTP. The
+ * deploy ORCHESTRATION (workspace hydration, entry-file lookup, progress
+ * events) stays in one place for both the human assistant and the operator,
+ * instead of forking into two copies that can drift.
+ *
+ * WHY IT IS SAFE TO ROUTE AROUND `turnMcp` HERE
+ * ---------------------------------------------
+ * Authorization does not move. `POST /v1/:appId/functions` runs the same
+ * `requireUserId` + app-resolution the human dashboard's own deploys depend on,
+ * and the credential is the org's `bb_sk_*` already carried by this turn. What
+ * is bypassed is only the operator's INTERNAL tool table — a gate meant for
+ * calls the loop makes on its own behalf, not for the implementation of a tool
+ * call the model made and policy already approved.
+ *
+ * The blast radius is one tool: anything other than `deploy_function` throws.
+ */
+/**
+ * Structural, not imported: `loop.ts` declares `Mcp` locally and does not
+ * export it, and `repo-http.ts` / `frontend-http.ts` both restate it here for
+ * the same reason. Keeping the three identical is what makes them one pattern.
+ */
+type Mcp = { call(name: string, args: unknown, jwt: string): Promise<any> }
+
+/**
+ * Same resolution order and rationale as `repo-http.ts`'s `defaultBaseUrl` —
+ * see that file's header for why this must be the public anycast host on Fly
+ * rather than a loopback (`plugins/fly-replay.ts` has to see the request to
+ * redirect it to the app's home region).
+ */
+function defaultBaseUrl(): string {
+  return process.env.CONTROL_API_URL ?? process.env.PUBLIC_API_URL ?? 'http://localhost:4000'
+}
+
+export type HttpFunctionDeps = {
+  baseUrl?: string
+  /** Injectable for tests. Production uses global `fetch`. */
+  fetchImpl?: typeof fetch
+}
+
+export function createHttpFunctionMcp(deps: HttpFunctionDeps = {}): Mcp {
+  const baseUrl = (deps.baseUrl ?? defaultBaseUrl()).replace(/\/+$/, '')
+  const doFetch = deps.fetchImpl ?? fetch
+
+  return {
+    async call(name: string, args: unknown, jwt: string) {
+      if (name !== 'deploy_function') {
+        throw new Error(`function-http: refusing "${name}" — this transport serves deploy_function only`)
+      }
+      const a = (args ?? {}) as Record<string, any>
+      const appId: string = a.app_id
+      if (!appId) throw new Error('function-http: app_id is required')
+
+      /**
+       * `app_id` moves into the path; everything else passes through unchanged.
+       *
+       * No snake/camel translation is needed here (unlike `frontend-http.ts`):
+       * `deployFunctionSchema` already takes `envVars`, `timeoutMs` and
+       * `memoryLimitMb` under exactly the names `deploy-function.ts` sends, and
+       * accepts the SINGULAR `trigger` — the route shims it to a one-element
+       * `triggers` array itself. Reshaping it here would duplicate that shim
+       * and give it a second place to drift from.
+       */
+      const { app_id: _omit, ...body } = a
+
+      const res = await doFetch(`${baseUrl}/v1/${encodeURIComponent(appId)}/functions`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${jwt}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      // Text first: error bodies are not always JSON, and an empty body would
+      // make res.json() throw with a message that hides the status the caller
+      // actually needs.
+      const text = await res.text()
+      if (!res.ok) {
+        throw new Error(`function deploy failed (${res.status}): ${text.slice(0, 500)}`)
+      }
+      let parsed: any = null
+      if (text) { try { parsed = JSON.parse(text) } catch { parsed = null } }
+      // `deploy-function.ts` reads `{ id, url }` off the result; the route
+      // returns both at the top level, so this passes straight through.
+      return parsed
+    },
+  }
+}

--- a/services/control-api/src/services/dashboard-agent/loop.ts
+++ b/services/control-api/src/services/dashboard-agent/loop.ts
@@ -43,6 +43,7 @@ import { createFileOps, type FileOpName } from './file-ops.js';
 import { createRepoSync, type RepoSync } from './repo-sync.js';
 import { createHttpRepoSync } from './repo-http.js';
 import { createHttpFrontendMcp } from './frontend-http.js';
+import { createHttpFunctionMcp } from './function-http.js';
 import { createDeployer } from './deploy.js';
 import { createFunctionDeployer } from './deploy-function.js';
 import { loadTemplate as loadTemplateDefault } from './template-loader.js';
@@ -914,8 +915,16 @@ export async function* runAgentTurn(
         onDeploymentProgress: (evt) => emit({ type: 'deployment_progress', ...evt }),
       });
 
+  /**
+   * On an operator turn the inner `deploy_function` call goes over HTTP, not
+   * MCP — see `function-http.ts` for why `turnMcp` refuses it at every setting
+   * of `yolo_mode`, and why widening the policy is the wrong fix. Same branch
+   * the frontend deployer takes a few lines above.
+   */
+  const functionMcp: Mcp = isOperator ? createHttpFunctionMcp() : turnMcp;
+
   // createFunctionDeployer's Mcp contract never throws (returns {ok:false,error}
-  // instead) — deps.mcp (the loop's default) throws on failure, so adapt it here.
+  // instead) — both transports above throw on failure, so adapt here.
   const functionDeployer = deps.functionDeployerFactory
     ? deps.functionDeployerFactory(emit)
     : createFunctionDeployer({
@@ -923,7 +932,7 @@ export async function* runAgentTurn(
         mcp: {
           async call(name: string, args: unknown, jwt: string) {
             try {
-              const result = await turnMcp.call(name, args, jwt);
+              const result = await functionMcp.call(name, args, jwt);
               return { ok: true as const, result };
             } catch (e) {
               return { ok: false as const, error: e instanceof Error ? e.message : String(e) };


### PR DESCRIPTION
## The bug

`deploy_function_from_workspace` could never succeed on an autonomous operator turn.

The outer tool sits at `'approval'` and **is** promoted at the dispatch site, so it runs — then `functionDeployer` makes its inner `deploy_function` call through `turnMcp`, which admits only a literal `'allow'` and deliberately passes no yolo context. The model saw:

```
Tool "deploy_function" is not permitted for the autonomous operator
```

in response to a tool it never named, at **every** setting of `yolo_mode`.

Observed in production 2026-08-10: an operator read a law firm's support tickets, wrote a conflicts check, and failed to ship it twice in one turn.

## The fix

Third instance of one bug — `repo-http.ts` fixed it for `manage_repo`, `frontend-http.ts` for `manage_frontend`, and `function-http.ts` does it for `deploy_function`. Same shape deliberately, so the three read as one pattern rather than three ad-hoc escapes.

- Policy is **not** widened: `deploy_function` stays at `'approval'`, `turnMcp` untouched
- Authorization does not move: `POST /v1/:appId/functions` runs the same `requireUserId` + app resolution the human dashboard's deploys use, with the org's `bb_sk_*` the turn already carries
- What is bypassed is the operator's *internal* tool table — a gate for calls the loop makes on its own behalf, not for the implementation of a tool call the model made and policy already approved
- `deploy-function.ts` is unmodified, so deploy orchestration stays in one place for both the assistant and the operator

## Tests

8 new, covering the route/credential/pass-through and — the important half — that the transport refuses every tool except `deploy_function`. That narrowness is the entire security argument for routing around the gate.

Pre-existing failures in this suite (48) are integration tests needing a local Postgres; identical on a clean tree.