### PR TITLE
Read the deployment status the platform actually writes

### DIFF
--- a/services/control-api/src/services/dashboard-agent/__tests__/deploy.test.ts
+++ b/services/control-api/src/services/dashboard-agent/__tests__/deploy.test.ts
@@ -106,3 +106,76 @@ describe('deploy_frontend — a throwing mcp is a failed deploy, not a failed tu
     expect(r.ok === false && r.error).toMatch(/manage_frontend/)
   })
 })
+
+/**
+ * THE STATUS VOCABULARY, pinned against the producer rather than against what
+ * this file used to assume.
+ *
+ * The tests above poll `'live'` and `'failed'`. Nothing in the platform ever
+ * writes those: `build-driver.service.ts` sets 'READY' on success and 'ERROR'
+ * on failure, and `GET /v1/:appId/frontend/deployments` passes
+ * `app_deployments.status` through verbatim. So for as long as the poll
+ * compared against the lowercase pair, it could not recognise a terminal state
+ * at ALL — every real deploy ran the full timeout and returned "did not reach
+ * a terminal status", whether the build had gone live or died in 8 seconds.
+ *
+ * The suite stayed green throughout, because it fed the code the same
+ * invented vocabulary the code was checking for. That is the specific way this
+ * bug survived: the mock agreed with the bug instead of with production.
+ *
+ * These cases use the REAL values and would have failed before the fix. Keep
+ * the lowercase ones above too — the poll accepts both now, and a deploy path
+ * that silently stopped honouring one of them should fail loudly here.
+ */
+describe('terminal status detection (real platform vocabulary)', () => {
+  const okFetch = () => vi.fn(async () => new Response('', { status: 200 }) as any) as any
+
+  async function deployWith(statusRow: Record<string, unknown>) {
+    const cache = new WorkingTreeCache()
+    cache.write(CONV, APP, 'package.json', '{}')
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = okFetch()
+    const mcp = makeMcp({
+      create_from_source: () => ({ deployment_id: 'dep_x', upload_url: 'https://s3/put' }),
+      start_from_source: () => ({ deployment_id: 'dep_x', status: 'WAITING' }),
+      list_deployments: () => ({ deployments: [{ id: 'dep_x', ...statusRow }] }),
+    })
+    try {
+      const d = createDeployer({ cache, mcp, onDeploymentProgress: () => {}, pollIntervalMs: 1, maxWaitMs: 200 })
+      return await d.deploy({ convId: CONV, appId: APP, jwt: JWT })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  }
+
+  it('treats READY as success and returns the url', async () => {
+    expect(await deployWith({ status: 'READY', url: 'https://x.butterbase.dev' })).toMatchObject({
+      ok: true, deployment_id: 'dep_x', url: 'https://x.butterbase.dev',
+    })
+  })
+
+  it('treats ERROR as failure rather than waiting out the whole window', async () => {
+    expect(await deployWith({ status: 'ERROR', error: 'BUILD_NONZERO_EXIT' })).toMatchObject({
+      ok: false, error: 'BUILD_NONZERO_EXIT',
+    })
+  })
+
+  it('surfaces error_message when the row carries that instead of error', async () => {
+    // The deployments route has used both spellings; reporting "build failed"
+    // when a real reason was available is what sent the operator looking for a
+    // bug in its own source.
+    expect(await deployWith({ status: 'ERROR', error_message: 'npm ERR! missing script: build' })).toMatchObject({
+      ok: false, error: 'npm ERR! missing script: build',
+    })
+  })
+
+  it('still reports a genuine timeout when the build never terminates', async () => {
+    const r = await deployWith({ status: 'BUILDING' });
+    expect(r).toMatchObject({ ok: false });
+    expect((r as any).error).toMatch(/did not reach a terminal status/);
+    // The old text told the caller to "check list_deployments", which no
+    // operator-reachable tool can do; following it cost a turn to a validation
+    // error on 2026-08-10.
+    expect((r as any).error).not.toMatch(/list_deployments/);
+  })
+})

--- a/services/control-api/src/services/dashboard-agent/deploy.ts
+++ b/services/control-api/src/services/dashboard-agent/deploy.ts
@@ -4,7 +4,18 @@ import type { WorkingTreeCache } from './working-tree.js'
 
 export type DeploymentProgressEvent = {
   deployment_id: string
-  status: 'queued' | 'building' | 'live' | 'failed'
+  /**
+   * Whatever `app_deployments.status` holds, passed through verbatim — in
+   * practice WAITING / BUILDING / READY / ERROR.
+   *
+   * Deliberately widened to `string` from the old
+   * `'queued'|'building'|'live'|'failed'` union, which described a vocabulary
+   * nothing in this system produces. That union was not merely unused: it made
+   * the wrong values look SANCTIONED, and the poll below was written to match
+   * it. A narrow type that disagrees with its producer is worse than no type,
+   * because it moves the bug from "obviously untyped" to "apparently checked".
+   */
+  status: string
   url?: string
   log_tail?: string
   error?: string
@@ -23,24 +34,25 @@ export type DeployDeps = {
 export function createDeployer(deps: DeployDeps) {
   const pollMs = deps.pollIntervalMs ?? 3000
   /**
-   * 15 minutes, raised from 5.
+   * 15 minutes, raised from 5 on 2026-08-09.
    *
-   * WHY. A frontend build is `npm install` plus a bundle in a cold container,
-   * and on 2026-08-09 three consecutive operator builds landed 5-6 minutes
-   * after being started — just outside the old window. Every one of them
-   * reached READY. The operator was told each had "timed out", so it deployed
-   * again, and again, until the duplicate-call guard ended the turn with a
-   * half-shipped feature: a conflicts UI live on the site with no backend
-   * function behind it, 404ing on use.
+   * THAT RAISE WAS A MISDIAGNOSIS, and it is left here as a worked example
+   * rather than quietly corrected. The symptom was real — operator builds
+   * reaching READY while the tool reported a timeout — but the cause was not
+   * impatience. The poll below compared `row.status` against 'live'/'failed',
+   * two values nothing in this system ever writes, so it could not recognise a
+   * terminal state at any window length. Widening it only made each doomed
+   * deploy waste 15 minutes instead of 5.
    *
-   * That is the failure mode a too-short poll produces here — not a lost
-   * deploy, but a SUCCESSFUL deploy reported as a failure to an agent whose
-   * natural response is to start another one. The cost of waiting longer is a
-   * slower turn; the cost of waiting too little is redundant builds and a
-   * corrupted deploy history.
+   * The lesson worth keeping: "a build that succeeded was reported as a
+   * timeout" is evidence that the poll cannot READ the outcome, and the first
+   * thing to check is the status vocabulary, not the clock. The actual fix is
+   * at the comparison itself.
    *
-   * Still bounded, because unbounded would hang a turn forever on a build that
-   * genuinely died. If this fires now it means something is actually wrong.
+   * The window still earns its size independently — a frontend build is
+   * `npm install` plus a bundle in a cold container, and 5-6 minutes is
+   * ordinary. It stays bounded because unbounded would hang a turn forever on
+   * a build that genuinely died.
    */
   const maxMs = deps.maxWaitMs ?? 15 * 60 * 1000
 
@@ -111,15 +123,50 @@ export function createDeployer(deps: DeployDeps) {
           log_tail: row.log_tail,
           error: row.error,
         })
-        if (row.status === 'live') return { ok: true as const, deployment_id, url: row.url }
-        if (row.status === 'failed') return { ok: false as const, error: row.error ?? 'build failed' }
+        /**
+         * MATCHED CASE-INSENSITIVELY AND IN BOTH VOCABULARIES, because these
+         * two lines used to read `=== 'live'` and `=== 'failed'` and NEITHER
+         * COULD EVER BE TRUE.
+         *
+         * `row.status` is `app_deployments.status` passed through verbatim by
+         * `GET /v1/:appId/frontend/deployments`, and the only values anything
+         * writes there are WAITING / BUILDING / READY / ERROR — see
+         * `build-driver.service.ts` (READY on success, ERROR on failure) and
+         * `deployment.service.ts`. The lowercase pair was a vocabulary that
+         * exists nowhere in the system.
+         *
+         * So the loop was unreachable on BOTH branches: every deploy ran the
+         * full `maxMs` and returned the timeout string below, whether the build
+         * had succeeded, failed, or was still going. The operator was told
+         * "timed out" for builds that had already failed in 8 seconds.
+         *
+         * This is also why raising `maxMs` from 5 to 15 minutes changed
+         * nothing. That edit was made on 2026-08-09 against exactly this
+         * symptom and misdiagnosed it as a too-short window — see the comment
+         * on `maxMs`, which is preserved above with its correction, because the
+         * reasoning in it is the trap: "builds reached READY but we reported a
+         * timeout" is evidence of a status the poll cannot recognise, not of a
+         * poll that is too impatient.
+         */
+        const status = String(row.status ?? '').toUpperCase()
+        if (status === 'READY' || status === 'LIVE') return { ok: true as const, deployment_id, url: row.url }
+        if (status === 'ERROR' || status === 'FAILED') {
+          return { ok: false as const, error: row.error ?? row.error_message ?? 'build failed' }
+        }
       }
       return {
         ok: false as const,
         error:
+          // Does NOT tell the caller to "check list_deployments": the operator
+          // has no tool that can. `manage_frontend` is deliberately unlisted
+          // for operator turns and `manage_app` has no such action, so the
+          // advice produced a guaranteed validation error — observed
+          // 2026-08-10, the model tried it and got
+          // `invalid_enum_value: "received": "list_deployments"`. Advice a
+          // reader cannot follow is worse than none; it costs a turn.
           `deployment did not reach a terminal status within ${Math.round(maxMs / 60000)} minutes. ` +
-          `It may still be building — check list_deployments before deploying again, ` +
-          `because starting another build does not cancel this one.`,
+          `It may still be building. Do NOT start another build — that does not cancel this one, ` +
+          `and two builds racing on the same app is how a half-shipped deploy happens.`,
       }
   }
 

--- a/services/control-api/src/services/dashboard-agent/loop.ts
+++ b/services/control-api/src/services/dashboard-agent/loop.ts
@@ -64,7 +64,11 @@ export type LoopEvent =
   | { type: 'error'; message: string; code?: string; availableUsd?: number; requiredUsd?: number }
   | { type: 'file_change'; app_id: string; path: string; kind: 'write' | 'delete'; content?: string; sha256?: string }
   | { type: 'active_app_change'; app_id: string; app_name?: string }
-  | { type: 'deployment_progress'; deployment_id: string; status: 'queued' | 'building' | 'live' | 'failed'; url?: string; log_tail?: string; error?: string }
+  // `status` is `app_deployments.status` verbatim — WAITING / BUILDING /
+  // READY / ERROR. It was typed 'queued'|'building'|'live'|'failed', a
+  // vocabulary nothing writes; see DeploymentProgressEvent in deploy.ts for
+  // the poll bug that union helped hide.
+  | { type: 'deployment_progress'; deployment_id: string; status: string; url?: string; log_tail?: string; error?: string }
   | { type: 'function_deployment_progress'; function_name: string; status: 'queued' | 'uploading' | 'live' | 'failed'; url?: string; error?: string }
   | { type: 'approval_required'; approval_id: string; tool_name: string; args: unknown; sensitivity: 'confirm' | 'destructive' }
   | { type: 'title_updated'; title: string };


### PR DESCRIPTION
## The bug

The frontend deploy poll compared `row.status` against `'live'` / `'failed'`. Nothing writes those:

```
build-driver.service.ts:203   SET status = 'READY'
build-driver.service.ts:234   SET status = 'ERROR'
```

Both branches unreachable → **every** frontend deploy burned the full window and returned `"did not reach a terminal status"`, regardless of what actually happened.

Observed 2026-08-10: an operator's two builds both failed with `BUILD_NONZERO_EXIT` in under 8 seconds; both were reported to it as timeouts. It could not learn its build was broken, so it retried into the same wall.

This is also why raising `maxWaitMs` 5 → 15 min on 2026-08-09 changed nothing — that edit targeted this exact symptom and misdiagnosed it as impatience.

## Changes

- Match `READY`/`ERROR` case-insensitively (still accepting `live`/`failed`), and fall back to `error_message`
- Widen `DeploymentProgressEvent.status` and the `LoopEvent` variant from the invented union to `string`. A narrow type that disagrees with its producer is worse than none — it made the wrong values look sanctioned, and the poll was written to match the *type* rather than the data
- Drop the "check `list_deployments`" advice on timeout: no operator-reachable tool can do that, and following it cost a turn to an enum validation error

## Tests

4 new cases using the real vocabulary — **they fail against the old code**. The 3 existing cases pass either way, which is exactly how this survived: the suite fed the code the same invented vocabulary the code was checking for.