### PR TITLE
feat(operator-traces): page the whole history instead of capping it at 50

### DIFF
--- a/db/control-plane/107_operator_trace_wake_index.sql
+++ b/db/control-plane/107_operator_trace_wake_index.sql
@@ -1,0 +1,24 @@
+-- @scope: platform
+
+-- Paging the operator trace viewer selects the page from WAKE messages: one
+-- row per turn, `WHERE conversation_id = $1 AND role = 'user'`, ordered by
+-- `(created_at, id)`.
+--
+-- The only index on this table is `(conversation_id, created_at)`, which does
+-- not carry `role`, so that query reads every message of the conversation and
+-- discards ~97% of them (a turn is one wake plus its whole tool transcript).
+-- One operator conversation per org is reused FOREVER, so that cost grows
+-- without bound — the exact failure the module's own header warns about.
+--
+-- Partial, because `role = 'user'` is a fixed predicate of the only query that
+-- uses this: the index then holds one entry per TURN rather than per message.
+-- `(created_at, id)` matches the ORDER BY and the cursor's row-value
+-- comparison exactly, so paging is an index scan from the cursor rather than a
+-- sort.
+--
+-- CONCURRENTLY is deliberately NOT used: it cannot run inside the migration
+-- runner's transaction. The table is small enough per conversation that the
+-- brief lock is not worth splitting this into an out-of-band step.
+CREATE INDEX IF NOT EXISTS dashboard_agent_messages_wake_idx
+  ON dashboard_agent_messages (conversation_id, created_at, id)
+  WHERE role = 'user';

--- a/services/control-api/src/routes/dashboard-agent.ts
+++ b/services/control-api/src/routes/dashboard-agent.ts
@@ -1165,8 +1165,36 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
     const org = await resolveCallerOrgId(app.controlDb, request, userId);
     if (!org.ok) return reply.code(org.code).send({ error: org.error });
 
