### PR TITLE
Show the model the argument schemas the server validates

### DIFF
--- a/services/control-api/src/services/dashboard-agent/__tests__/mcp-tool-schemas.test.ts
+++ b/services/control-api/src/services/dashboard-agent/__tests__/mcp-tool-schemas.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `mcp-tool-schemas.ts` — real argument schemas, fetched from the validator.
+ *
+ * The property under test is narrow but load-bearing: what the model is TOLD
+ * about a tool's arguments must come from the same place that REJECTS them.
+ * The hand-written catalog failed that in both directions — it omitted every
+ * required field except `action`, and advertised `action` as required on tools
+ * that reject it outright. The model obeyed the schema and was rejected for it,
+ * six times in one turn on `select_rows` alone.
+ *
+ * So the tests here are mostly about the FAILURE paths, because a schema
+ * fetcher that throws, or that caches an outage, is worse than the bug it
+ * replaces: it would take turns down rather than merely making them clumsy.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchMcpToolSchemas, applyMcpToolSchemas, __resetMcpToolSchemaCache } from '../mcp-tool-schemas.js';
+
+const JWT = 'bb_sk_test';
+
+const REAL_SELECT_ROWS = {
+  type: 'object',
+  properties: {
+    app_id: { type: 'string' },
+    table: { type: 'string' },
+    limit: { type: 'number' },
+  },
+  required: ['app_id', 'table'],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function sseResponse(body: unknown) {
+  const text = `event: message\ndata: ${JSON.stringify(body)}\n\n`;
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => 'text/event-stream' },
+    text: async () => text,
+    json: async () => {
+      throw new Error('should not call json() on an SSE response');
+    },
+  } as unknown as Response;
+}
+
+const okPayload = {
+  result: { tools: [{ name: 'select_rows', inputSchema: REAL_SELECT_ROWS }] },
+};
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  __resetMcpToolSchemaCache();
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __resetMcpToolSchemaCache();
+});
+
+describe('fetching', () => {
+  it('returns the schema the server validates against', async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse(okPayload)) as any;
+    const schemas = await fetchMcpToolSchemas(JWT);
+    expect(schemas.get('select_rows')).toEqual(REAL_SELECT_ROWS);
+  });
+
+  it('asks for tools/list with both accept types', async () => {
+    const spy = vi.fn(async () => jsonResponse(okPayload));
+    globalThis.fetch = spy as any;
+    await fetchMcpToolSchemas(JWT);
+    const init = spy.mock.calls[0][1] as any;
+    expect(JSON.parse(init.body).method).toBe('tools/list');
+    // StreamableHTTP answers 406 without both — the same trap callMcpTool hit.
+    expect(init.headers.accept).toContain('text/event-stream');
+    expect(init.headers.accept).toContain('application/json');
+    expect(init.headers.authorization).toBe(`Bearer ${JWT}`);
+  });
+
+  it('parses an SSE reply, because the transport may answer either way', async () => {
+    globalThis.fetch = vi.fn(async () => sseResponse(okPayload)) as any;
+    const schemas = await fetchMcpToolSchemas(JWT);
+    expect(schemas.get('select_rows')).toEqual(REAL_SELECT_ROWS);
+  });
+});
+
+describe('failure is never fatal', () => {
+  it.each([
+    ['a network error', async () => { throw new Error('ECONNREFUSED'); }],
+    ['a non-200', async () => jsonResponse({}, 503)],
+    ['a JSON-RPC error', async () => jsonResponse({ error: { message: 'nope' } })],
+    ['a malformed payload', async () => jsonResponse({ result: { tools: 'not-an-array' } })],
+  ])('returns an empty map on %s, rather than throwing', async (_label, impl) => {
+    globalThis.fetch = vi.fn(impl) as any;
+    await expect(fetchMcpToolSchemas(JWT)).resolves.toBeInstanceOf(Map);
+    expect((await fetchMcpToolSchemas(JWT)).size).toBe(0);
+  });
+
+  it('does not cache an empty result, so a blip is not pinned for the whole TTL', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('down'); }) as any;
+    expect((await fetchMcpToolSchemas(JWT)).size).toBe(0);
+
+    globalThis.fetch = vi.fn(async () => jsonResponse(okPayload)) as any;
+    expect((await fetchMcpToolSchemas(JWT)).get('select_rows')).toEqual(REAL_SELECT_ROWS);
+  });
+
+  it('caches a good result instead of refetching every turn', async () => {
+    const spy = vi.fn(async () => jsonResponse(okPayload));
+    globalThis.fetch = spy as any;
+    await fetchMcpToolSchemas(JWT);
+    await fetchMcpToolSchemas(JWT);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('overlaying onto the catalog', () => {
+  const HAND_WRITTEN = [
+    // Exactly what the catalog advertised, and exactly what the server rejects.
+    { name: 'select_rows', parameters: { type: 'object', properties: { action: { type: 'string' } }, required: ['action'], additionalProperties: true } },
+    { name: 'write_file', parameters: { type: 'object', properties: { path: { type: 'string' } } } },
+  ];
+
+  it('replaces the wrong hand-written schema with the real one', () => {
+    const out = applyMcpToolSchemas(HAND_WRITTEN, new Map([['select_rows', REAL_SELECT_ROWS]]));
+    expect(out.find((t) => t.name === 'select_rows')!.parameters).toEqual(REAL_SELECT_ROWS);
+  });
+
+  it('stops advertising `action` as required on a tool that rejects it', () => {
+    const out = applyMcpToolSchemas(HAND_WRITTEN, new Map([['select_rows', REAL_SELECT_ROWS]]));
+    const p = out.find((t) => t.name === 'select_rows')!.parameters as any;
+    // The precise defect: the model was told to send `action`, then rejected
+    // with "Unrecognized key(s) in object: action".
+    expect(p.required).not.toContain('action');
+    expect(p.required).toEqual(['app_id', 'table']);
+    expect(p.properties).not.toHaveProperty('action');
+  });
+
+  it('leaves loop-internal tools alone — they have no MCP counterpart', () => {
+    const out = applyMcpToolSchemas(HAND_WRITTEN, new Map([['select_rows', REAL_SELECT_ROWS]]));
+    expect(out.find((t) => t.name === 'write_file')!.parameters).toEqual(HAND_WRITTEN[1].parameters);
+  });
+
+  it('changes nothing when no schemas were fetched', () => {
+    expect(applyMcpToolSchemas(HAND_WRITTEN, new Map())).toEqual(HAND_WRITTEN);
+  });
+});

--- a/services/control-api/src/services/dashboard-agent/loop.ts
+++ b/services/control-api/src/services/dashboard-agent/loop.ts
@@ -44,6 +44,7 @@ import { createRepoSync, type RepoSync } from './repo-sync.js';
 import { createHttpRepoSync } from './repo-http.js';
 import { createHttpFrontendMcp } from './frontend-http.js';
 import { createHttpFunctionMcp } from './function-http.js';
+import { applyMcpToolSchemas, fetchMcpToolSchemas } from './mcp-tool-schemas.js';
 import { createDeployer } from './deploy.js';
 import { createFunctionDeployer } from './deploy-function.js';
 import { loadTemplate as loadTemplateDefault } from './template-loader.js';
@@ -160,6 +161,23 @@ export type LoopDeps = {
   fileOpsFactory?: (emit: (evt: LoopEvent) => void, ensureHydrated: (i: { convId: string; appId: string; jwt: string }) => Promise<void>) => ReturnType<typeof createFileOps>;
   deployerFactory?: (emit: (evt: LoopEvent) => void) => ReturnType<typeof createDeployer>;
   functionDeployerFactory?: (emit: (evt: LoopEvent) => void) => ReturnType<typeof createFunctionDeployer>;
+  /**
+   * Supplies the REAL argument schemas for MCP tools, replacing the
+   * hand-written ones in `tool-catalog.ts` — see `mcp-tool-schemas.ts` for the
+   * mismatch that motivates it.
+   *
+   * INJECTED RATHER THAN CALLED DIRECTLY, deliberately. It performs a network
+   * round-trip, and a turn must not acquire one that callers cannot see or
+   * control: the first version of this called `fetchMcpToolSchemas` inline and
+   * broke 96 tests, because it consumed responses their mocked `fetch` had
+   * queued for the model. That was a real signal, not test friction — an
+   * unannounced fetch in the hot path is exactly what an injected dependency
+   * exists to prevent.
+   *
+   * Omitted means "do not fetch": the hand-written catalog is used unchanged,
+   * which is the behaviour every existing caller already had.
+   */
+  toolSchemas?: (jwt: string) => Promise<Map<string, Record<string, unknown>>>;
   // Task 5 (Plan 3d): snapshot auto-naming. Tests can inject a stub gateway
   // and/or a spy for the store write; production builds a real gateway chat
   // client bound to the request's JWT and use the real store.upsertSnapshotLabel.
@@ -210,6 +228,19 @@ function getDefaultDeps(): LoopDeps {
       upsertSnapshotLabel,
       getConversation,
       updateConversationTitle,
+      /**
+       * Real MCP argument schemas, replacing the hand-written ones the model
+       * is otherwise shown — see `toolSchemas` on LoopDeps.
+       *
+       * BEHIND A FLAG, default off, for two reasons. It changes what EVERY
+       * agent turn is told about EVERY tool, which is a large blast radius for
+       * a correctness fix and deserves a deliberate rollout rather than
+       * arriving with a deploy. And it adds a network round-trip to the turn
+       * path, which the default deps must not impose on callers that never
+       * asked for it — including the whole test suite, which supplies its own
+       * `fetch` and had 96 tests broken by an unflagged version of this.
+       */
+      toolSchemas: process.env.MCP_REAL_TOOL_SCHEMAS === '1' ? fetchMcpToolSchemas : undefined,
     };
   }
   return _defaultDeps;
@@ -770,12 +801,27 @@ export async function* runAgentTurn(
   // thing that decides whether a turn with no sandbox can reach it. There is
   // no host-side build, and a build that ran in THIS process would execute the
   // customer's `postinstall` scripts on the control plane.
-  const tools = isOperator
+  const baseTools = isOperator
     ? getToolCatalog()
         .filter((t) => isOperatorToolAllowed(t.name))
         .filter((t) => t.name !== OPERATOR_SANDBOX_CODE_TOOL || typeof input.codeExecutor === 'function')
         .filter((t) => t.name !== OPERATOR_BUILD_TOOL || typeof input.buildExecutor === 'function')
     : getToolCatalog().filter((t) => t.operatorOnly !== true);
+
+  /**
+   * Replace the hand-written argument schemas with the ones the MCP server
+   * actually validates against — see `mcp-tool-schemas.ts` for the mismatch
+   * this fixes (most notably `required: ['action']` advertised on tools that
+   * reject an `action` argument outright).
+   *
+   * Degrades to `baseTools` on any failure, so an unreachable MCP server costs
+   * argument accuracy and never a turn. Loop-internal tools with no MCP
+   * counterpart — write_file, deploy_frontend, the scratchpad — keep their
+   * hand-written schema, which for them is the only source there is.
+   */
+  const tools = deps.toolSchemas
+    ? applyMcpToolSchemas(baseTools, await deps.toolSchemas(input.jwt))
+    : baseTools;
 
   /**
    * One line per operator turn recording what the model was actually offered.

--- a/services/control-api/src/services/dashboard-agent/mcp-tool-schemas.ts
+++ b/services/control-api/src/services/dashboard-agent/mcp-tool-schemas.ts
@@ -1,0 +1,160 @@
+/**
+ * The REAL argument schemas for MCP tools, fetched from the MCP server.
+ *
+ * THE BUG THIS EXISTS TO FIX
+ * --------------------------
+ * `tool-catalog.ts` hand-writes the `parameters` it advertises to the model,
+ * and for most tools that is `flatActionParams()`:
+ *
+ *     { properties: { action: {type:'string'} }, required: ['action'],
+ *       additionalProperties: true }
+ *
+ * Which is not merely thin — it is WRONG in both directions at once.
+ *
+ * It UNDER-SPECIFIES: `app_id`, `table`, `function_name`, `code` and every
+ * enum value appear nowhere in the schema, only as English in the description.
+ * The model has to infer them, and when it infers wrong the MCP server rejects
+ * the call.
+ *
+ * It also MIS-SPECIFIES: `required: ['action']` is advertised on tools that do
+ * not accept an `action` argument at all. `select_rows` is the clearest case —
+ * the schema says `action` is mandatory, the server answers
+ * `Unrecognized key(s) in object: action`. The model obeys the schema it was
+ * given and is punished for it, every single time.
+ *
+ * Measured on one operator turn (2026-08-10): six `select_rows` rejections for
+ * the unrecognised `action`, plus missing-field rejections on
+ * `invoke_function` (`function_name`), `deploy_function` (`code`) and
+ * `read_file` (`app_id`), plus invalid-enum rejections on `manage_substrate`
+ * and `manage_integrations`. Every one traced to this single helper.
+ *
+ * WHY FETCH RATHER THAN HAND-CORRECT
+ * ----------------------------------
+ * The MCP server already declares these as zod and validates against them, so
+ * it is the only source that cannot disagree with the validator. Hand-writing
+ * better schemas here would fix today's mismatches and start drifting the next
+ * time a tool gains a parameter — which is exactly how the current ones got
+ * wrong. `tools/list` returns the same JSON Schema the server enforces.
+ *
+ * FAILURE IS NON-FATAL BY DESIGN: every failure path returns an empty map and
+ * the caller keeps the hand-written catalog. A momentarily unreachable MCP
+ * server must degrade the model's argument accuracy, never break the turn.
+ */
+
+type JsonSchema = Record<string, unknown>;
+
+type CacheEntry = { at: number; schemas: Map<string, JsonSchema> };
+
+/**
+ * Process-local, with a TTL rather than forever. Tool schemas change only on
+ * an MCP server deploy, so a stale entry is harmless for minutes and a refetch
+ * every turn would add a round-trip to a hot path for no benefit.
+ */
+let cache: CacheEntry | null = null;
+const TTL_MS = 10 * 60 * 1000;
+
+/** Exposed for tests; production has no reason to call this. */
+export function __resetMcpToolSchemaCache(): void {
+  cache = null;
+}
+
+/**
+ * Parses both transports the MCP StreamableHTTP endpoint may answer with.
+ * Mirrors `callMcpTool`'s handling — the server MAY reply with SSE even for a
+ * single request, and a JSON-only reader silently fails against it.
+ */
+async function readRpcBody(res: Response): Promise<{ result?: unknown; error?: { message?: string } } | null> {
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.startsWith('text/event-stream')) {
+    return (await res.json()) as { result?: unknown; error?: { message?: string } };
+  }
+  const text = await res.text();
+  let jsonRpc: { result?: unknown; error?: { message?: string } } | null = null;
+  for (const frame of text.split(/\r?\n\r?\n/)) {
+    const dataLines = frame
+      .split(/\r?\n/)
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice(5).trimStart());
+    if (dataLines.length === 0) continue;
+    try {
+      const parsed = JSON.parse(dataLines.join('\n'));
+      if (parsed && typeof parsed === 'object' && ('result' in parsed || 'error' in parsed)) {
+        jsonRpc = parsed;
+      }
+    } catch {
+      /* heartbeats and other non-JSON frames */
+    }
+  }
+  return jsonRpc;
+}
+
+/**
+ * `name -> inputSchema` for every tool the MCP server advertises.
+ *
+ * Returns an EMPTY MAP on any failure — unreachable server, non-200, JSON-RPC
+ * error, malformed payload. Callers treat "no schema for this tool" as "keep
+ * the hand-written one", so an empty map is simply today's behaviour.
+ */
+export async function fetchMcpToolSchemas(jwt: string, now = Date.now()): Promise<Map<string, JsonSchema>> {
+  if (cache && now - cache.at < TTL_MS) return cache.schemas;
+
+  const url = `${process.env.MCP_SERVER_URL ?? 'http://localhost:3010'}/mcp`;
+  const schemas = new Map<string, JsonSchema>();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        // Both content types, or StreamableHTTP answers 406.
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${jwt}`,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+    if (!res.ok) return schemas;
+
+    const body = await readRpcBody(res);
+    if (!body || body.error) return schemas;
+
+    const tools = (body.result as { tools?: unknown[] } | undefined)?.tools;
+    if (!Array.isArray(tools)) return schemas;
+
+    for (const t of tools) {
+      const tool = t as { name?: unknown; inputSchema?: unknown };
+      if (typeof tool.name !== 'string') continue;
+      // An input schema that is not an object is not usable as a function
+      // schema; skipping leaves the hand-written entry in place rather than
+      // advertising something the model cannot read.
+      if (!tool.inputSchema || typeof tool.inputSchema !== 'object' || Array.isArray(tool.inputSchema)) continue;
+      schemas.set(tool.name, tool.inputSchema as JsonSchema);
+    }
+  } catch {
+    return new Map();
+  }
+
+  // Only cache a non-empty result. Caching an empty map would pin a transient
+  // outage in place for the whole TTL, turning a blip into ten minutes of
+  // degraded argument accuracy.
+  if (schemas.size > 0) cache = { at: now, schemas };
+  return schemas;
+}
+
+/**
+ * Overlay real schemas onto the hand-written catalog.
+ *
+ * Server-supplied schemas WIN where present, because the server is what
+ * validates. Tools with no server entry — the loop-internal ones like
+ * `write_file`, `deploy_frontend` and `update_operator_scratchpad`, which have
+ * no MCP counterpart — keep their hand-written schema, which for those is the
+ * only source there is.
+ */
+export function applyMcpToolSchemas<T extends { name: string; parameters: object }>(
+  tools: T[],
+  schemas: Map<string, JsonSchema>,
+): T[] {
+  if (schemas.size === 0) return tools;
+  return tools.map((t) => {
+    const real = schemas.get(t.name);
+    return real ? { ...t, parameters: real } : t;
+  });
+}


### PR DESCRIPTION
## The bug

`tool-catalog.ts` hand-writes the `parameters` shown to the model. For most tools that is:

```js
{ properties: { action: {type:'string'} }, required: ['action'], additionalProperties: true }
```

Wrong in **both** directions:

- **Under-specifies** — `app_id`, `table`, `function_name`, `code` and every enum value exist only as English prose in the description.
- **Mis-specifies** — `required: ['action']` on tools that reject `action`. `select_rows` says action is mandatory; the server answers `Unrecognized key(s) in object: action`. The model obeys the schema and is punished for it.

Measured on one operator turn (2026-08-10): 6 × `select_rows` rejections, plus missing-field rejections on `invoke_function`, `deploy_function`, `read_file`, plus invalid-enum on `manage_substrate` and `manage_integrations`. All from this one helper.

Verified against the live MCP server — `select_rows` really returns:

```
required: ["app_id","table"]
props:    app_id, table, filters, select, order, limit, offset, as_role, as_user
```

## The fix

Fetch `tools/list` and overlay the real `inputSchema`. The server declares these as zod and validates against them, so it's the only source that *cannot* disagree with the validator. Hand-correcting the catalog would fix today's mismatches and drift on the next parameter added.

- **Behind `MCP_REAL_TOOL_SCHEMAS`, default off.** Changes what every agent is told about every tool; deserves deliberate rollout.
- **Injected as a dep, not called inline.** The first version broke 96 tests by consuming responses their mocked `fetch` had queued for the model — a real signal about an unannounced fetch in the hot path.
- **Failure is never fatal.** Any error → empty map → hand-written catalog. Empty results aren't cached, so a blip isn't pinned for the TTL.

## Tests

13 new, weighted toward failure paths (network error, non-200, JSON-RPC error, malformed payload, SSE transport, cache behaviour), plus one pinning the exact defect: after overlay, `required` no longer contains `action`.

Suite unchanged at the pre-existing 48 failures (integration tests needing local Postgres) with the flag off.