### PR TITLE
feat(operator): gate place_call behind human approval

### DIFF
--- a/services/control-api/src/services/dashboard-agent/operator-policy.ts
+++ b/services/control-api/src/services/dashboard-agent/operator-policy.ts
@@ -334,6 +334,11 @@ export const OPERATOR_TOOL_SURFACE: ReadonlySet<string> = new Set(OPERATOR_TOOL_
  */
 export const SUBSTRATE_APPROVAL_REQUIRED_CAPABILITIES: ReadonlySet<string> = new Set([
   'send_email_draft',
+  // Reaches a named person in real time, in the organization's name, and
+  // cannot be recalled — the same category as an email, further out. Mirrors
+  // cloud/packages/substrate-core/src/capabilities/place-call.ts, where it is
+  // also NOT yolo-eligible.
+  'place_call',
   'delete_entity',
   'merge_entities',
   'record_principle',


### PR DESCRIPTION
`place_call` is a new substrate capability: it reaches a named person by phone, in the organization's name, and cannot be recalled. In substrate-core it is `approval_required` and **not** yolo-eligible.

This adds it to `SUBSTRATE_APPROVAL_REQUIRED_CAPABILITIES` so the operator loop expects the gate. Substrate enforces it either way — that list is the floor, not the ceiling — but without this the loop handles the resulting pending action less gracefully.

The drift guard in `__tests__/operator-policy.test.ts` reads the real capability sources and will confirm the mirror once both halves are in one checkout; it necessarily fails in a split working tree where the internal capability lives in a different worktree.

Paired with the internal change adding `cloud/packages/substrate-core/src/capabilities/place-call.ts`.