-    const { limit } = request.query as { limit?: string };
-    const parsedLimit = Number.parseInt(limit ?? '10', 10);
+    const q = request.query as {
+      limit?: string;
+      cursor?: string;
+      since?: string;
+      until?: string;
+      order?: string;
+    };
+    const parsedLimit = Number.parseInt(q.limit ?? '10', 10);
+
+    // A date that does not parse is rejected rather than ignored. Silently
+    // dropping a filter shows the caller MORE than they asked for and reads as
+    // if the range simply had that much in it.
+    const parseDate = (raw: string | undefined, field: string) => {
+      if (raw === undefined || raw === '') return null;
+      const d = new Date(raw);
+      if (Number.isNaN(d.getTime())) throw new Error(`invalid ${field}: ${raw}`);
+      return d;
+    };
+
+    let since: Date | null;
+    let until: Date | null;
+    try {
+      since = parseDate(q.since, 'since');
+      until = parseDate(q.until, 'until');
+    } catch (e) {
+      return reply.code(400).send({ error: e instanceof Error ? e.message : 'invalid date' });
+    }
+    if (since && until && since > until) {
+      return reply.code(400).send({ error: 'since is after until' });
+    }
 
     const conv = await app.controlDb.query<{ id: string }>(
       `SELECT id FROM dashboard_agent_conversations
@@ -1175,18 +1203,18 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
       [org.orgId, operatorUserId(org.orgId)],
     );
     if (conv.rows.length === 0) {
-      return reply.send({ conversationId: null, traces: [] });
+      return reply.send({ conversationId: null, traces: [], nextCursor: null, truncated: false });
     }
 
     const conversationId = conv.rows[0].id;
-    return reply.send({
-      conversationId,
-      traces: await listOperatorTraces(
-        app.controlDb,
-        conversationId,
-        Number.isFinite(parsedLimit) ? parsedLimit : 10,
-      ),
+    const page = await listOperatorTraces(app.controlDb, conversationId, {
+      limit: Number.isFinite(parsedLimit) ? parsedLimit : 10,
+      cursor: q.cursor ?? null,
+      since,
+      until,
+      order: q.order === 'oldest' ? 'oldest' : 'newest',
     });
+    return reply.send({ conversationId, ...page });
   });
 
   // ── POST /operator/approvals/:id/resolve ─────────────────────────────────

--- a/services/control-api/src/services/dashboard-agent/__tests__/operator-traces.test.ts
+++ b/services/control-api/src/services/dashboard-agent/__tests__/operator-traces.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Paging the operator trace viewer.
+ *
+ * The thing under test is the boundary arithmetic, so these run against a real
+ * Postgres rather than a stubbed pool: the page is chosen by a row-value
+ * comparison `(created_at, id) < ($1, $2)` against the same tuple the ORDER BY
+ * uses, and a fake that pattern-matches SQL would agree with whatever the code
+ * did, including the off-by-one it exists to catch.
+ *
+ * The regression that motivated all of this has its own test: turn 51 used to
+ * be unreachable at any limit.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { listOperatorTraces } from '../operator-traces.js';
+
+const CONN =
+  process.env.DATABASE_URL || 'postgresql://butterbase:butterbase_dev@localhost:5433/butterbase_control';
+
+/** Turns to seed. Deliberately past the old MAX_TURNS = 50 ceiling. */
+const TURNS = 60;
+const STEPS_PER_TURN = 3;
+
+let pool: pg.Pool;
+let conversationId: string;
+let orgId: string;
+
+/** Wake `n` (1-based) — the content is the assertable identity of a turn. */
+const wakeText = (n: number) => `wake ${n}`;
+
+beforeAll(async () => {
+  pool = new pg.Pool({ connectionString: CONN, max: 5 });
+
+  const stamp = Date.now();
+  const org = await pool.query<{ id: string }>(
+    `INSERT INTO organizations (name, owner_id, personal)
+     VALUES ($1, gen_random_uuid(), true) RETURNING id`,
+    [`traces-test-${stamp}`],
+  );
+  orgId = org.rows[0].id;
+
+  const conv = await pool.query<{ id: string }>(
+    `INSERT INTO dashboard_agent_conversations (organization_id, user_id, title, model)
+     VALUES ($1, gen_random_uuid(), 'traces test', 'test-model') RETURNING id`,
+    [orgId],
+  );
+  conversationId = conv.rows[0].id;
+
+  // Timestamps are explicit and one minute apart. Two rows sharing a
+  // millisecond is exactly what the id half of the cursor is for, so the last
+  // turn's rows are deliberately given an IDENTICAL created_at.
+  const base = new Date('2026-01-01T00:00:00.000Z').getTime();
+  for (let t = 1; t <= TURNS; t++) {
+    const at = new Date(base + t * 60_000);
+    await pool.query(
+      `INSERT INTO dashboard_agent_messages (conversation_id, role, content, created_at)
+       VALUES ($1, 'user', $2, $3)`,
+      [conversationId, wakeText(t), at],
+    );
+    for (let s = 0; s < STEPS_PER_TURN; s++) {
+      await pool.query(
+        `INSERT INTO dashboard_agent_messages
+           (conversation_id, role, content, tool_name, tool_args, tool_result, created_at)
+         VALUES ($1, 'tool', '', $2, '{}'::jsonb, '{"ok":true}'::jsonb, $3)`,
+        [conversationId, `tool_${s}`, new Date(at.getTime() + (s + 1) * 1000)],
+      );
+    }
+  }
+});
+
+afterAll(async () => {
+  if (conversationId) {
+    await pool.query(`DELETE FROM dashboard_agent_messages WHERE conversation_id = $1`, [conversationId]);
+    await pool.query(`DELETE FROM dashboard_agent_conversations WHERE id = $1`, [conversationId]);
+  }
+  if (orgId) await pool.query(`DELETE FROM organizations WHERE id = $1`, [orgId]);
+  await pool.end();
+});
+
+describe('listOperatorTraces paging', () => {
+  it('limit means TURNS, not messages', async () => {
+    const page = await listOperatorTraces(pool, conversationId, { limit: 3 });
+    expect(page.traces).toHaveLength(3);
+    // Newest first: turn 60, 59, 58.
+    expect(page.traces.map((t) => t.wake)).toEqual([wakeText(60), wakeText(59), wakeText(58)]);
+  });
+
+  it('every returned turn has its head — no half-turns', async () => {
+    const page = await listOperatorTraces(pool, conversationId, { limit: 10 });
+    for (const t of page.traces) {
+      expect(t.wake).not.toBe('');
+      expect(t.steps).toHaveLength(STEPS_PER_TURN);
+    }
+  });
+
+  it("a turn's steps stop at the next wake", async () => {
+    // The upper bound is the whole reason for the second query. Without it the
+    // transcript read runs to the end of the conversation and every later
+    // turn's steps pile onto the last turn of the page.
+    const page = await listOperatorTraces(pool, conversationId, { limit: 1 });
+    expect(page.traces[0].wake).toBe(wakeText(60));
+    expect(page.traces[0].steps).toHaveLength(STEPS_PER_TURN);
+
+    const middle = await listOperatorTraces(pool, conversationId, { limit: 1, cursor: page.nextCursor });
+    expect(middle.traces[0].wake).toBe(wakeText(59));
+    expect(middle.traces[0].steps).toHaveLength(STEPS_PER_TURN);
+  });
+
+  it('the cursor reaches turn 51 and beyond — the old 50 ceiling is gone', async () => {
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      const page: Awaited<ReturnType<typeof listOperatorTraces>> = await listOperatorTraces(
+        pool,
+        conversationId,
+        { limit: 10, cursor },
+      );
+      seen.push(...page.traces.map((t) => t.wake));
+      cursor = page.nextCursor;
+      pages++;
+      expect(pages).toBeLessThan(20); // a cursor that stops advancing must fail, not hang
+    } while (cursor);
+
+    expect(seen).toHaveLength(TURNS);
+    // No repeats and no gaps: the walk is exactly the conversation, once.
+    expect(new Set(seen).size).toBe(TURNS);
+    const expected = Array.from({ length: TURNS }, (_, i) => wakeText(TURNS - i));
+    expect(seen).toEqual(expected);
+    expect(seen).toContain(wakeText(51));
+    expect(seen).toContain(wakeText(1));
+  });
+
+  it('nextCursor is null only on the last page', async () => {
+    const first = await listOperatorTraces(pool, conversationId, { limit: TURNS - 1 });
+    expect(first.nextCursor).not.toBeNull();
+
+    const whole = await listOperatorTraces(pool, conversationId, { limit: TURNS });
+    expect(whole.traces).toHaveLength(TURNS);
+    expect(whole.nextCursor).toBeNull();
+  });
+
+  it('order=oldest walks the other way', async () => {
+    const page = await listOperatorTraces(pool, conversationId, { limit: 3, order: 'oldest' });
+    expect(page.traces.map((t) => t.wake)).toEqual([wakeText(1), wakeText(2), wakeText(3)]);
+
+    const next = await listOperatorTraces(pool, conversationId, {
+      limit: 3,
+      order: 'oldest',
+      cursor: page.nextCursor,
+    });
+    expect(next.traces.map((t) => t.wake)).toEqual([wakeText(4), wakeText(5), wakeText(6)]);
+  });
+
+  it('since/until filter on when the turn STARTED', async () => {
+    const base = new Date('2026-01-01T00:00:00.000Z').getTime();
+    // Turns 10..12 inclusive.
+    const since = new Date(base + 10 * 60_000);
+    const until = new Date(base + 12 * 60_000);
+
+    const page = await listOperatorTraces(pool, conversationId, { limit: 50, since, until });
+    expect(page.traces.map((t) => t.wake)).toEqual([wakeText(12), wakeText(11), wakeText(10)]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('an unreadable cursor shows the first page rather than failing', async () => {
+    const page = await listOperatorTraces(pool, conversationId, { limit: 2, cursor: 'not-a-cursor' });
+    expect(page.traces.map((t) => t.wake)).toEqual([wakeText(60), wakeText(59)]);
+  });
+
+  it('a page size over the ceiling is clamped, not honoured', async () => {
+    const page = await listOperatorTraces(pool, conversationId, { limit: 5000 });
+    expect(page.traces.length).toBeLessThanOrEqual(100);
+  });
+
+  it('an empty conversation pages to nothing', async () => {
+    const empty = await pool.query<{ id: string }>(
+      `INSERT INTO dashboard_agent_conversations (organization_id, user_id, title, model)
+       VALUES ($1, gen_random_uuid(), 'empty', 'test-model') RETURNING id`,
+      [orgId],
+    );
+    const page = await listOperatorTraces(pool, empty.rows[0].id, { limit: 10 });
+    expect(page.traces).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+    await pool.query(`DELETE FROM dashboard_agent_conversations WHERE id = $1`, [empty.rows[0].id]);
+  });
+});

--- a/services/control-api/src/services/dashboard-agent/operator-traces.ts
+++ b/services/control-api/src/services/dashboard-agent/operator-traces.ts
@@ -28,15 +28,36 @@
  *
  * One operator conversation per org is reused FOREVER, so an unbounded read of
  * this table is the same scheduled failure `operator-history.ts` exists to
- * prevent. Rows are fetched newest-first with a hard cap, then reversed —
- * never `SELECT *` over the conversation.
+ * prevent. A request reads ONE PAGE, and a page is bounded twice over: by the
+ * number of turns asked for, and by a message ceiling behind it.
+ *
+ * ── Why the page is selected from wake messages, not from the transcript ─────
+ *
+ * The first version read the newest N messages and derived whatever turns fell
+ * out, which made the page size a guess: a turn is however many rows the agent
+ * happened to write, so "the last 1500 messages" is an unknown number of turns,
+ * and the oldest one is nearly always cut off at the head. It was capped at 50
+ * turns total with no way to reach turn 51 — the history was simply
+ * unreachable.
+ *
+ * Now the page is chosen from the wake messages alone (one row per turn, so
+ * `LIMIT n` means exactly n turns), and the transcript is then fetched for the
+ * bounded time range those wakes span. Every returned turn has its head, the
+ * cursor walks the whole conversation, and `MAX_MESSAGES` goes back to being
+ * what it should always have been: a safety valve, not the pagination.
  */
 import type pg from 'pg';
 
-/** Hard ceiling on messages read per request, whatever the caller asks for. */
+/**
+ * Safety valve on the transcript read behind one page. Not the paginator — the
+ * page size is chosen from wake rows before this applies. It only trips when a
+ * single page's turns are enormous, and when it does the caller is told
+ * (`truncated`) rather than silently shown a turn missing its middle.
+ */
 const MAX_MESSAGES = 1500;
-/** Hard ceiling on turns returned. */
-const MAX_TURNS = 50;
+/** Ceiling on turns per page. Pagination, not truncation: use the cursor. */
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 10;
 /** Tool args/results are for eyeballing, not archaeology — cap the payloads. */
 const MAX_PAYLOAD_CHARS = 4000;
 
@@ -129,36 +150,174 @@ type ApprovalRow = {
   resolved_at: Date | null;
 };
 
+export type OperatorTraceOrder = 'newest' | 'oldest';
+
+export type ListOperatorTracesOptions = {
+  /** Turns per page. Clamped to [1, MAX_PAGE_SIZE]. */
+  limit?: number;
+  /** Opaque cursor from a previous page's `nextCursor`. */
+  cursor?: string | null;
+  /** Only turns that STARTED at or after this instant. */
+  since?: Date | null;
+  /** Only turns that STARTED at or before this instant. */
+  until?: Date | null;
+  order?: OperatorTraceOrder;
+};
+
+export type OperatorTracePage = {
+  traces: OperatorTrace[];
+  /** Pass back as `cursor` for the next page. Null when the page is the last. */
+  nextCursor: string | null;
+  /**
+   * True when MAX_MESSAGES cut the transcript read for this page, so some turn
+   * on it is missing steps. Surfaced rather than swallowed: a debugging view
+   * that quietly drops tool calls teaches the reader the agent did less than
+   * it did.
+   */
+  truncated: boolean;
+};
+
 /**
- * Most recent operator turns for `conversationId`, newest turn first.
+ * A cursor is the position of a wake message in the conversation's total order,
+ * which is `(created_at, id)` — `created_at` alone is not unique enough, and
+ * two wakes in the same millisecond would make a page repeat or skip forever.
  *
- * The message read is newest-first + capped, so the OLDEST turn in the window
- * is very likely truncated at its head. It is dropped rather than shown as a
- * turn with no wake message — a half-turn in a debugging view is worse than
- * one fewer turn, because it looks like the agent did less than it did.
+ * Encoded rather than structured so callers treat it as opaque and we stay free
+ * to change it. It is not a security boundary: the route resolves the
+ * conversation from the caller's own org before this is ever applied, so a
+ * forged cursor can only move someone around inside their own transcript.
+ */
+function encodeCursor(createdAt: Date, id: string): string {
+  return Buffer.from(`${createdAt.toISOString()}|${id}`, 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
+  try {
+    const raw = Buffer.from(cursor, 'base64url').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep <= 0) return null;
+    const createdAt = new Date(raw.slice(0, sep));
+    const id = raw.slice(sep + 1);
+    if (Number.isNaN(createdAt.getTime()) || !id) return null;
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
+}
+
+type WakeRow = { id: string; created_at: Date };
+
+/**
+ * One page of operator turns for `conversationId`.
+ *
+ * Every turn on the page is complete — the page is selected from wake messages
+ * first, then the transcript is read for exactly the range they span, so no
+ * turn can lose its head to a window edge.
+ *
+ * A bad cursor is treated as no cursor (first page) rather than an error: it is
+ * a debugging view, and a stale link should show the top of the list instead of
+ * a failure.
  */
 export async function listOperatorTraces(
   pool: pg.Pool,
   conversationId: string,
-  limit = 10,
-): Promise<OperatorTrace[]> {
-  const turnLimit = Math.min(Math.max(1, limit), MAX_TURNS);
+  options: ListOperatorTracesOptions = {},
+): Promise<OperatorTracePage> {
+  const { cursor = null, since = null, until = null, order = 'newest' } = options;
+  const pageSize = Math.min(Math.max(1, Math.trunc(options.limit ?? DEFAULT_PAGE_SIZE)), MAX_PAGE_SIZE);
+  const newestFirstOrder = order !== 'oldest';
+
+  // ── 1. Which turns are on this page? ──────────────────────────────────────
+  //
+  // One row per turn, so LIMIT here means turns. `pageSize + 1` is the
+  // has-more probe: if the extra row comes back there is another page, and it
+  // is dropped before the transcript read so it costs nothing but a row.
+  const where: string[] = ['conversation_id = $1', "role = 'user'"];
+  const params: unknown[] = [conversationId];
+
+  if (since) {
+    params.push(since);
+    where.push(`created_at >= $${params.length}`);
+  }
+  if (until) {
+    params.push(until);
+    where.push(`created_at <= $${params.length}`);
+  }
+
+  const decoded = cursor ? decodeCursor(cursor) : null;
+  if (decoded) {
+    // Row-value comparison against the same tuple the ORDER BY uses, so the
+    // boundary is exact whichever direction we are walking.
+    params.push(decoded.createdAt, decoded.id);
+    const cmp = newestFirstOrder ? '<' : '>';
+    where.push(`(created_at, id) ${cmp} ($${params.length - 1}, $${params.length})`);
+  }
+
+  const dir = newestFirstOrder ? 'DESC' : 'ASC';
+  params.push(pageSize + 1);
+
+  const { rows: wakeRows } = await pool.query<WakeRow>(
+    `SELECT id, created_at
+       FROM dashboard_agent_messages
+      WHERE ${where.join(' AND ')}
+      ORDER BY created_at ${dir}, id ${dir}
+      LIMIT $${params.length}`,
+    params,
+  );
+
+  const hasMore = wakeRows.length > pageSize;
+  const pageWakes = hasMore ? wakeRows.slice(0, pageSize) : wakeRows;
+  if (pageWakes.length === 0) return { traces: [], nextCursor: null, truncated: false };
+
+  const lastWake = pageWakes[pageWakes.length - 1];
+  const nextCursor = hasMore ? encodeCursor(lastWake.created_at, lastWake.id) : null;
+
+  // ── 2. The transcript for exactly the range those wakes span ──────────────
+  //
+  // Lower bound is the page's earliest wake, inclusive. The upper bound is
+  // EXCLUSIVE of the wake that opens the next turn — without it the read would
+  // run to the end of the conversation and pull in every later turn's steps,
+  // which the derivation below would then hang off the last turn on this page.
+  const earliest = newestFirstOrder ? lastWake : pageWakes[0];
+  const latestWake = newestFirstOrder ? pageWakes[0] : lastWake;
+
+  const nextTurnStart = await pool.query<WakeRow>(
+    `SELECT id, created_at
+       FROM dashboard_agent_messages
+      WHERE conversation_id = $1 AND role = 'user'
+        AND (created_at, id) > ($2, $3)
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1`,
+    [conversationId, latestWake.created_at, latestWake.id],
+  );
+
+  const transcriptParams: unknown[] = [conversationId, earliest.created_at, earliest.id];
+  let upperBound = '';
+  if (nextTurnStart.rows.length > 0) {
+    const stop = nextTurnStart.rows[0];
+    transcriptParams.push(stop.created_at, stop.id);
+    upperBound = ` AND (created_at, id) < ($4, $5)`;
+  }
+  transcriptParams.push(MAX_MESSAGES + 1);
 
   const { rows } = await pool.query<Row>(
     `SELECT id, role, content, tool_name, tool_args, tool_result,
             model_used, pending_approval_id, created_at
        FROM dashboard_agent_messages
       WHERE conversation_id = $1
-      ORDER BY created_at DESC, id DESC
-      LIMIT $2`,
-    [conversationId, MAX_MESSAGES],
+        AND (created_at, id) >= ($2, $3)${upperBound}
+      ORDER BY created_at ASC, id ASC
+      LIMIT $${transcriptParams.length}`,
+    transcriptParams,
   );
