### PR TITLE
feat(neon): project-per-app provisioning machinery (Phases 1-2, flag off)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -153,6 +153,20 @@ CONTROL_PLANE_URL_PLATFORM_REGION=http://control-api.us-east-1.internal:4000
 # Phase 4: per-region Neon data project IDs.
 NEON_DATA_PROJECT_ID_US_EAST_1=prod-data-use1
 
+# --- Neon project-per-app (design doc 2026-08-20) ---
+# Neon organization id. Required by GET /projects.
+NEON_ORG_ID=org-round-cell-11808374
+# Provision each new app into its own Neon project. Default false.
+BUTTERBASE_PROJECT_PER_TENANT=false
+# Butterbase region -> Neon region_id. Defaults to aws-<region> when unset.
+NEON_REGION_US_EAST_1=aws-us-east-1
+NEON_REGION_US_WEST_2=aws-us-west-2
+# Neon API budget is 700 req/min account-wide, burst 40/s per route.
+NEON_API_RATE_LIMIT_RPS=10
+NEON_API_RATE_LIMIT_BURST=20
+# Postgres major version for newly created tenant projects.
+NEON_PG_VERSION=17
+
 # Phase 5: move-app saga
 MOVE_APP_DRIVER_ENABLED=true
 MOVE_APP_STEP_TIMEOUT_SECONDS=1800

--- a/.env.production.example
+++ b/.env.production.example
@@ -166,6 +166,10 @@ NEON_API_RATE_LIMIT_RPS=10
 NEON_API_RATE_LIMIT_BURST=20
 # Postgres major version for newly created tenant projects.
 NEON_PG_VERSION=17
+# Postgres major version per region. MUST match the region's existing data
+# project, or new apps land on a different major than their neighbours.
+NEON_PG_VERSION_US_EAST_1=17
+NEON_PG_VERSION_US_WEST_2=18
 
 # Phase 5: move-app saga
 MOVE_APP_DRIVER_ENABLED=true

