### PR TITLE
fix: restore working star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ See [`SECURITY.md`](./SECURITY.md). Report vulnerabilities to `security@butterba
 
 ## Star history
 
-<a href="https://www.star-history.com/#butterbase-ai/butterbase&Date">
+<a href="https://star-history.dera.page/#butterbase-ai/butterbase&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=butterbase-ai/butterbase&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=butterbase-ai/butterbase&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=butterbase-ai/butterbase&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=butterbase-ai/butterbase&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=butterbase-ai/butterbase&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=butterbase-ai/butterbase&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
The current star history chart is broken and no longer renders reliably. Update the README chart links so the project history remains visible.