### PR TITLE
feat(ai-router): provider-quaternary slot + assistant model lock

### DIFF
--- a/db/control-plane/migrate.ts
+++ b/db/control-plane/migrate.ts
@@ -1,7 +1,7 @@
 import pg from 'pg';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -285,7 +285,11 @@ async function migrate(): Promise<void> {
 }
 
 // Only auto-run when invoked directly, not when imported by tests.
-const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;
+// pathToFileURL, not `file://${argv[1]}`: the latter never matches on Windows
+// (backslash paths, percent-encoding), so the runner exited 0 having applied
+// nothing.
+const isDirectInvocation =
+  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectInvocation) {
   migrate().catch((err) => {
     console.error('Migration error:', err);

--- a/db/runtime-plane/migrate.ts
+++ b/db/runtime-plane/migrate.ts
@@ -1,7 +1,7 @@
 import pg from 'pg';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -136,7 +136,10 @@ async function migrate(): Promise<void> {
   console.log('Runtime migrations complete across all regions.');
 }
 
-const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;
+// pathToFileURL: `file://${argv[1]}` never matches on Windows, so this runner
+// silently applied nothing there.
+const isDirectInvocation =
+  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectInvocation) {
   migrate().catch((err) => {
     console.error('Migration error:', err);

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -90,6 +90,11 @@ export const config = {
       providerSecondaryCatalogUrl: process.env.AI_PROVIDER_SECONDARY_CATALOG_URL || undefined,
       providerTertiaryApiKey: process.env.AI_PROVIDER_TERTIARY_API_KEY ?? '',
       providerTertiaryBaseUrl: process.env.AI_PROVIDER_TERTIARY_BASE_URL || undefined,
+      // Quaternary has no default base URL on purpose: the upstream's endpoint,
+      // API key and model must all belong to the same region, so guessing a
+      // default would silently send traffic to the wrong one.
+      providerQuaternaryApiKey: process.env.AI_PROVIDER_QUATERNARY_API_KEY ?? '',
+      providerQuaternaryBaseUrl: process.env.AI_PROVIDER_QUATERNARY_BASE_URL || undefined,
       catalogRefreshLockTtlSec: parseInt(process.env.AI_CATALOG_LOCK_TTL_SEC ?? '600', 10),
     } as const;
   })(),

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -2148,12 +2148,14 @@ export async function adminRoutes(app: FastifyInstance) {
       let providerPrimaryAdapter: any = null;
       let providerSecondaryAdapter: any = null;
       let providerTertiaryAdapter: any = null;
+      let providerQuaternaryAdapter: any = null;
       try {
         // @ts-expect-error — overlay path resolved at runtime
         const overlay = await import('../../../../cloud-overlays/dist/cloud-overlays/bootstrap.js');
         providerPrimaryAdapter = overlay.providerPrimaryAdapter;
         providerSecondaryAdapter = overlay.providerSecondaryAdapter;
         providerTertiaryAdapter = overlay.providerTertiaryAdapter;
+        providerQuaternaryAdapter = overlay.providerQuaternaryAdapter;
       } catch { /* OSS mode */ }
 
       const adapters = [];
@@ -2177,6 +2179,12 @@ export async function adminRoutes(app: FastifyInstance) {
         adapters.push(providerTertiaryAdapter({
           apiKey: config.aiRouter.providerTertiaryApiKey,
           baseUrl: config.aiRouter.providerTertiaryBaseUrl,
+        }));
+      }
+      if (providerQuaternaryAdapter && config.aiRouter.providerQuaternaryApiKey) {
+        adapters.push(providerQuaternaryAdapter({
+          apiKey: config.aiRouter.providerQuaternaryApiKey,
+          baseUrl: config.aiRouter.providerQuaternaryBaseUrl,
         }));
       }
       if (adapters.length === 0) {
@@ -2211,6 +2219,7 @@ export async function adminRoutes(app: FastifyInstance) {
       { name: 'provider-primary', configured: !!config.aiRouter.providerPrimaryApiKey },
       { name: 'provider-secondary', configured: !!config.aiRouter.providerSecondaryApiKey },
       { name: 'provider-tertiary', configured: !!config.aiRouter.providerTertiaryApiKey },
+      { name: 'provider-quaternary', configured: !!config.aiRouter.providerQuaternaryApiKey },
     ];
     // ai_usage_logs.router exists; rows are written only on settle so every row
     // is a "success". Treat the presence of any fallback_chain entry naming a

--- a/services/control-api/src/routes/ai-config.ts
+++ b/services/control-api/src/routes/ai-config.ts
@@ -89,6 +89,10 @@ async function buildAdapters(): Promise<Map<RouterName, RouterAdapter>> {
       apiKey: config.aiRouter.providerTertiaryApiKey,
       baseUrl: config.aiRouter.providerTertiaryBaseUrl,
     }));
+    if (config.aiRouter.providerQuaternaryApiKey) m.set('provider-quaternary', overlay.providerQuaternaryAdapter({
+      apiKey: config.aiRouter.providerQuaternaryApiKey,
+      baseUrl: config.aiRouter.providerQuaternaryBaseUrl,
+    }));
   } catch { /* OSS mode: only openrouter is available */ }
   return m;
 }

--- a/services/control-api/src/routes/dashboard-agent.ts
+++ b/services/control-api/src/routes/dashboard-agent.ts
@@ -190,19 +190,52 @@ export function mergeSnapshotsWithLabels(
   return merged;
 }
 
+/**
+ * ============================================================================
+ * ASSISTANT MODEL — currently the ONE model the assistant runs on.
+ *
+ * The assistant is pinned to a single model on purpose: this id is in
+ * PREFERRED_ROUTER_BY_MODEL (select.ts), so every assistant turn is served
+ * direct by the vendor slot rather than through an aggregator.
+ *
+ * PRICE, and why this id specifically: the vendor's PUBLIC pricing page omits
+ * every qwen3.8 variant, but the Model Studio console quotes qwen3.8-max at
+ * $0.002/1K in and $0.006/1K out — i.e. $2.00/$6.00 per Mtok, flat, no
+ * input-size tiers. That is exactly what the aggregator charges for the same
+ * id, so routing it direct is cost-neutral. It matters that this is a real
+ * quoted rate rather than an estimate: the direct adapter reports
+ * `providerCostUsd: null` and billing settles from the catalog price, so a
+ * guessed number here would bill customers a guess.
+ *
+ * `resolveAssistantModel` ignores any caller-supplied or previously-stored id.
+ * That is deliberate — a conversation's `model` column may hold whatever was
+ * picked before the lock, and honouring it would send old threads to a
+ * different provider. Remove the override (not just the default) when
+ * re-opening model choice.
+ * ============================================================================
+ */
+export const ASSISTANT_MODEL = 'qwen/qwen3.8-max';
+
+/** Single source of truth while the assistant is locked to one model. */
+function resolveAssistantModel(_requested?: string | null): string {
+  return ASSISTANT_MODEL;
+}
+
 // ---------------------------------------------------------------------------
 // Validation schemas
 // ---------------------------------------------------------------------------
 
 const createConversationBody = z.object({
   title: z.string().min(1).max(500).default('New conversation'),
-  model: z.string().min(1).default('qwen/qwen3.8-max'),
+  // Accepted for backward compatibility but ignored — see ASSISTANT_MODEL.
+  model: z.string().min(1).default(ASSISTANT_MODEL),
 });
 
 const postMessageBody = z.object({
   conversation_id: z.string().uuid(),
   message: z.string().min(1),
-  model: z.string().min(1).default('qwen/qwen3.8-max'),
+  // Accepted for backward compatibility but ignored — see ASSISTANT_MODEL.
+  model: z.string().min(1).default(ASSISTANT_MODEL),
 });
 
 const rewindBody = z.object({
@@ -444,7 +477,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
       app.controlDb,
       userId,
       parsed.data.title,
-      parsed.data.model,
+      resolveAssistantModel(parsed.data.model),
     );
 
     return reply.code(201).send({ conversation });
@@ -503,7 +536,8 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
     const { id } = request.params as { id: string };
     const body = patchConversationBody.parse(request.body);
 
-    const updated = await updateConversationModel(app.controlDb, id, userId, body.model);
+    // Model choice is locked; accept the call but always write the pinned id.
+    const updated = await updateConversationModel(app.controlDb, id, userId, resolveAssistantModel(body.model));
     if (!updated) return reply.code(404).send({ error: 'conversation not found' });
     return reply.send({ conversation: updated });
   });