-  if (rows.length === 0) return [];
 
-  const chronological = rows.slice().reverse();
+  // Read one more than the ceiling so a full read is distinguishable from one
+  // that was cut. Chronological already — no reverse.
+  const truncated = rows.length > MAX_MESSAGES;
+  const chronological = truncated ? rows.slice(0, MAX_MESSAGES) : rows;
 
-  // Split on the wake message. Anything before the first one belongs to a turn
-  // whose head fell outside the window — see the doc comment.
+  // Split on the wake message. The first row IS a wake by construction, so
+  // unlike the previous implementation there is no head-truncated remnant.
   const turns: OperatorTrace[] = [];
   for (const row of chronological) {
     if (row.role === 'user') {
@@ -199,11 +358,14 @@ export async function listOperatorTraces(
     });
   }
 
-  const newestFirst = turns.reverse().slice(0, turnLimit);
+  // Derived chronologically; the caller's order decides which way it reads.
+  // No slice — the page size was settled by the wake query, and cutting here
+  // again is what made turn 51 unreachable.
+  const ordered = newestFirstOrder ? turns.reverse() : turns;
 
   // Attach approvals. A gated turn's assistant row carries the approval id;
   // the approval itself holds the resolution a later click wrote.
-  const approvalIds = newestFirst
+  const approvalIds = ordered
     .flatMap((t) => t.steps.map((s) => s.pendingApprovalId))
     .filter((v): v is string => typeof v === 'string');
 