--- a/services/control-api/src/config.test.ts
+++ b/services/control-api/src/config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { positiveIntOr } from './config.js';
+
+describe('positiveIntOr (Neon rate-limit env parsing)', () => {
+  it('accepts a valid positive integer', () => {
+    expect(positiveIntOr('25', 10)).toBe(25);
+  });
+
+  it('falls back when unset', () => {
+    expect(positiveIntOr(undefined, 10)).toBe(10);
+    expect(positiveIntOr('', 20)).toBe(20);
+  });
+
+  it('falls back on 0 — a 0 rate would throw inside TokenBucket at import time', () => {
+    expect(positiveIntOr('0', 10)).toBe(10);
+  });
+
+  it('falls back on negative values', () => {
+    expect(positiveIntOr('-5', 20)).toBe(20);
+  });
+
+  it('falls back on non-numeric values instead of yielding NaN', () => {
+    expect(positiveIntOr('abc', 10)).toBe(10);
+    expect(positiveIntOr('  ', 20)).toBe(20);
+  });
+
+  it('truncates a decimal to its integer part when still positive', () => {
+    expect(positiveIntOr('7.9', 10)).toBe(7);
+  });
+});

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -185,6 +185,16 @@ export const config = {
     /** Postgres role that owns per-app DBs; created via Neon API if missing on the branch */
     databaseOwner: process.env.NEON_DATA_DATABASE_OWNER ?? 'butterbase',
     enabled: process.env.NEON_API_KEY !== undefined && process.env.NEON_API_KEY !== '',
+    /** Neon organization id. Required by GET /projects. */
+    orgId: process.env.NEON_ORG_ID ?? '',
+    /** Provision each app into its own Neon project instead of a shared one. */
+    projectPerTenant: process.env.BUTTERBASE_PROJECT_PER_TENANT === 'true',
+    /** Sustained Neon API call rate. Account budget is 700/min ≈ 11.6/s. */
+    rateLimitRps: parseInt(process.env.NEON_API_RATE_LIMIT_RPS ?? '10', 10),
+    /** Burst allowance. Neon documents 40/s per route. */
+    rateLimitBurst: parseInt(process.env.NEON_API_RATE_LIMIT_BURST ?? '20', 10),
+    /** Postgres major version for newly created tenant projects. */
+    pgVersion: parseInt(process.env.NEON_PG_VERSION ?? '17', 10),
     orphanReconciler: {
       // Off by default. Flip to true only after inspecting a dry-run cycle.
       enabled: process.env.NEON_ORPHAN_RECONCILER_ENABLED === 'true',

--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -21,6 +21,17 @@ function resolveSesRegion(): string {
   return 'us-east-1';
 }
 
+/**
+ * Parse a strictly-positive integer env var, falling back to `fallback` for
+ * unset, non-numeric (NaN) or non-positive values. Used for the Neon rate
+ * limiter, where a 0 would throw inside the TokenBucket constructor at import
+ * time (control-api never boots) and a NaN would busy-loop every Neon call.
+ */
+export function positiveIntOr(raw: string | undefined, fallback: number): number {
+  const parsed = parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export const config = {
   port: parseInt(process.env.CONTROL_API_PORT ?? '4000', 10),
   nodeEnv: process.env.NODE_ENV ?? 'development',
@@ -190,9 +201,9 @@ export const config = {
     /** Provision each app into its own Neon project instead of a shared one. */
     projectPerTenant: process.env.BUTTERBASE_PROJECT_PER_TENANT === 'true',
     /** Sustained Neon API call rate. Account budget is 700/min ≈ 11.6/s. */
-    rateLimitRps: parseInt(process.env.NEON_API_RATE_LIMIT_RPS ?? '10', 10),
+    rateLimitRps: positiveIntOr(process.env.NEON_API_RATE_LIMIT_RPS, 10),
     /** Burst allowance. Neon documents 40/s per route. */
-    rateLimitBurst: parseInt(process.env.NEON_API_RATE_LIMIT_BURST ?? '20', 10),
+    rateLimitBurst: positiveIntOr(process.env.NEON_API_RATE_LIMIT_BURST, 20),
     /** Postgres major version for newly created tenant projects. */
     pgVersion: parseInt(process.env.NEON_PG_VERSION ?? '17', 10),
     orphanReconciler: {

--- a/services/control-api/src/services/__tests__/neon-project-live.integration.test.ts
+++ b/services/control-api/src/services/__tests__/neon-project-live.integration.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { createProjectForApp, projectNameForApp } from '../neon-client.js';
+import { config } from '../../config.js';
+
+const LIVE = process.env.NEON_LIVE_TEST === '1' && !!config.neon.apiKey;
+const CONCURRENCY = 10;
+const createdProjectIds: string[] = [];
+
+async function deleteProject(id: string): Promise<number> {
+  const res = await fetch(`https://console.neon.tech/api/v2/projects/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${config.neon.apiKey}` },
+  });
+  return res.status;
+}
+
+describe.skipIf(!LIVE)('Neon tenant project provisioning (live)', () => {
+  afterAll(async () => {
+    // Cleanup must run even if assertions failed — a leaked project bills forever.
+    for (const id of createdProjectIds) {
+      const status = await deleteProject(id);
+      if (status !== 200 && status !== 404) {
+        console.error(`[live-test] FAILED to delete project ${id}: HTTP ${status}`);
+      }
+    }
+  });
+
+  it(`creates ${CONCURRENCY} projects concurrently with zero conflicts`, async () => {
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENCY }, (_, i) =>
+        createProjectForApp({
+          appId: `app_livetest${String(i).padStart(4, '0')}`,
+          neonRegionId: 'aws-us-east-1',
+          databaseName: `db_app_livetest${String(i).padStart(4, '0')}`,
+          ownerRole: config.neon.databaseOwner,
+        }),
+      ),
+    );
+
+    for (const r of results) {
+      if (r.status === 'fulfilled') createdProjectIds.push(r.value.projectId);
+    }
+
+    const rejected = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
+    // A 423 here means Neon started treating project creation as a conflicting
+    // operation — the core assumption of the project-per-app design is broken.
+    const conflicts = rejected.filter((r) => String(r.reason?.message ?? '').includes('423'));
+
+    expect(conflicts).toHaveLength(0);
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(CONCURRENCY);
+  }, 120_000);
+
+  it('names projects so the reconciler can find them', () => {
+    expect(projectNameForApp('app_livetest0000')).toBe('bb-app_livetest0000');
+  });
+});

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -44,6 +44,9 @@ vi.mock('../neon-projects.js', () => ({
   }),
   // Also read by defaultDeps(); unused on the legacy path.
   getNeonRegionIdForRegion: vi.fn(() => 'aws-us-east-1'),
+  // defaultDeps() eagerly reads every member of neon-projects.js; unused on
+  // the legacy path but required or the mock factory throws "No export".
+  getNeonPgVersionForRegion: vi.fn(() => 17),
 }));
 
 vi.mock('../provisioner.js', () => ({

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -32,6 +32,9 @@ vi.mock('../neon-client.js', () => ({
   // though the legacy (flag-off) path never calls them.
   createProjectForApp: vi.fn().mockResolvedValue(undefined),
   waitUntilUriQueryable: vi.fn().mockResolvedValue(undefined),
+  // Task 7 added findProjectByName to ProvisionDeps/defaultDeps(); same
+  // eager-read trap as above — the legacy (flag-off) path never calls it.
+  findProjectByName: vi.fn(),
 }));
 
 vi.mock('../neon-projects.js', () => ({

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -27,6 +27,11 @@ vi.mock('../neon-client.js', () => ({
   }),
   grantSchemaPrivileges: vi.fn().mockResolvedValue(undefined),
   deleteDatabase: vi.fn().mockResolvedValue(undefined),
+  // provisionNeonDbForApp's defaultDeps() reads every member of this module up
+  // front, so the mock must define the project-per-tenant members too even
+  // though the legacy (flag-off) path never calls them.
+  createProjectForApp: vi.fn().mockResolvedValue(undefined),
+  waitUntilUriQueryable: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../neon-projects.js', () => ({
@@ -34,6 +39,8 @@ vi.mock('../neon-projects.js', () => ({
     if (region === 'us-east-1') return 'neon-proj-us-east-1';
     throw new Error(`Missing env var NEON_DATA_PROJECT_ID_${region.toUpperCase().replace(/-/g, '_')} for region ${region}`);
   }),
+  // Also read by defaultDeps(); unused on the legacy path.
+  getNeonRegionIdForRegion: vi.fn(() => 'aws-us-east-1'),
 }));
 
 vi.mock('../provisioner.js', () => ({

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -28,6 +28,7 @@ function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
     waitUntilUriQueryable: async () => { calls.push('waitUntilUriQueryable'); },
     getDataProjectIdForRegion: () => 'shared-proj-us-east-1',
     getNeonRegionIdForRegion: () => 'aws-us-east-1',
+    findProjectByName: async () => { calls.push('findProjectByName'); return null; },
     ...overrides,
   };
   return { deps, calls };
@@ -86,6 +87,25 @@ describe('provisionNeonDbForApp', () => {
       const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
       expect(result.poolerConnectionString).toBeNull();
       expect(result.connectionUri).toBe('postgres://u:p@direct/db');
+    });
+
+    it('adopts an existing project instead of creating a duplicate on retry', async () => {
+      const { deps, calls } = makeDeps({
+        findProjectByName: async () => ({ id: 'already-there' }),
+      });
+
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('already-there');
+      expect(calls).not.toContain('createProjectForApp');
+    });
+
+    it('creates a project when none exists yet', async () => {
+      const { deps, calls } = makeDeps({ findProjectByName: async () => null });
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('tenant-proj-1');
+      expect(calls).toContain('createProjectForApp');
     });
   });
 

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { provisionNeonDbForApp, type ProvisionDeps } from './app-db-provision.js';
+import { config } from '../config.js';
+
+const APP_ID = 'app_k3f9x2m1qp0z';
+const REGION = 'us-east-1';
+
+/** Records every dependency call so tests can assert what was and was NOT called. */
+function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
+  const calls: string[] = [];
+  const deps: ProvisionDeps = {
+    createProjectForApp: async (p) => {
+      calls.push('createProjectForApp');
+      return { projectId: 'tenant-proj-1', databaseName: p.databaseName, connectionUri: 'postgres://u:p@direct/db' };
+    },
+    ensureRoleExists: async () => { calls.push('ensureRoleExists'); },
+    createDatabase: async () => { calls.push('createDatabase'); return null; },
+    grantSchemaPrivileges: async () => { calls.push('grantSchemaPrivileges'); },
+    withNeonProjectLock: async (_id, fn) => { calls.push('withNeonProjectLock'); return fn(); },
+    getConnectionString: async () => {
+      calls.push('getConnectionString');
+      return {
+        connectionUri: 'postgres://u:p@direct/db',
+        poolerHost: 'ep-x-pooler.us-east-1.aws.neon.tech',
+        pooledConnectionUri: 'postgres://u:p@ep-x-pooler.us-east-1.aws.neon.tech/db',
+      };
+    },
+    waitUntilUriQueryable: async () => { calls.push('waitUntilUriQueryable'); },
+    getDataProjectIdForRegion: () => 'shared-proj-us-east-1',
+    getNeonRegionIdForRegion: () => 'aws-us-east-1',
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe('provisionNeonDbForApp', () => {
+  const original = config.neon.projectPerTenant;
+  afterEach(() => { config.neon.projectPerTenant = original; });
+
+  describe('tenant mode (projectPerTenant = true)', () => {
+    beforeEach(() => { config.neon.projectPerTenant = true; });
+
+    it('creates a dedicated project and returns its id', async () => {
+      const { deps } = makeDeps();
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('tenant-proj-1');
+      expect(result.neonDatabaseName).toBe(`db_${APP_ID}`);
+      expect(result.connectionUri).toBe('postgres://u:p@direct/db');
+    });
+
+    it('NEVER calls grantSchemaPrivileges — neondb_owner does not exist on a tenant project', async () => {
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(calls).not.toContain('grantSchemaPrivileges');
+    });
+
+    it('NEVER calls ensureRoleExists — the role is created by POST /projects', async () => {
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(calls).not.toContain('ensureRoleExists');
+    });
+
+    it('does not take the project lock — a new project has no conflicting operations', async () => {
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(calls).not.toContain('withNeonProjectLock');
+    });
+
+    it('waits for the database to become queryable before returning', async () => {
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(calls).toContain('waitUntilUriQueryable');
+    });
+
+    it('returns the pooled connection string when one is available', async () => {
+      const { deps } = makeDeps();
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(result.poolerConnectionString).toBe('postgres://u:p@ep-x-pooler.us-east-1.aws.neon.tech/db');
+    });
+
+    it('tolerates the pooled lookup failing — the direct URI is enough to serve', async () => {
+      const { deps } = makeDeps({
+        getConnectionString: async () => { throw new Error('pooler lookup exploded'); },
+      });
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(result.poolerConnectionString).toBeNull();
+      expect(result.connectionUri).toBe('postgres://u:p@direct/db');
+    });
+  });
+
+  describe('legacy mode (projectPerTenant = false)', () => {
+    beforeEach(() => { config.neon.projectPerTenant = false; });
+
+    it('creates a database inside the shared project, under the lock', async () => {
+      const { deps, calls } = makeDeps();
+      const result = await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('shared-proj-us-east-1');
+      expect(calls).toContain('withNeonProjectLock');
+      expect(calls).toContain('ensureRoleExists');
+      expect(calls).toContain('createDatabase');
+      expect(calls).toContain('grantSchemaPrivileges');
+    });
+
+    it('never creates a project', async () => {
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+      expect(calls).not.toContain('createProjectForApp');
+    });
+  });
+});

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -8,9 +8,11 @@ const REGION = 'us-east-1';
 /** Records every dependency call so tests can assert what was and was NOT called. */
 function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
   const calls: string[] = [];
+  const createProjectForAppCalls: Parameters<ProvisionDeps['createProjectForApp']>[0][] = [];
   const deps: ProvisionDeps = {
     createProjectForApp: async (p) => {
       calls.push('createProjectForApp');
+      createProjectForAppCalls.push(p);
       return { projectId: 'tenant-proj-1', databaseName: p.databaseName, connectionUri: 'postgres://u:p@direct/db' };
     },
     ensureRoleExists: async () => { calls.push('ensureRoleExists'); },
@@ -28,10 +30,11 @@ function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
     waitUntilUriQueryable: async () => { calls.push('waitUntilUriQueryable'); },
     getDataProjectIdForRegion: () => 'shared-proj-us-east-1',
     getNeonRegionIdForRegion: () => 'aws-us-east-1',
+    getNeonPgVersionForRegion: () => 18,
     findProjectByName: async () => { calls.push('findProjectByName'); return null; },
     ...overrides,
   };
-  return { deps, calls };
+  return { deps, calls, createProjectForAppCalls };
 }
 
 describe('provisionNeonDbForApp', () => {
@@ -50,7 +53,7 @@ describe('provisionNeonDbForApp', () => {
       expect(result.connectionUri).toBe('postgres://u:p@direct/db');
     });
 
-    it('NEVER calls grantSchemaPrivileges — neondb_owner does not exist on a tenant project', async () => {
+    it('NEVER calls grantSchemaPrivileges — the owning role already has schema rights', async () => {
       const { deps, calls } = makeDeps();
       await provisionNeonDbForApp(REGION, APP_ID, deps);
       expect(calls).not.toContain('grantSchemaPrivileges');
@@ -106,6 +109,16 @@ describe('provisionNeonDbForApp', () => {
 
       expect(result.neonProjectId).toBe('tenant-proj-1');
       expect(calls).toContain('createProjectForApp');
+    });
+
+    it('passes the per-region pgVersion through to createProjectForApp', async () => {
+      const { deps, createProjectForAppCalls } = makeDeps({
+        getNeonPgVersionForRegion: () => 18,
+      });
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(createProjectForAppCalls).toHaveLength(1);
+      expect(createProjectForAppCalls[0]?.pgVersion).toBe(18);
     });
   });
 

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -82,14 +82,25 @@ export async function provisionNeonDbForApp(
   if (config.neon.projectPerTenant) {
     // Idempotency: a retried neon_task must adopt the project a crashed
     // earlier attempt already created, or we leak a billed project per retry.
+    // This lookup runs on EVERY tenant provision, not just retries, and an
+    // unguarded throw here aborts the provision — that is deliberate. If the
+    // lookup fails transiently while a project already exists, degrading to
+    // create would produce exactly the duplicate billed project this task
+    // exists to prevent, so we fail closed instead. Aborting is safe: the
+    // neon_tasks queue retries the whole task, and neonFetch already retries
+    // transient failures (423/429/5xx and network errors) before this throws.
     const existing = await deps.findProjectByName(neonClient.projectNameForApp(appId));
 
     let projectId: string;
     let connectionUri: string;
+    // Reused for the pooler lookup below when we adopted rather than created,
+    // so we don't call getConnectionString twice for the same project.
+    let adoptedConn: Awaited<ReturnType<typeof deps.getConnectionString>> | null = null;
 
     if (existing) {
       projectId = existing.id;
-      connectionUri = (await deps.getConnectionString(projectId, neonDbName, owner)).connectionUri;
+      adoptedConn = await deps.getConnectionString(projectId, neonDbName, owner);
+      connectionUri = adoptedConn.connectionUri;
     } else {
       const created = await deps.createProjectForApp({
         appId,
@@ -107,7 +118,7 @@ export async function provisionNeonDbForApp(
     // The pooled URI is a nice-to-have; a failure here must not fail provisioning.
     let poolerConnectionString: string | null = null;
     try {
-      const conn = await deps.getConnectionString(projectId, neonDbName, owner);
+      const conn = adoptedConn ?? (await deps.getConnectionString(projectId, neonDbName, owner));
       poolerConnectionString = pooledFrom(connectionUri, conn.pooledConnectionUri, conn.poolerHost);
     } catch {
       poolerConnectionString = null;

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -1,6 +1,10 @@
 import { config } from '../config.js';
 import * as neonClient from './neon-client.js';
-import { getDataProjectIdForRegion, getNeonRegionIdForRegion } from './neon-projects.js';
+import {
+  getDataProjectIdForRegion,
+  getNeonRegionIdForRegion,
+  getNeonPgVersionForRegion,
+} from './neon-projects.js';
 
 export interface ProvisionedDb {
   connectionUri: string;
@@ -20,6 +24,7 @@ export interface ProvisionDeps {
   waitUntilUriQueryable: typeof neonClient.waitUntilUriQueryable;
   getDataProjectIdForRegion: typeof getDataProjectIdForRegion;
   getNeonRegionIdForRegion: typeof getNeonRegionIdForRegion;
+  getNeonPgVersionForRegion: typeof getNeonPgVersionForRegion;
   findProjectByName: typeof neonClient.findProjectByName;
 }
 
@@ -34,6 +39,7 @@ function defaultDeps(): ProvisionDeps {
     waitUntilUriQueryable: neonClient.waitUntilUriQueryable,
     getDataProjectIdForRegion,
     getNeonRegionIdForRegion,
+    getNeonPgVersionForRegion,
     findProjectByName: neonClient.findProjectByName,
   };
 }
@@ -117,6 +123,7 @@ export async function provisionNeonDbForApp(
         neonRegionId: deps.getNeonRegionIdForRegion(region),
         databaseName: neonDbName,
         ownerRole: owner,
+        pgVersion: deps.getNeonPgVersionForRegion(region),
       });
       projectId = created.projectId;
       connectionUri = created.connectionUri;

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -1,0 +1,127 @@
+import { config } from '../config.js';
+import * as neonClient from './neon-client.js';
+import { getDataProjectIdForRegion, getNeonRegionIdForRegion } from './neon-projects.js';
+
+export interface ProvisionedDb {
+  connectionUri: string;
+  poolerConnectionString: string | null;
+  neonProjectId: string;
+  neonDatabaseName: string;
+}
+
+/** Injectable seam. Every member defaults to the real Neon client. */
+export interface ProvisionDeps {
+  createProjectForApp: typeof neonClient.createProjectForApp;
+  ensureRoleExists: typeof neonClient.ensureRoleExists;
+  createDatabase: typeof neonClient.createDatabase;
+  grantSchemaPrivileges: typeof neonClient.grantSchemaPrivileges;
+  withNeonProjectLock: typeof neonClient.withNeonProjectLock;
+  getConnectionString: typeof neonClient.getConnectionString;
+  waitUntilUriQueryable: typeof neonClient.waitUntilUriQueryable;
+  getDataProjectIdForRegion: typeof getDataProjectIdForRegion;
+  getNeonRegionIdForRegion: typeof getNeonRegionIdForRegion;
+}
+
+function defaultDeps(): ProvisionDeps {
+  return {
+    createProjectForApp: neonClient.createProjectForApp,
+    ensureRoleExists: neonClient.ensureRoleExists,
+    createDatabase: neonClient.createDatabase,
+    grantSchemaPrivileges: neonClient.grantSchemaPrivileges,
+    withNeonProjectLock: neonClient.withNeonProjectLock,
+    getConnectionString: neonClient.getConnectionString,
+    waitUntilUriQueryable: neonClient.waitUntilUriQueryable,
+    getDataProjectIdForRegion,
+    getNeonRegionIdForRegion,
+  };
+}
+
+/** Neon returns pooled hosts as `ep-<id>-pooler...` on the default port.
+ *  We deliberately do NOT rewrite the port — the historical `:6543` rewrite
+ *  is an obsolete Neon convention (design doc §6.2). */
+function pooledFrom(
+  direct: string,
+  pooled: string | undefined,
+  poolerHost: string | undefined,
+): string | null {
+  if (pooled) return pooled;
+  if (!poolerHost) return null;
+  try {
+    const url = new URL(direct);
+    url.hostname = poolerHost;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Provision the customer Postgres database for one app and return everything
+ * the caller needs to write `app_db_connections`.
+ *
+ * Two shapes, selected by `config.neon.projectPerTenant`:
+ *
+ *   tenant — one Neon project per app. Single POST creates project, database
+ *            and owner role. No role bootstrap, no schema grant, no lock.
+ *   legacy — a database inside the region's shared project, serialised behind
+ *            the Redis mutex because concurrent creates on one project return
+ *            HTTP 423.
+ *
+ * The caller owns migrations and all database writes.
+ */
+export async function provisionNeonDbForApp(
+  region: string,
+  appId: string,
+  deps: ProvisionDeps = defaultDeps(),
+): Promise<ProvisionedDb> {
+  const neonDbName = `db_${appId}`;
+  const owner = config.neon.databaseOwner;
+
+  if (config.neon.projectPerTenant) {
+    const created = await deps.createProjectForApp({
+      appId,
+      neonRegionId: deps.getNeonRegionIdForRegion(region),
+      databaseName: neonDbName,
+      ownerRole: owner,
+    });
+
+    // POST /projects returns while create_timeline/start_compute are still running.
+    await deps.waitUntilUriQueryable(created.connectionUri, neonDbName);
+
+    // The pooled URI is a nice-to-have; a failure here must not fail provisioning.
+    let poolerConnectionString: string | null = null;
+    try {
+      const conn = await deps.getConnectionString(created.projectId, neonDbName, owner);
+      poolerConnectionString = pooledFrom(created.connectionUri, conn.pooledConnectionUri, conn.poolerHost);
+    } catch {
+      poolerConnectionString = null;
+    }
+
+    return {
+      connectionUri: created.connectionUri,
+      poolerConnectionString,
+      neonProjectId: created.projectId,
+      neonDatabaseName: neonDbName,
+    };
+  }
+
+  const dataProjectId = deps.getDataProjectIdForRegion(region);
+
+  await deps.withNeonProjectLock(dataProjectId, async () => {
+    await deps.ensureRoleExists(dataProjectId, owner);
+    await deps.createDatabase(dataProjectId, neonDbName, owner);
+  });
+
+  const conn = await deps.getConnectionString(dataProjectId, neonDbName, owner);
+
+  // PG 15+ revokes CREATE on public from non-owners; the shared project's
+  // databases are owned by neondb_owner, so the app role needs the grant.
+  await deps.grantSchemaPrivileges(dataProjectId, neonDbName, owner);
+
+  return {
+    connectionUri: conn.connectionUri,
+    poolerConnectionString: pooledFrom(conn.connectionUri, conn.pooledConnectionUri, conn.poolerHost),
+    neonProjectId: dataProjectId,
+    neonDatabaseName: neonDbName,
+  };
+}

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -20,6 +20,7 @@ export interface ProvisionDeps {
   waitUntilUriQueryable: typeof neonClient.waitUntilUriQueryable;
   getDataProjectIdForRegion: typeof getDataProjectIdForRegion;
   getNeonRegionIdForRegion: typeof getNeonRegionIdForRegion;
+  findProjectByName: typeof neonClient.findProjectByName;
 }
 
 function defaultDeps(): ProvisionDeps {
@@ -33,6 +34,7 @@ function defaultDeps(): ProvisionDeps {
     waitUntilUriQueryable: neonClient.waitUntilUriQueryable,
     getDataProjectIdForRegion,
     getNeonRegionIdForRegion,
+    findProjectByName: neonClient.findProjectByName,
   };
 }
 
@@ -78,29 +80,43 @@ export async function provisionNeonDbForApp(
   const owner = config.neon.databaseOwner;
 
   if (config.neon.projectPerTenant) {
-    const created = await deps.createProjectForApp({
-      appId,
-      neonRegionId: deps.getNeonRegionIdForRegion(region),
-      databaseName: neonDbName,
-      ownerRole: owner,
-    });
+    // Idempotency: a retried neon_task must adopt the project a crashed
+    // earlier attempt already created, or we leak a billed project per retry.
+    const existing = await deps.findProjectByName(neonClient.projectNameForApp(appId));
+
+    let projectId: string;
+    let connectionUri: string;
+
+    if (existing) {
+      projectId = existing.id;
+      connectionUri = (await deps.getConnectionString(projectId, neonDbName, owner)).connectionUri;
+    } else {
+      const created = await deps.createProjectForApp({
+        appId,
+        neonRegionId: deps.getNeonRegionIdForRegion(region),
+        databaseName: neonDbName,
+        ownerRole: owner,
+      });
+      projectId = created.projectId;
+      connectionUri = created.connectionUri;
+    }
 
     // POST /projects returns while create_timeline/start_compute are still running.
-    await deps.waitUntilUriQueryable(created.connectionUri, neonDbName);
+    await deps.waitUntilUriQueryable(connectionUri, neonDbName);
 
     // The pooled URI is a nice-to-have; a failure here must not fail provisioning.
     let poolerConnectionString: string | null = null;
     try {
-      const conn = await deps.getConnectionString(created.projectId, neonDbName, owner);
-      poolerConnectionString = pooledFrom(created.connectionUri, conn.pooledConnectionUri, conn.poolerHost);
+      const conn = await deps.getConnectionString(projectId, neonDbName, owner);
+      poolerConnectionString = pooledFrom(connectionUri, conn.pooledConnectionUri, conn.poolerHost);
     } catch {
       poolerConnectionString = null;
     }
 
     return {
-      connectionUri: created.connectionUri,
+      connectionUri,
       poolerConnectionString,
-      neonProjectId: created.projectId,
+      neonProjectId: projectId,
       neonDatabaseName: neonDbName,
     };
   }

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -38,9 +38,19 @@ function defaultDeps(): ProvisionDeps {
   };
 }
 
-/** Neon returns pooled hosts as `ep-<id>-pooler...` on the default port.
- *  We deliberately do NOT rewrite the port — the historical `:6543` rewrite
- *  is an obsolete Neon convention (design doc §6.2). */
+/** Pick the pooled connection string for `app_db_connections`.
+ *
+ *  This function does not itself append the historical `:6543` port. It does
+ *  NOT, however, guarantee the port is absent: `getConnectionString` in
+ *  neon-client.ts still sets `url.port = '6543'` on its cached-pooler-host
+ *  branch, and the `pooled` value is returned here verbatim. So the obsolete
+ *  `:6543` convention (design doc §6.2) is not yet fixed — the rewrite just
+ *  lives upstream.
+ *
+ *  Because `getConnectionString` never returns a truthy `poolerHost` without
+ *  also returning `pooledConnectionUri`, the host-construct branch below is
+ *  effectively unreachable today; it is kept as a defensive fallback should
+ *  that upstream contract change. */
 function pooledFrom(
   direct: string,
   pooled: string | undefined,

--- a/services/control-api/src/services/neon-client-create-project.test.ts
+++ b/services/control-api/src/services/neon-client-create-project.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { buildCreateProjectBody, projectNameForApp } from './neon-client.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildCreateProjectBody, projectNameForApp, createProjectForApp, findProjectByName } from './neon-client.js';
 
 describe('projectNameForApp', () => {
   it('prefixes the app id so the reconciler can search for it', () => {
@@ -38,5 +38,70 @@ describe('buildCreateProjectBody', () => {
       project: Record<string, unknown>;
     };
     expect('org_id' in body.project).toBe(false);
+  });
+});
+
+describe('createProjectForApp retry semantics', () => {
+  const params = {
+    appId: 'app_k3f9x2m1qp0z',
+    neonRegionId: 'aws-us-east-1',
+    databaseName: 'db_app_k3f9x2m1qp0z',
+    ownerRole: 'butterbase',
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT retry POST /projects on a network error (a retry would double-bill a project)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createProjectForApp(params)).rejects.toThrow('ECONNRESET');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry POST /projects on a 5xx — Neon may already have created it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('bad gateway', { status: 502 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createProjectForApp(params)).rejects.toThrow('Neon API error 502');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues exactly one POST on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project: { id: 'proj-123' },
+          connection_uris: [{ connection_uri: 'postgresql://u:p@host/db' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const created = await createProjectForApp(params);
+    expect(created.projectId).toBe('proj-123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].method).toBe('POST');
+  });
+
+  it('still retries idempotent GETs (opt-out is scoped to project creation)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ projects: [{ id: 'proj-9', name: 'bb-app_x' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(findProjectByName('bb-app_x')).resolves.toEqual({ id: 'proj-9' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/control-api/src/services/neon-client-create-project.test.ts
+++ b/services/control-api/src/services/neon-client-create-project.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildCreateProjectBody, projectNameForApp } from './neon-client.js';
+
+describe('projectNameForApp', () => {
+  it('prefixes the app id so the reconciler can search for it', () => {
+    expect(projectNameForApp('app_k3f9x2m1qp0z')).toBe('bb-app_k3f9x2m1qp0z');
+  });
+});
+
+describe('buildCreateProjectBody', () => {
+  const params = {
+    appId: 'app_k3f9x2m1qp0z',
+    neonRegionId: 'aws-us-east-1',
+    databaseName: 'db_app_k3f9x2m1qp0z',
+    ownerRole: 'butterbase',
+    orgId: 'org-round-cell-11808374',
+    pgVersion: 17,
+  };
+
+  it('creates project, database and role in a single request body', () => {
+    const body = buildCreateProjectBody(params) as {
+      project: {
+        name: string; org_id: string; region_id: string; pg_version: number;
+        branch: { database_name: string; role_name: string };
+      };
+    };
+
+    expect(body.project.name).toBe('bb-app_k3f9x2m1qp0z');
+    expect(body.project.org_id).toBe('org-round-cell-11808374');
+    expect(body.project.region_id).toBe('aws-us-east-1');
+    expect(body.project.pg_version).toBe(17);
+    expect(body.project.branch.database_name).toBe('db_app_k3f9x2m1qp0z');
+    expect(body.project.branch.role_name).toBe('butterbase');
+  });
+
+  it('omits org_id when none is configured rather than sending an empty string', () => {
+    const body = buildCreateProjectBody({ ...params, orgId: '' }) as {
+      project: Record<string, unknown>;
+    };
+    expect('org_id' in body.project).toBe(false);
+  });
+});

--- a/services/control-api/src/services/neon-client-retry.test.ts
+++ b/services/control-api/src/services/neon-client-retry.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { computeRetryDelayMs } from './neon-client.js';
+
+const BACKOFF = [500, 1000, 2000, 4000, 8000];
+
+describe('computeRetryDelayMs', () => {
+  it('returns null for success and for non-retryable client errors', () => {
+    expect(computeRetryDelayMs(200, null, 1, BACKOFF)).toBeNull();
+    expect(computeRetryDelayMs(400, null, 1, BACKOFF)).toBeNull();
+    expect(computeRetryDelayMs(404, null, 1, BACKOFF)).toBeNull();
+    expect(computeRetryDelayMs(409, null, 1, BACKOFF)).toBeNull();
+  });
+
+  it('retries 423 with the positional backoff', () => {
+    expect(computeRetryDelayMs(423, null, 1, BACKOFF)).toBe(500);
+    expect(computeRetryDelayMs(423, null, 3, BACKOFF)).toBe(2000);
+  });
+
+  it('retries 5xx with the positional backoff', () => {
+    expect(computeRetryDelayMs(500, null, 1, BACKOFF)).toBe(500);
+    expect(computeRetryDelayMs(503, null, 2, BACKOFF)).toBe(1000);
+  });
+
+  it('retries 429 even with no Retry-After header', () => {
+    expect(computeRetryDelayMs(429, null, 1, BACKOFF)).toBe(500);
+  });
+
+  it('honours a numeric Retry-After (seconds) on 429', () => {
+    expect(computeRetryDelayMs(429, '3', 1, BACKOFF)).toBe(3000);
+  });
+
+  it('prefers Retry-After over backoff when it is longer', () => {
+    expect(computeRetryDelayMs(429, '30', 1, BACKOFF)).toBe(30_000);
+  });
+
+  it('ignores an unparseable Retry-After and falls back to backoff', () => {
+    expect(computeRetryDelayMs(429, 'Wed, 21 Oct 2026 07:28:00 GMT', 1, BACKOFF)).toBe(500);
+  });
+
+  it('clamps past the end of the backoff table', () => {
+    expect(computeRetryDelayMs(423, null, 99, BACKOFF)).toBe(8000);
+  });
+});

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -578,8 +578,14 @@ export function buildCreateProjectBody(params: {
  *
  * Unlike the shared-project path this needs NO `ensureRoleExists` (the role
  * is created here), NO `grantSchemaPrivileges` (the role owns the database,
- * and `neondb_owner` does not exist on such a project), and NO project lock
- * (a brand-new project has no concurrent operations to conflict with).
+ * so the grant is redundant), and NO project lock (a brand-new project has no
+ * concurrent operations to conflict with).
+ *
+ * Note: an earlier comment here claimed `grantSchemaPrivileges` would *fail*
+ * because `neondb_owner` does not exist on such a project. That is wrong in
+ * production, where NEON_DATA_DATABASE_OWNER is itself `neondb_owner`, so the
+ * owner role and the grant's connecting role are the same. Skipping the call
+ * is still correct — it is simply redundant, not fatal.
  *
  * The response's operations are still running on return, so the caller must
  * `waitUntilUriQueryable` before using the URI.

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -518,3 +518,86 @@ export async function getConnectionString(
     pooledConnectionUri,
   };
 }
+
+export interface CreatedProject {
+  projectId: string;
+  databaseName: string;
+  connectionUri: string;
+}
+
+/** Project naming convention. The `bb-` prefix makes the tenant reconciler's
+ *  `GET /projects?search=bb-app_` query precise. */
+export function projectNameForApp(appId: string): string {
+  return `bb-${appId}`;
+}
+
+/** Extracted so the request shape is unit-testable without touching the network. */
+export function buildCreateProjectBody(params: {
+  appId: string;
+  neonRegionId: string;
+  databaseName: string;
+  ownerRole: string;
+  orgId?: string;
+  pgVersion?: number;
+}): Record<string, unknown> {
+  const project: Record<string, unknown> = {
+    name: projectNameForApp(params.appId),
+    region_id: params.neonRegionId,
+    pg_version: params.pgVersion ?? config.neon.pgVersion,
+    branch: {
+      database_name: params.databaseName,
+      role_name: params.ownerRole,
+    },
+  };
+  // Sending org_id: '' is rejected; omit it entirely when unset.
+  if (params.orgId) project.org_id = params.orgId;
+  return { project };
+}
+
+/**
+ * Create a dedicated Neon project for one app: project, default branch,
+ * database and owner role in a single API call.
+ *
+ * Unlike the shared-project path this needs NO `ensureRoleExists` (the role
+ * is created here), NO `grantSchemaPrivileges` (the role owns the database,
+ * and `neondb_owner` does not exist on such a project), and NO project lock
+ * (a brand-new project has no concurrent operations to conflict with).
+ *
+ * The response's operations are still running on return, so the caller must
+ * `waitUntilUriQueryable` before using the URI.
+ */
+export async function createProjectForApp(params: {
+  appId: string;
+  neonRegionId: string;
+  databaseName: string;
+  ownerRole: string;
+  orgId?: string;
+  pgVersion?: number;
+}): Promise<CreatedProject> {
+  const res = await neonFetch('/projects', {
+    method: 'POST',
+    body: JSON.stringify(
+      buildCreateProjectBody({ ...params, orgId: params.orgId ?? config.neon.orgId }),
+    ),
+  });
+
+  const data = await res.json() as {
+    project?: { id?: string };
+    connection_uris?: { connection_uri?: string }[];
+  };
+
+  const projectId = data.project?.id;
+  if (!projectId) {
+    throw new Error(`Neon create-project response missing project.id for app ${params.appId}`);
+  }
+
+  // POST /projects returns the connection URI inline. Fall back to the
+  // dedicated endpoint if a future API version stops doing so.
+  let connectionUri = data.connection_uris?.[0]?.connection_uri ?? '';
+  if (!connectionUri) {
+    const resolved = await getConnectionString(projectId, params.databaseName, params.ownerRole);
+    connectionUri = resolved.connectionUri;
+  }
+
+  return { projectId, databaseName: params.databaseName, connectionUri };
+}

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -601,3 +601,23 @@ export async function createProjectForApp(params: {
 
   return { projectId, databaseName: params.databaseName, connectionUri };
 }
+
+/**
+ * Look up a project by its exact name. Used to make tenant provisioning
+ * idempotent: a retried task must adopt the project a crashed earlier
+ * attempt created rather than create a second one.
+ *
+ * `search` does partial matching, so the exact name is re-checked locally.
+ */
+export async function findProjectByName(
+  name: string,
+  orgId: string = config.neon.orgId,
+): Promise<{ id: string } | null> {
+  const params = new URLSearchParams({ search: name, limit: '400' });
+  if (orgId) params.set('org_id', orgId);
+
+  const res = await neonFetch(`/projects?${params}`);
+  const data = await res.json() as { projects?: { id: string; name: string }[] };
+  const match = data.projects?.find((p) => p.name === name);
+  return match ? { id: match.id } : null;
+}

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -2,6 +2,7 @@ import pg from 'pg';
 import { config } from '../config.js';
 import { getRedisClient } from './redis.js';
 import { randomBytes } from 'node:crypto';
+import { TokenBucket } from './neon-rate-limiter.js';
 
 const BASE_URL = 'https://console.neon.tech/api/v2';
 
@@ -116,12 +117,48 @@ export async function withNeonProjectLock<T>(
   throw new Error(`Timed out waiting for Neon project lock (project=${projectId})`.replace(/(:\/\/[^:]*:)[^@]+(@)/g, '$1***$2'));
 }
 
+/**
+ * Account-wide limiter. Neon's budget is per-account, not per-project, so a
+ * single module-level bucket is the correct scope.
+ */
+const neonLimiter = new TokenBucket({
+  ratePerSecond: config.neon.rateLimitRps,
+  burst: config.neon.rateLimitBurst,
+});
+
+/**
+ * Decide whether an HTTP status is retryable and how long to wait.
+ * Returns null when the caller should not retry.
+ *
+ *   423 — Neon "conflicting operations on this project" (shared-project topology)
+ *   429 — account rate limit; Retry-After wins when it is longer than our backoff
+ *   5xx — Neon server error
+ */
+export function computeRetryDelayMs(
+  status: number,
+  retryAfter: string | null,
+  attempt: number,
+  backoffMs: number[],
+): number | null {
+  const retryable = status === 423 || status === 429 || status >= 500;
+  if (!retryable) return null;
+
+  const base = backoffMs[Math.min(attempt - 1, backoffMs.length - 1)] ?? backoffMs[backoffMs.length - 1];
+
+  if (status === 429 && retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) return Math.max(base, seconds * 1000);
+  }
+  return base;
+}
+
 async function neonFetch(path: string, options: RequestInit = {}): Promise<Response> {
   const maxAttempts = 6;
   const backoffMs = [500, 1000, 2000, 4000, 8000];
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let res: Response;
+    await neonLimiter.acquire();
     try {
       res = await fetch(`${BASE_URL}${path}`, {
         ...options,
@@ -141,9 +178,8 @@ async function neonFetch(path: string, options: RequestInit = {}): Promise<Respo
       throw err;
     }
 
-    // Retry on 423 (conflict / operation in progress) and 5xx (server errors)
-    if ((res.status === 423 || res.status >= 500) && attempt < maxAttempts) {
-      const delay = backoffMs[attempt - 1] ?? 8000;
+    const delay = computeRetryDelayMs(res.status, res.headers.get('retry-after'), attempt, backoffMs);
+    if (delay !== null && attempt < maxAttempts) {
       await new Promise((resolve) => globalThis.setTimeout(resolve, delay));
       continue;
     }

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -118,8 +118,13 @@ export async function withNeonProjectLock<T>(
 }
 
 /**
- * Account-wide limiter. Neon's budget is per-account, not per-project, so a
- * single module-level bucket is the correct scope.
+ * Per-process limiter. A single module-level bucket covers every Neon call this
+ * process makes (Neon's budget is per-account, not per-project, so limiting per
+ * project would be the wrong axis). It is NOT account-wide: the total fleet rate
+ * is `rateLimitRps × control-api process count`, so two regional processes at
+ * 10 rps can exceed the ~700/min account budget in theory. Acceptable at current
+ * volume — Neon calls are bursty and rare — but revisit before scaling the
+ * process count or raising the rps.
  */
 const neonLimiter = new TokenBucket({
   ratePerSecond: config.neon.rateLimitRps,
@@ -152,8 +157,21 @@ export function computeRetryDelayMs(
   return base;
 }
 
-async function neonFetch(path: string, options: RequestInit = {}): Promise<Response> {
-  const maxAttempts = 6;
+export interface NeonFetchOptions extends RequestInit {
+  /**
+   * Set to false for non-idempotent requests (e.g. `POST /projects`). A retry
+   * after a lost response or a 502 would issue a second create and produce a
+   * duplicate billed project, which this loop cannot detect. With retry off the
+   * failure surfaces to the caller, whose own task-level retry re-enters the
+   * adopt-before-create path. Defaults to true — GETs and DELETEs are
+   * idempotent and must keep retrying.
+   */
+  retry?: boolean;
+}
+
+async function neonFetch(path: string, options: NeonFetchOptions = {}): Promise<Response> {
+  const { retry = true, ...requestInit } = options;
+  const maxAttempts = retry ? 6 : 1;
   const backoffMs = [500, 1000, 2000, 4000, 8000];
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -161,11 +179,11 @@ async function neonFetch(path: string, options: RequestInit = {}): Promise<Respo
     await neonLimiter.acquire();
     try {
       res = await fetch(`${BASE_URL}${path}`, {
-        ...options,
+        ...requestInit,
         headers: {
           'Authorization': `Bearer ${config.neon.apiKey}`,
           'Content-Type': 'application/json',
-          ...options.headers,
+          ...requestInit.headers,
         },
       });
     } catch (err: unknown) {
@@ -574,8 +592,14 @@ export async function createProjectForApp(params: {
   orgId?: string;
   pgVersion?: number;
 }): Promise<CreatedProject> {
+  // retry: false — POST /projects is not idempotent. If Neon creates the
+  // project but the response is lost (network error) or arrives as a 5xx, a
+  // retry here would create a second billed project with the same name. The
+  // error instead propagates to provisionNeonDbForApp's caller; the neon_tasks
+  // queue re-runs the task and adopt-before-create picks up whatever landed.
   const res = await neonFetch('/projects', {
     method: 'POST',
+    retry: false,
     body: JSON.stringify(
       buildCreateProjectBody({ ...params, orgId: params.orgId ?? config.neon.orgId }),
     ),

--- a/services/control-api/src/services/neon-projects.test.ts
+++ b/services/control-api/src/services/neon-projects.test.ts
@@ -3,6 +3,7 @@ import {
   getDataProjectIdForRegion,
   getRuntimeProjectIdForRegion,
   assertNeonProjectsConfig,
+  getNeonRegionIdForRegion,
   __resetNeonProjectsCache,
 } from './neon-projects.js';
 
@@ -57,5 +58,28 @@ describe('assertNeonProjectsConfig', () => {
     process.env.NEON_DATA_PROJECT_ID_EU_WEST_1 = 'd-euw1';
     // missing NEON_RUNTIME_PROJECT_ID_EU_WEST_1
     expect(() => assertNeonProjectsConfig()).toThrow(/NEON_RUNTIME_PROJECT_ID_EU_WEST_1/);
+  });
+});
+
+describe('getNeonRegionIdForRegion', () => {
+  beforeEach(() => {
+    __resetNeonProjectsCache();
+    delete process.env.NEON_REGION_US_EAST_1;
+    delete process.env.NEON_REGION_AP_SOUTH_1;
+  });
+
+  it('defaults to aws-<region>', () => {
+    expect(getNeonRegionIdForRegion('us-east-1')).toBe('aws-us-east-1');
+    expect(getNeonRegionIdForRegion('us-west-2')).toBe('aws-us-west-2');
+  });
+
+  it('honours an explicit NEON_REGION_<REGION> override', () => {
+    process.env.NEON_REGION_AP_SOUTH_1 = 'azure-ap-south-1';
+    expect(getNeonRegionIdForRegion('ap-south-1')).toBe('azure-ap-south-1');
+  });
+
+  it('derives the env key by upper-casing and underscoring the region', () => {
+    process.env.NEON_REGION_US_EAST_1 = 'aws-us-east-1-custom';
+    expect(getNeonRegionIdForRegion('us-east-1')).toBe('aws-us-east-1-custom');
   });
 });

--- a/services/control-api/src/services/neon-projects.test.ts
+++ b/services/control-api/src/services/neon-projects.test.ts
@@ -4,8 +4,10 @@ import {
   getRuntimeProjectIdForRegion,
   assertNeonProjectsConfig,
   getNeonRegionIdForRegion,
+  getNeonPgVersionForRegion,
   __resetNeonProjectsCache,
 } from './neon-projects.js';
+import { config } from '../config.js';
 
 const SAVED_ENV = { ...process.env };
 
@@ -81,5 +83,26 @@ describe('getNeonRegionIdForRegion', () => {
   it('derives the env key by upper-casing and underscoring the region', () => {
     process.env.NEON_REGION_US_EAST_1 = 'aws-us-east-1-custom';
     expect(getNeonRegionIdForRegion('us-east-1')).toBe('aws-us-east-1-custom');
+  });
+});
+
+describe('getNeonPgVersionForRegion', () => {
+  beforeEach(() => {
+    delete process.env.NEON_PG_VERSION_US_WEST_2;
+    delete process.env.NEON_PG_VERSION_US_EAST_1;
+  });
+
+  it('honours NEON_PG_VERSION_US_WEST_2', () => {
+    process.env.NEON_PG_VERSION_US_WEST_2 = '18';
+    expect(getNeonPgVersionForRegion('us-west-2')).toBe(18);
+  });
+
+  it('falls back to the global default when unset', () => {
+    expect(getNeonPgVersionForRegion('us-west-2')).toBe(config.neon.pgVersion);
+  });
+
+  it('falls back to the global default on a non-numeric value', () => {
+    process.env.NEON_PG_VERSION_US_WEST_2 = 'not-a-number';
+    expect(getNeonPgVersionForRegion('us-west-2')).toBe(config.neon.pgVersion);
   });
 });

--- a/services/control-api/src/services/neon-projects.ts
+++ b/services/control-api/src/services/neon-projects.ts
@@ -1,3 +1,5 @@
+import { config } from '../config.js';
+
 const dataCache = new Map<string, string>();
 const runtimeCache = new Map<string, string>();
 
@@ -43,6 +45,20 @@ export function getNeonRegionIdForRegion(region: string): string {
   const explicit = process.env[envKey('NEON_REGION', region)];
   if (explicit) return explicit;
   return `aws-${region}`;
+}
+
+/**
+ * Postgres major version to use when creating a tenant project in `region`.
+ * Regions can run different major versions on their shared data project
+ * (e.g. us-east-1 is on PG 17, us-west-2 is on PG 18); a new tenant project
+ * MUST match its region's neighbours, not a single global default. Reads
+ * env directly on every call — no caching, matching getNeonRegionIdForRegion.
+ */
+export function getNeonPgVersionForRegion(region: string): number {
+  const raw = process.env[envKey('NEON_PG_VERSION', region)];
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return config.neon.pgVersion;
 }
 
 export function assertNeonProjectsConfig(): void {

--- a/services/control-api/src/services/neon-projects.ts
+++ b/services/control-api/src/services/neon-projects.ts
@@ -33,6 +33,18 @@ export function getRuntimeProjectIdForRegion(region: string): string {
   return value;
 }
 
+/**
+ * Butterbase region → Neon `region_id` for project creation.
+ * Neon ids look like `aws-us-east-1`; our regions look like `us-east-1`,
+ * so the default is a prefix. Override per-region when a region lives on
+ * a different cloud.
+ */
+export function getNeonRegionIdForRegion(region: string): string {
+  const explicit = process.env[envKey('NEON_REGION', region)];
+  if (explicit) return explicit;
+  return `aws-${region}`;
+}
+
 export function assertNeonProjectsConfig(): void {
   const regionsRaw = process.env.BUTTERBASE_REGIONS ?? '';
   const regions = regionsRaw.split(',').map((s) => s.trim()).filter(Boolean);

--- a/services/control-api/src/services/neon-rate-limiter.test.ts
+++ b/services/control-api/src/services/neon-rate-limiter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucket } from './neon-rate-limiter.js';
+
+/** Fake clock: `sleep` advances virtual time instead of waiting. */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => { t += ms; },
+    advance: (ms: number) => { t += ms; },
+    elapsed: () => t,
+  };
+}
+
+describe('TokenBucket', () => {
+  it('allows a full burst immediately without sleeping', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket({ ratePerSecond: 10, burst: 20, now: clock.now, sleep: clock.sleep });
+
+    for (let i = 0; i < 20; i++) await bucket.acquire();
+
+    expect(clock.elapsed()).toBe(0);
+  });
+
+  it('sleeps once the burst is exhausted', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket({ ratePerSecond: 10, burst: 2, now: clock.now, sleep: clock.sleep });
+
+    await bucket.acquire();
+    await bucket.acquire();
+    await bucket.acquire(); // must wait ~100ms for one token at 10rps
+
+    expect(clock.elapsed()).toBeGreaterThanOrEqual(100);
+  });
+
+  it('refills over elapsed time', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket({ ratePerSecond: 10, burst: 5, now: clock.now, sleep: clock.sleep });
+
+    for (let i = 0; i < 5; i++) await bucket.acquire();
+    clock.advance(1000); // 1s at 10rps refills to the burst cap of 5
+
+    for (let i = 0; i < 5; i++) await bucket.acquire();
+    expect(clock.elapsed()).toBe(1000); // no additional sleeping
+  });
+
+  it('never exceeds the burst cap when idle for a long time', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket({ ratePerSecond: 10, burst: 3, now: clock.now, sleep: clock.sleep });
+
+    clock.advance(60_000); // idle a minute
+
+    await bucket.acquire();
+    await bucket.acquire();
+    await bucket.acquire();
+    await bucket.acquire(); // 4th must still wait — cap is 3
+
+    expect(clock.elapsed()).toBeGreaterThan(60_000);
+  });
+
+  it('serialises concurrent acquires so they do not all take the same token', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket({ ratePerSecond: 10, burst: 1, now: clock.now, sleep: clock.sleep });
+
+    await Promise.all([bucket.acquire(), bucket.acquire(), bucket.acquire()]);
+
+    // 1 free + 2 that each wait ~100ms
+    expect(clock.elapsed()).toBeGreaterThanOrEqual(200);
+  });
+});

--- a/services/control-api/src/services/neon-rate-limiter.ts
+++ b/services/control-api/src/services/neon-rate-limiter.ts
@@ -1,0 +1,70 @@
+export interface TokenBucketOptions {
+  /** Sustained rate. */
+  ratePerSecond: number;
+  /** Maximum tokens accumulated while idle. Defaults to ratePerSecond. */
+  burst?: number;
+  /** Injectable for tests. */
+  now?: () => number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Classic token bucket, used to keep our Neon API call rate under the
+ * account-wide budget (700 req/min, burst 40/s per route).
+ *
+ * `acquire()` calls are serialised through a promise chain so that N
+ * concurrent callers consume N tokens rather than all observing the same
+ * one. That serialisation is bookkeeping only — it does not make the
+ * underlying HTTP calls sequential.
+ */
+export class TokenBucket {
+  private tokens: number;
+  private last: number;
+  private readonly rate: number;
+  private readonly burst: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(opts: TokenBucketOptions) {
+    if (opts.ratePerSecond <= 0) throw new Error('TokenBucket: ratePerSecond must be > 0');
+    this.rate = opts.ratePerSecond;
+    this.burst = opts.burst ?? opts.ratePerSecond;
+    this.now = opts.now ?? (() => Date.now());
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => globalThis.setTimeout(r, ms)));
+    this.tokens = this.burst;
+    this.last = this.now();
+  }
+
+  async acquire(): Promise<void> {
+    const run = this.chain.then(() => this.take());
+    // Keep the chain alive even if a take() rejects.
+    this.chain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async take(): Promise<void> {
+    for (;;) {
+      this.refill();
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+      const deficit = 1 - this.tokens;
+      await this.sleep(Math.max(1, Math.ceil((deficit / this.rate) * 1000)));
+    }
+  }
+
+  private refill(): void {
+    const t = this.now();
+    const elapsedSec = (t - this.last) / 1000;
+    if (elapsedSec > 0) {
+      this.tokens = Math.min(this.burst, this.tokens + elapsedSec * this.rate);
+      this.last = t;
+    }
+  }
+}

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -4,7 +4,7 @@ import { config, assertRegionConfig } from '../config.js';
 import { getRuntimeDbPool } from './runtime-db.js';
 import { getRuntimeDbForApp } from './region-resolver.js';
 import * as neonClient from './neon-client.js';
-import { getDataProjectIdForRegion } from './neon-projects.js';
+import { provisionNeonDbForApp } from './app-db-provision.js';
 import { runMigrationsWithRetry, generateAppId, insertAppRow, provisionAppBackground } from './provisioner.js';
 import { runDataPlaneMigrations } from './migrator.js';
 import { notifyProvisioningFailed, notifyCloneFailed } from './failure-notifications.service.js';
@@ -242,58 +242,31 @@ async function executeProvision(
   const runtimePool = await getRuntimeDbForApp(controlDb, appId);
 
   if (config.neon.enabled) {
-    const neonDbName = `db_${appId}`;
-    const owner = config.neon.databaseOwner;
-
-    // Resolve which Neon data project to use based on the app's region
+    // The app's home region may differ from this worker's region.
     const appRegionRow = await runtimePool.query<{ region: string }>(
       `SELECT region FROM apps WHERE id = $1`,
       [appId],
     );
     if (appRegionRow.rows.length === 0) throw new Error(`neon-task-worker: app ${appId} not found`);
     const appRegion = appRegionRow.rows[0].region;
-    const dataProjectId = getDataProjectIdForRegion(appRegion);
 
-    // Serialize mutating Neon API calls
-    await neonClient.withNeonProjectLock(dataProjectId, async () => {
-      await neonClient.ensureRoleExists(dataProjectId, owner);
-      try {
-        await neonClient.createDatabase(dataProjectId, neonDbName, owner);
-      } catch (err) {
-        // Idempotency: if DB already exists (crashed previous attempt), continue
-        const msg = err instanceof Error ? err.message : '';
-        if (msg.includes('already exists')) {
-          logger.info({ appId, neonDbName }, '[neon-task-worker] Database already exists, continuing');
-        } else {
-          throw err;
-        }
-      }
-    });
-
-    const { connectionUri, poolerHost, pooledConnectionUri } =
-      await neonClient.getConnectionString(dataProjectId, neonDbName, owner);
-
-    await neonClient.grantSchemaPrivileges(dataProjectId, neonDbName, owner);
-
-    let poolerConnectionString: string | null = null;
-    if (pooledConnectionUri) {
-      poolerConnectionString = pooledConnectionUri;
-    } else if (poolerHost) {
-      const url = new URL(connectionUri);
-      url.hostname = poolerHost;
-      url.port = '6543';
-      poolerConnectionString = url.toString();
-    }
+    const provisioned = await provisionNeonDbForApp(appRegion, appId);
 
     // app_db_connections is a runtime-tier table
     await runtimePool.query(
       `INSERT INTO app_db_connections (app_id, connection_string, pooler_connection_string, neon_project_id, neon_database_name)
        VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (app_id) DO NOTHING`,
-      [appId, connectionUri, poolerConnectionString, dataProjectId, neonDbName],
+      [
+        appId,
+        provisioned.connectionUri,
+        provisioned.poolerConnectionString,
+        provisioned.neonProjectId,
+        provisioned.neonDatabaseName,
+      ],
     );
 
-    await runMigrationsWithRetry(connectionUri);
+    await runMigrationsWithRetry(provisioned.connectionUri);
   } else {
     // Local dev
     const client = await dataPlaneDb.connect();

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -252,11 +252,20 @@ async function executeProvision(
 
     const provisioned = await provisionNeonDbForApp(appRegion, appId);
 
-    // app_db_connections is a runtime-tier table
+    // app_db_connections is a runtime-tier table.
+    // DO UPDATE, not DO NOTHING: the clone-resume re-provision path can reach
+    // here with a row already present. Dropping the insert would leave the app
+    // pointing at the old database while the freshly created tenant project
+    // bills unrecorded. With project-per-tenant off this rewrites identical
+    // values (same shared project id, same db_<appId> name).
     await runtimePool.query(
       `INSERT INTO app_db_connections (app_id, connection_string, pooler_connection_string, neon_project_id, neon_database_name)
        VALUES ($1, $2, $3, $4, $5)
-       ON CONFLICT (app_id) DO NOTHING`,
+       ON CONFLICT (app_id) DO UPDATE
+         SET connection_string = EXCLUDED.connection_string,
+             pooler_connection_string = EXCLUDED.pooler_connection_string,
+             neon_project_id = EXCLUDED.neon_project_id,
+             neon_database_name = EXCLUDED.neon_database_name`,
       [
         appId,
         provisioned.connectionUri,

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -5,6 +5,7 @@ import { getRuntimeDbPool } from './runtime-db.js';
 import { runDataPlaneMigrations } from './migrator.js';
 import * as neonClient from './neon-client.js';
 import { getDataProjectIdForRegion } from './neon-projects.js';
+import { provisionNeonDbForApp } from './app-db-provision.js';
 import {
   APP_ID_PREFIX,
   APP_ID_LENGTH,
@@ -141,40 +142,22 @@ export async function provisionAppBackground(
 
   try {
     if (config.neon.enabled) {
-      const dataProjectId = getDataProjectIdForRegion(region);
-      const neonDbName = `db_${appId}`;
-      const owner = config.neon.databaseOwner;
-
-      // Serialize mutating Neon API calls; read-only getConnectionString runs outside the lock.
-      await neonClient.withNeonProjectLock(dataProjectId, async () => {
-        await neonClient.ensureRoleExists(dataProjectId, owner);
-        await neonClient.createDatabase(dataProjectId, neonDbName, owner);
-      });
-
-      const { connectionUri, poolerHost, pooledConnectionUri } =
-        await neonClient.getConnectionString(dataProjectId, neonDbName, owner);
-
-      // PG 15+ revokes CREATE on public schema by default; grant it to the app role
-      await neonClient.grantSchemaPrivileges(dataProjectId, neonDbName, owner);
-
-      let poolerConnectionString: string | null = null;
-      if (pooledConnectionUri) {
-        poolerConnectionString = pooledConnectionUri;
-      } else if (poolerHost) {
-        const url = new URL(connectionUri);
-        url.hostname = poolerHost;
-        url.port = '6543';
-        poolerConnectionString = url.toString();
-      }
+      const provisioned = await provisionNeonDbForApp(region, appId);
 
       await runtimeDb.query(
         `INSERT INTO app_db_connections (app_id, connection_string, pooler_connection_string, neon_project_id, neon_database_name)
          VALUES ($1, $2, $3, $4, $5)
          ON CONFLICT (app_id) DO NOTHING`,
-        [appId, connectionUri, poolerConnectionString, dataProjectId, neonDbName]
+        [
+          appId,
+          provisioned.connectionUri,
+          provisioned.poolerConnectionString,
+          provisioned.neonProjectId,
+          provisioned.neonDatabaseName,
+        ]
       );
 
-      await runMigrationsWithRetry(connectionUri);
+      await runMigrationsWithRetry(provisioned.connectionUri);
     } else {
       const client = await dataPlaneDb.connect();
       try {

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -145,9 +145,17 @@ export async function provisionAppBackground(
       const provisioned = await provisionNeonDbForApp(region, appId);
 
       await runtimeDb.query(
+        // DO UPDATE, not DO NOTHING: a re-provision (e.g. clone-resume) can
+        // create a fresh Neon project, and dropping the row would leave the app
+        // pointing at the old database while the new project bills unrecorded.
+        // With project-per-tenant off this rewrites identical values.
         `INSERT INTO app_db_connections (app_id, connection_string, pooler_connection_string, neon_project_id, neon_database_name)
          VALUES ($1, $2, $3, $4, $5)
-         ON CONFLICT (app_id) DO NOTHING`,
+         ON CONFLICT (app_id) DO UPDATE
+           SET connection_string = EXCLUDED.connection_string,
+               pooler_connection_string = EXCLUDED.pooler_connection_string,
+               neon_project_id = EXCLUDED.neon_project_id,
+               neon_database_name = EXCLUDED.neon_database_name`,
         [
           appId,
           provisioned.connectionUri,


### PR DESCRIPTION
Adds the machinery to provision each app into its own Neon project instead of a database inside a shared per-region project. **Ships dormant** — `BUTTERBASE_PROJECT_PER_TENANT` defaults to `false` and the tenant path is unreachable until it is set.

Design: `docs/superpowers/specs/2026-08-20-neon-project-per-app-design.md` (internal repo).

## Why

Neon caps databases at 500 per branch. Measured against production on 2026-08-20:

| Region | Databases | Cap |
|---|---|---|
| us-east-1 | 394 | 500 |
| us-west-2 | 388 | 500 |

Both regions are ~78% full. Project-per-app removes the ceiling (100k projects granted) and also removes the Redis mutex that currently serialises every app creation in a region.

## The load-bearing measurement

Raw calls against the real Neon API, no retry, no lock:

| Concurrency | `POST /projects` | database creates in one project |
|---|---|---|
| 10 | 10/10 succeed, 0 conflicts | 3/10 — **7 × HTTP 423** |
| 40 | 40/40 succeed, 0 conflicts | 4/40 — **36 × HTTP 423** |

HTTP 423 is scoped to a single project's operation set, so the shared-project topology degrades under load while per-project provisioning scales flat. That is why `withNeonProjectLock` exists, and why it is unnecessary for tenant projects.

## What's here

- `TokenBucket` rate limiter guarding the account-wide Neon budget (700 req/min), wired into `neonFetch`, with 429 + `Retry-After` handling.
- `createProjectForApp` — project, database and owner role in one `POST /projects`.
- `provisionNeonDbForApp` — single seam owning the legacy-vs-tenant branch; both existing call sites (`provisionAppBackground`, `executeProvision`) now route through it instead of carrying duplicate copies of the Neon sequence.
- Adopt-before-create, so a retried `neon_tasks` provision reuses an existing project rather than creating a second billed one.
- `POST /projects` made non-retryable — `neonFetch`'s retry would otherwise duplicate a project when a response is lost.
- Per-region Postgres version (`NEON_PG_VERSION_<REGION>`), because us-east-1 runs PG 17 and us-west-2 runs PG 18.

No schema migrations. `app_db_connections.neon_project_id` already existed and was already per-app; it simply starts holding distinct values.

## Verification

- Flag-off behaviour is unchanged: the legacy branch reproduces the previous sequence operation-for-operation, verified against the deleted code.
- 8 test suites, 58 tests. Three of them assert the tenant path never calls `grantSchemaPrivileges`, `ensureRoleExists` or `withNeonProjectLock`.
- An opt-in live concurrency regression (`NEON_LIVE_TEST=1`) asserts zero 423s; inert by default.
- Production image builds and loads, including with pathological rate-limit env values.

## Not in scope

Enabling the flag (Phase 3), the tenant delete path and reconciler (Phase 4), and the backfill (Phase 5). Phase 3 is blocked on routing `provisionAppDb` (move-app) through the same helper.