@@ -789,7 +823,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
         userId,
         jwt,
         userMessage: userMessageToReplay,
-        model: conversation.model,
+        model: resolveAssistantModel(conversation.model),
         pool: app.controlDb,
         organizationId: readOrgId(request),
       });
@@ -1316,7 +1350,7 @@ export async function dashboardAgentRoutes(app: FastifyInstance) {
 
     try {
       const conversation = await getConversation(app.controlDb, conversationId, userId);
-      const model = conversation?.model ?? 'qwen/qwen3.8-max';
+      const model = resolveAssistantModel(conversation?.model);
 
       // Empty userMessage: the resumed turn's history already contains the
       // just-persisted tool-result row (via resolveApprovalAndPersistResult).

--- a/services/control-api/src/routes/gateway.ts
+++ b/services/control-api/src/routes/gateway.ts
@@ -49,6 +49,7 @@ export async function buildAdapters(): Promise<Map<RouterName, RouterAdapter>> {
     if (config.aiRouter.providerPrimaryApiKey) m.set('provider-primary', overlay.providerPrimaryAdapter({ apiKey: config.aiRouter.providerPrimaryApiKey, baseUrl: config.aiRouter.providerPrimaryBaseUrl }));
     if (config.aiRouter.providerSecondaryApiKey) m.set('provider-secondary', overlay.providerSecondaryAdapter({ apiKey: config.aiRouter.providerSecondaryApiKey, baseUrl: config.aiRouter.providerSecondaryBaseUrl, catalogUrl: config.aiRouter.providerSecondaryCatalogUrl }));
     if (config.aiRouter.providerTertiaryApiKey) m.set('provider-tertiary', overlay.providerTertiaryAdapter({ apiKey: config.aiRouter.providerTertiaryApiKey, baseUrl: config.aiRouter.providerTertiaryBaseUrl }));
+    if (config.aiRouter.providerQuaternaryApiKey) m.set('provider-quaternary', overlay.providerQuaternaryAdapter({ apiKey: config.aiRouter.providerQuaternaryApiKey, baseUrl: config.aiRouter.providerQuaternaryBaseUrl }));
   } catch { /* OSS mode: only openrouter is available */ }
   return m;
 }

--- a/services/control-api/src/services/ai-router/normalize.ts
+++ b/services/control-api/src/services/ai-router/normalize.ts
@@ -1,6 +1,6 @@
 import overridesRaw from './normalize-overrides.json' with { type: 'json' };
 
-export type RouterName = 'openrouter' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary';
+export type RouterName = 'openrouter' | 'provider-primary' | 'provider-secondary' | 'provider-tertiary' | 'provider-quaternary';
 
 const overrides = overridesRaw as unknown as Record<RouterName, Record<string, string>>;
 

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -37,7 +37,7 @@ const FALLBACK_KINDS: ReadonlySet<string> = new Set(['transport', 'rate_limit', 
  * slot-cooldown MGET stays O(known-slots) instead of scanning Redis keys.
  * Extend when adding new named slots.
  */
-const KNOWN_ROUTER_SLOTS = ['provider-primary', 'provider-secondary', 'provider-tertiary', 'openrouter'] as const;
+const KNOWN_ROUTER_SLOTS = ['provider-primary', 'provider-secondary', 'provider-tertiary', 'provider-quaternary', 'openrouter'] as const;
 
 /**
  * Pick the active ranker. Waterfall wins over presence-mode when both are

--- a/services/control-api/src/services/ai-router/select.ts
+++ b/services/control-api/src/services/ai-router/select.ts
@@ -42,6 +42,33 @@ function score(r: CatalogRouter): number {
 const PREFERRED_ROUTER_BY_MODEL: Readonly<Record<string, RouterName>> = {
   'bytedance/seedance-2.0': 'provider-tertiary',
   'bytedance/seedance-2.0-fast': 'provider-tertiary',
+  // Qwen models the vendor serves first-party: pin them to the direct slot so
+  // they stop being single-sourced through OpenRouter. This list must stay a
+  // subset of the ids in the quaternary adapter's static model table — a model
+  // pinned here but absent from that table has no quaternary row on its catalog
+  // entry, so promotePreferred finds nothing and price/waterfall ordering wins
+  // unchanged (soft hint, not a hard route).
+  // qwen3.8-max is the dashboard assistant's locked model (ASSISTANT_MODEL in
+  // routes/dashboard-agent.ts) and is at price parity with OpenRouter, so this
+  // pin costs nothing.
+  'qwen/qwen3.8-max': 'provider-quaternary',
+  'qwen/qwen3.7-max': 'provider-quaternary',
+  'qwen/qwen3.7-plus': 'provider-quaternary',
+  'qwen/qwen3.6-flash': 'provider-quaternary',
+  'qwen/qwen3.6-plus': 'provider-quaternary',
+  'qwen/qwen3-max': 'provider-quaternary',
+  'qwen/qwen3-coder-plus': 'provider-quaternary',
+  'qwen/qwen3-coder-flash': 'provider-quaternary',
+  'qwen/qwen-plus': 'provider-quaternary',
+  'qwen/qwen3-235b-a22b': 'provider-quaternary',
+  'qwen/qwen3-8b': 'provider-quaternary',
+  'qwen/qwen3-30b-a3b': 'provider-quaternary',
+  'qwen/qwen3-next-80b-a3b-instruct': 'provider-quaternary',
+  'qwen/qwen3-vl-32b-instruct': 'provider-quaternary',
+  'qwen/qwen3-vl-8b-instruct': 'provider-quaternary',
+  'qwen/qwen3.5-27b': 'provider-quaternary',
+  'qwen/qwen3.5-122b-a10b': 'provider-quaternary',
+  'qwen/qwen3.6-27b': 'provider-quaternary',
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a fourth router slot (`provider-quaternary`) so Qwen models can be served **direct by the vendor** instead of only through an aggregator, and locks the dashboard assistant to a single model routed through it.

Every Qwen model in the prod catalog is currently **single-sourced** through one aggregator — 56 of them — so an aggregator outage takes out the entire vendor. This gives the pinned models a real second source.

The adapter implementation lives in the cloud overlay (separate PR in butterbase-internal); this is the OSS wiring only, so OSS builds stay green without it.

## Commits

- `feat(ai-router)` — `RouterName` union, `KNOWN_ROUTER_SLOTS`, config env vars, `buildAdapters()` registration in gateway/ai-config/admin, and 18 canonical ids pinned via `PREFERRED_ROUTER_BY_MODEL`
- `feat(assistant)` — assistant locked to `qwen/qwen3.8-max`, overriding both caller-supplied and stored model ids
- `fix(db)` — migration runners never self-invoked on Windows

## Design notes

**Why `PREFERRED_ROUTER_BY_MODEL` and not `WATERFALL_SLOT_ORDER`.** `promotePreferred()` runs in *both* the price and waterfall rankers, so the pin holds under prod's `AI_ROUTER_MODE=waterfall` without reordering the named slots. It stays a soft hint — if the slot is disabled or absent from an entry, ranking falls back to normal.

**No default base URL.** The upstream is region-pinned: endpoint, key and model must all belong to the same region or the call fails outright. A guessed default would silently send traffic to the wrong region, so `AI_PROVIDER_QUATERNARY_BASE_URL` is required.

**Assistant model choice.** `qwen3.8-max` is quoted at \$2.00/\$6.00 per Mtok on the console — parity with the aggregator for the same id, so pinning it direct is cost-neutral. That it is a real quoted rate matters: the direct adapter reports `providerCostUsd: null` and billing settles from the catalog price, so an unpriced model would bill customers against a guess.

**The `fix(db)` commit** is unrelated to Qwen but was found en route: the runners guarded their entry point with ``import.meta.url === `file://${process.argv[1]}` ``, never true on Windows. `migrate()` was never called — the command exited 0 having applied nothing, leaving the DB dozens of migrations behind with nothing logged.

## Rollout safety

Additive. An older image that sees `provider-quaternary` in a catalog entry hits `ctx.adapters.get()` → `undefined` → `no_adapter` → `continue`, so it skips the unknown slot rather than 500ing. Verified at `router.ts:237`.

Inert until `AI_PROVIDER_QUATERNARY_API_KEY` and `_BASE_URL` are set — `buildAdapters()` skips the slot without them.

## Test

`select.test.ts` 31/31. Adapter suite (21/21) lives with the implementation in the internal repo.