@@ -215,7 +377,7 @@ export async function listOperatorTraces(
       [approvalIds],
     );
     const byId = new Map(approvals.map((a) => [a.id, a]));
-    for (const turn of newestFirst) {
+    for (const turn of ordered) {
       const gatedStep = turn.steps.find((s) => s.pendingApprovalId);
       const found = gatedStep?.pendingApprovalId ? byId.get(gatedStep.pendingApprovalId) : undefined;
       if (found) {
@@ -231,5 +393,5 @@ export async function listOperatorTraces(
     }
   }
 
-  return newestFirst;
+  return { traces: ordered, nextCursor, truncated };
 }


### PR DESCRIPTION
`MAX_TURNS = 50` was a ceiling on the **total**, not a page size, and there was no cursor — so turn 51 was unreachable at any `limit`. Clicking 'load more' past 50 in the dashboard did nothing.

**The page is now selected from wake messages**, not from the transcript. One `role='user'` row per turn, so `LIMIT n` means exactly n turns; the transcript is then read for the range those wakes span, bounded above by the next turn's wake. Two things fall out beyond pagination:

- a page size means what it says (previously 'the newest 1500 messages' was an unknown number of turns)
- every returned turn has its head. The old window cut the oldest turn open and then dropped it, so at limit 10 you often got 9.

**Cursor** is `(created_at, id)` compared as a row value against the same tuple the `ORDER BY` uses, so two wakes in one millisecond cannot make a page repeat or skip. Opaque base64url; a bad one shows page 1 rather than erroring.

Also adds `since`/`until`/`order=oldest`, all applied to the wake query so they are real rather than a client-side filter over a partial window. `MAX_MESSAGES` stays as a safety valve on one page's transcript read and is now **reported** (`truncated`) instead of silently dropping steps.

`107_operator_trace_wake_index.sql` — the wake query filters `role='user'`, which `(conversation_id, created_at)` does not carry, so it read every message of a conversation that is reused forever. Partial index, one entry per turn.

**Tests:** new `operator-traces.test.ts`, 10 cases against a real Postgres — including a 60-turn cursor walk asserting exact order, no repeats, no gaps, and that turn 51 is reachable. Verified the 13 pre-existing failures in `src/services/dashboard-agent/` are identical on `origin/main` (49 failed both sides; this branch adds 10 passing).