### PR TITLE
feat(neon): region-scope tenant project names; route provisionAppDb + abort through the tenant path

### DIFF
--- a/services/control-api/src/services/__tests__/neon-project-live.integration.test.ts
+++ b/services/control-api/src/services/__tests__/neon-project-live.integration.test.ts
@@ -30,6 +30,7 @@ describe.skipIf(!LIVE)('Neon tenant project provisioning (live)', () => {
       Array.from({ length: CONCURRENCY }, (_, i) =>
         createProjectForApp({
           appId: `app_livetest${String(i).padStart(4, '0')}`,
+          region: 'us-east-1',
           neonRegionId: 'aws-us-east-1',
           databaseName: `db_app_livetest${String(i).padStart(4, '0')}`,
           ownerRole: config.neon.databaseOwner,
@@ -51,6 +52,6 @@ describe.skipIf(!LIVE)('Neon tenant project provisioning (live)', () => {
   }, 120_000);
 
   it('names projects so the reconciler can find them', () => {
-    expect(projectNameForApp('app_livetest0000')).toBe('bb-app_livetest0000');
+    expect(projectNameForApp('app_livetest0000', 'us-east-1')).toBe('bb-app_livetest0000-us-east-1');
   });
 });

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -9,6 +9,7 @@ const REGION = 'us-east-1';
 function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
   const calls: string[] = [];
   const createProjectForAppCalls: Parameters<ProvisionDeps['createProjectForApp']>[0][] = [];
+  const findProjectByNameCalls: string[] = [];
   const deps: ProvisionDeps = {
     createProjectForApp: async (p) => {
       calls.push('createProjectForApp');
@@ -31,10 +32,14 @@ function makeDeps(overrides: Partial<ProvisionDeps> = {}) {
     getDataProjectIdForRegion: () => 'shared-proj-us-east-1',
     getNeonRegionIdForRegion: () => 'aws-us-east-1',
     getNeonPgVersionForRegion: () => 18,
-    findProjectByName: async () => { calls.push('findProjectByName'); return null; },
+    findProjectByName: async (name) => {
+      calls.push('findProjectByName');
+      findProjectByNameCalls.push(name);
+      return null;
+    },
     ...overrides,
   };
-  return { deps, calls, createProjectForAppCalls };
+  return { deps, calls, createProjectForAppCalls, findProjectByNameCalls };
 }
 
 describe('provisionNeonDbForApp', () => {
@@ -109,6 +114,34 @@ describe('provisionNeonDbForApp', () => {
 
       expect(result.neonProjectId).toBe('tenant-proj-1');
       expect(calls).toContain('createProjectForApp');
+    });
+
+    it('looks up the adoptable project by its region-scoped name', async () => {
+      const { deps, findProjectByNameCalls } = makeDeps();
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(findProjectByNameCalls).toEqual([`bb-${APP_ID}-${REGION}`]);
+    });
+
+    it('scopes the adopt lookup per region so a retained source is never adopted by the dest', async () => {
+      const { deps, findProjectByNameCalls } = makeDeps();
+      await provisionNeonDbForApp('us-east-1', APP_ID, deps);
+      await provisionNeonDbForApp('eu-west-1', APP_ID, deps);
+
+      expect(findProjectByNameCalls).toEqual([
+        `bb-${APP_ID}-us-east-1`,
+        `bb-${APP_ID}-eu-west-1`,
+      ]);
+    });
+
+    it('passes the Butterbase region and the Neon region id as separate params', async () => {
+      const { deps, createProjectForAppCalls } = makeDeps({
+        getNeonRegionIdForRegion: () => 'aws-us-east-1',
+      });
+      await provisionNeonDbForApp(REGION, APP_ID, deps);
+
+      expect(createProjectForAppCalls[0]?.region).toBe(REGION);
+      expect(createProjectForAppCalls[0]?.neonRegionId).toBe('aws-us-east-1');
     });
 
     it('passes the per-region pgVersion through to createProjectForApp', async () => {

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -105,7 +105,7 @@ export async function provisionNeonDbForApp(
     // exists to prevent, so we fail closed instead. Aborting is safe: the
     // neon_tasks queue retries the whole task, and neonFetch already retries
     // transient failures (423/429/5xx and network errors) before this throws.
-    const existing = await deps.findProjectByName(neonClient.projectNameForApp(appId));
+    const existing = await deps.findProjectByName(neonClient.projectNameForApp(appId, region));
 
     let projectId: string;
     let connectionUri: string;
@@ -120,6 +120,7 @@ export async function provisionNeonDbForApp(
     } else {
       const created = await deps.createProjectForApp({
         appId,
+        region,
         neonRegionId: deps.getNeonRegionIdForRegion(region),
         databaseName: neonDbName,
         ownerRole: owner,

--- a/services/control-api/src/services/move-app/step-abort.test.ts
+++ b/services/control-api/src/services/move-app/step-abort.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // vi.mock is hoisted before variable declarations, so mocks must use vi.fn() inline.
 vi.mock('../kv/migration-sentinel.js', () => ({ clearKvBlock: vi.fn().mockResolvedValue(undefined) }));
@@ -8,12 +8,14 @@ vi.mock('../region-resolver.js', () => ({ invalidateAppRegion: vi.fn().mockResol
 vi.mock('../neon-client.js', () => ({
   withNeonProjectLock: vi.fn().mockImplementation((_id: string, fn: () => Promise<void>) => fn()),
   deleteDatabase: vi.fn().mockResolvedValue(undefined),
+  deleteProject: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../neon-projects.js', () => ({ getDataProjectIdForRegion: vi.fn().mockReturnValue('proj-123') }));
 
 import { executeAbort } from './step-abort.js';
 import { clearKvBlock } from '../kv/migration-sentinel.js';
 import { kvRedisFor } from '../kv/redis-registry.js';
+import { deleteDatabase, deleteProject } from '../neon-client.js';
 
 const makeCtx = (): any => {
   const queryFn = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -99,5 +101,92 @@ describe('executeAbort', () => {
 
     expect(res.next).toBe('aborted');
     expect(ctx.log.warn).toHaveBeenCalled();
+  });
+});
+
+describe('executeAbort — dest Neon teardown', () => {
+  // getDataProjectIdForRegion is mocked to 'proj-123' above: that is the dest
+  // region's SHARED data project.
+  const SHARED_PROJECT = 'proj-123';
+
+  const makeCtxWithConn = (connRow: Record<string, string> | null): any => {
+    const queryFn = vi.fn().mockImplementation((sql: string) =>
+      sql.includes('SELECT neon_project_id')
+        ? Promise.resolve({ rows: connRow ? [connRow] : [], rowCount: connRow ? 1 : 0 })
+        : Promise.resolve({ rows: [], rowCount: 1 }),
+    );
+    return {
+      controlPool: { query: queryFn },
+      runtimePoolFor: vi.fn().mockReturnValue({ query: queryFn }),
+      redisFor: vi.fn().mockReturnValue({}),
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      _queryFn: queryFn,
+    };
+  };
+
+  beforeEach(() => {
+    vi.mocked(clearKvBlock).mockReset().mockResolvedValue(undefined);
+    vi.mocked(deleteDatabase).mockReset().mockResolvedValue(undefined);
+    vi.mocked(deleteProject).mockReset().mockResolvedValue(undefined);
+  });
+
+  it('tenant: deletes the whole dest project, not a database inside the shared one', async () => {
+    const ctx = makeCtxWithConn({
+      neon_project_id: 'tenant-proj-9',
+      neon_database_name: 'db_app-x',
+    });
+    const m = makeMigration({
+      dest_resources: { dest_app_id: 'dest-app-y', neon_db_name: 'cust_app_x_eu' },
+    });
+
+    const res = await executeAbort(ctx, m);
+
+    expect(res.next).toBe('aborted');
+    expect(deleteProject).toHaveBeenCalledWith('tenant-proj-9');
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('tenant: an already-gone project (404) is success, not a warning', async () => {
+    vi.mocked(deleteProject).mockRejectedValue(new Error('Neon API error 404 /projects/tenant-proj-9: not found'));
+    const ctx = makeCtxWithConn({
+      neon_project_id: 'tenant-proj-9',
+      neon_database_name: 'db_app-x',
+    });
+    const m = makeMigration({ dest_resources: { dest_app_id: 'dest-app-y' } });
+
+    const res = await executeAbort(ctx, m);
+
+    expect(res.next).toBe('aborted');
+    expect(ctx.log.info).toHaveBeenCalled();
+    expect(ctx.log.warn).not.toHaveBeenCalled();
+  });
+
+  it('legacy: a row on the shared data project still deletes the database', async () => {
+    const ctx = makeCtxWithConn({
+      neon_project_id: SHARED_PROJECT,
+      neon_database_name: 'cust_app_x_eu',
+    });
+    const m = makeMigration({
+      dest_resources: { dest_app_id: 'dest-app-y', neon_db_name: 'cust_app_x_eu' },
+    });
+
+    const res = await executeAbort(ctx, m);
+
+    expect(res.next).toBe('aborted');
+    expect(deleteDatabase).toHaveBeenCalledWith(SHARED_PROJECT, 'cust_app_x_eu');
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('legacy: no app_db_connections row keeps the pre-existing shared-project teardown', async () => {
+    const ctx = makeCtxWithConn(null);
+    const m = makeMigration({
+      dest_resources: { dest_app_id: 'dest-app-y', neon_db_name: 'cust_app_x_eu' },
+    });
+
+    const res = await executeAbort(ctx, m);
+
+    expect(res.next).toBe('aborted');
+    expect(deleteDatabase).toHaveBeenCalledWith(SHARED_PROJECT, 'cust_app_x_eu');
+    expect(deleteProject).not.toHaveBeenCalled();
   });
 });

--- a/services/control-api/src/services/move-app/step-abort.ts
+++ b/services/control-api/src/services/move-app/step-abort.ts
@@ -27,6 +27,30 @@ import { wrap } from '../kv/redis-client.js';
  * (saga-executor enforces this).
  */
 export const executeAbort: StepHandler = async (ctx, m) => {
+  // 0) Read the dest `app_db_connections` row BEFORE step 1 deletes it. Its
+  //    `neon_project_id` is the discriminator between the two teardown shapes
+  //    (same one `executeDeprovision` uses): equal to the region's shared data
+  //    project means the legacy `cust_*` database lives inside it; anything
+  //    else means provisionAppDb took the project-per-tenant path and created
+  //    a dedicated project that must be deleted whole, or it bills forever and
+  //    a retry adopts a project that already has the schema.
+  let destConn: { neon_project_id: string; neon_database_name: string } | null = null;
+  if (m.dest_resources.dest_app_id) {
+    try {
+      const destPool = ctx.runtimePoolFor(m.dest_region);
+      const r = await destPool.query<{ neon_project_id: string; neon_database_name: string }>(
+        `SELECT neon_project_id, neon_database_name FROM app_db_connections WHERE app_id = $1`,
+        [m.app_id],
+      );
+      destConn = r.rows?.[0] ?? null;
+    } catch (err) {
+      ctx.log.warn(
+        { migrationId: m.id, err: (err as Error).message },
+        '[move-app abort] dest app_db_connections lookup failed; falling back to shared-project teardown',
+      );
+    }
+  }
+
   // 1) Remove the dest reservation row, if reserving_dest got far enough
   //    to create it. Idempotent: row may already be gone.
   if (m.dest_resources.dest_app_id) {
@@ -54,19 +78,49 @@ export const executeAbort: StepHandler = async (ctx, m) => {
   //     Without this, restoring_data fails on the second attempt with
   //     'schema "realtime" already exists' (or similar) because the prior
   //     attempt's restore left objects behind in the same Neon DB.
-  const neonDbName = m.dest_resources.neon_db_name as string | undefined;
-  if (neonDbName) {
-    const dataProjectId = getDataProjectIdForRegion(m.dest_region);
-    if (dataProjectId) {
-      try {
-        await neonClient.withNeonProjectLock(dataProjectId, async () => {
-          await neonClient.deleteDatabase(dataProjectId, neonDbName);
-        });
-      } catch (err) {
-        ctx.log.warn(
-          { migrationId: m.id, neonDbName, err: (err as Error).message },
-          '[move-app abort] dest Neon DB delete failed; continuing (manual cleanup may be needed)',
+  //     Under project-per-tenant the dest is a whole project, not a database
+  //     inside the shared one, so the tenant branch deletes the project.
+  const tenantProjectId =
+    destConn?.neon_project_id &&
+    destConn.neon_project_id !== getDataProjectIdForRegion(m.dest_region)
+      ? destConn.neon_project_id
+      : null;
+
+  if (tenantProjectId) {
+    try {
+      await neonClient.withNeonProjectLock(tenantProjectId, async () => {
+        await neonClient.deleteProject(tenantProjectId);
+      });
+    } catch (err) {
+      // Idempotency: an already-deleted project (404) is success, not an error.
+      const msg = err instanceof Error ? err.message : '';
+      if (msg.includes('404') || msg.includes('not found')) {
+        ctx.log.info(
+          { migrationId: m.id, neonProjectId: tenantProjectId },
+          '[move-app abort] dest Neon project already deleted, continuing',
         );
+      } else {
+        ctx.log.warn(
+          { migrationId: m.id, neonProjectId: tenantProjectId, err: msg },
+          '[move-app abort] dest Neon project delete failed; continuing (manual cleanup may be needed)',
+        );
+      }
+    }
+  } else {
+    const neonDbName = m.dest_resources.neon_db_name as string | undefined;
+    if (neonDbName) {
+      const dataProjectId = getDataProjectIdForRegion(m.dest_region);
+      if (dataProjectId) {
+        try {
+          await neonClient.withNeonProjectLock(dataProjectId, async () => {
+            await neonClient.deleteDatabase(dataProjectId, neonDbName);
+          });
+        } catch (err) {
+          ctx.log.warn(
+            { migrationId: m.id, neonDbName, err: (err as Error).message },
+            '[move-app abort] dest Neon DB delete failed; continuing (manual cleanup may be needed)',
+          );
+        }
       }
     }
   }

--- a/services/control-api/src/services/move-app/step-reserve-dest.test.ts
+++ b/services/control-api/src/services/move-app/step-reserve-dest.test.ts
@@ -40,4 +40,23 @@ describe('executeReserveDest', () => {
     expect(res.next).toBe('blocking_writes');
     expect(ctx.provisionAppDb).not.toHaveBeenCalled();
   });
+
+  it('rejects a same-region move before touching either region', async () => {
+    const runtime = { query: vi.fn() };
+    const ctx: any = {
+      controlPool: { query: vi.fn() },
+      runtimePoolFor: () => runtime,
+      redisFor: () => null,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      provisionAppDb: vi.fn(),
+    };
+    const m: any = {
+      id: 'mig-3', app_id: 'app-x', user_id: 'u', source_region: 'us-east-1',
+      dest_region: 'us-east-1', current_step: 'reserving_dest', dest_resources: {},
+    };
+
+    await expect(executeReserveDest(ctx, m)).rejects.toThrow(/us-east-1/);
+    expect(ctx.provisionAppDb).not.toHaveBeenCalled();
+    expect(runtime.query).not.toHaveBeenCalled();
+  });
 });

--- a/services/control-api/src/services/move-app/step-reserve-dest.ts
+++ b/services/control-api/src/services/move-app/step-reserve-dest.ts
@@ -12,6 +12,17 @@ export interface ReserveDestCtx {
 
 export const executeReserveDest: StepHandler = async (ctx, m) => {
   const cx = ctx as unknown as ReserveDestCtx & typeof ctx;
+
+  // Moving an app to the region it already occupies is a no-op, and it is the
+  // one case where the source and destination Neon projects would collide on
+  // name under region-scoped naming (`bb-<appId>-<region>`) — the source
+  // database is retained after cutover, so both would exist at once.
+  if (m.dest_region === m.source_region) {
+    throw new Error(
+      `cannot move app ${m.app_id} to its current region ${m.dest_region}: source and destination regions must differ`,
+    );
+  }
+
   const destPool = ctx.runtimePoolFor(m.dest_region);
 
   if (!m.dest_resources.dest_app_id) {

--- a/services/control-api/src/services/neon-client-create-project.test.ts
+++ b/services/control-api/src/services/neon-client-create-project.test.ts
@@ -3,13 +3,19 @@ import { buildCreateProjectBody, projectNameForApp, createProjectForApp, findPro
 
 describe('projectNameForApp', () => {
   it('prefixes the app id so the reconciler can search for it', () => {
-    expect(projectNameForApp('app_k3f9x2m1qp0z')).toBe('bb-app_k3f9x2m1qp0z');
+    expect(projectNameForApp('app_k3f9x2m1qp0z', 'us-east-1')).toBe('bb-app_k3f9x2m1qp0z-us-east-1');
+  });
+
+  it('suffixes the region so a moved app cannot collide with its retained source', () => {
+    expect(projectNameForApp('app_x', 'us-west-2')).toBe('bb-app_x-us-west-2');
+    expect(projectNameForApp('app_x', 'us-west-2')).not.toBe(projectNameForApp('app_x', 'us-east-1'));
   });
 });
 
 describe('buildCreateProjectBody', () => {
   const params = {
     appId: 'app_k3f9x2m1qp0z',
+    region: 'us-east-1',
     neonRegionId: 'aws-us-east-1',
     databaseName: 'db_app_k3f9x2m1qp0z',
     ownerRole: 'butterbase',
@@ -25,12 +31,23 @@ describe('buildCreateProjectBody', () => {
       };
     };
 
-    expect(body.project.name).toBe('bb-app_k3f9x2m1qp0z');
+    expect(body.project.name).toBe('bb-app_k3f9x2m1qp0z-us-east-1');
     expect(body.project.org_id).toBe('org-round-cell-11808374');
     expect(body.project.region_id).toBe('aws-us-east-1');
     expect(body.project.pg_version).toBe(17);
     expect(body.project.branch.database_name).toBe('db_app_k3f9x2m1qp0z');
     expect(body.project.branch.role_name).toBe('butterbase');
+  });
+
+  it('keeps the region-scoped name and the Neon region id as separate fields', () => {
+    const body = buildCreateProjectBody({
+      ...params,
+      region: 'us-west-2',
+      neonRegionId: 'aws-us-west-2',
+    }) as { project: { name: string; region_id: string } };
+
+    expect(body.project.name).toBe('bb-app_k3f9x2m1qp0z-us-west-2');
+    expect(body.project.region_id).toBe('aws-us-west-2');
   });
 
   it('omits org_id when none is configured rather than sending an empty string', () => {
@@ -44,6 +61,7 @@ describe('buildCreateProjectBody', () => {
 describe('createProjectForApp retry semantics', () => {
   const params = {
     appId: 'app_k3f9x2m1qp0z',
+    region: 'us-east-1',
     neonRegionId: 'aws-us-east-1',
     databaseName: 'db_app_k3f9x2m1qp0z',
     ownerRole: 'butterbase',

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -544,14 +544,25 @@ export interface CreatedProject {
 }
 
 /** Project naming convention. The `bb-` prefix makes the tenant reconciler's
- *  `GET /projects?search=bb-app_` query precise. */
-export function projectNameForApp(appId: string): string {
-  return `bb-${appId}`;
+ *  `GET /projects?search=bb-app_` query precise.
+ *
+ *  The region suffix is load-bearing, not decoration: an app keeps its `app_id`
+ *  across a region move and the source database is retained after cutover, so
+ *  one app legitimately owns storage in two regions at once. Without the
+ *  suffix, source and destination projects would share a name and
+ *  `findProjectByName`'s exact match could adopt the wrong side of an
+ *  in-flight move. `region` is the Butterbase region (`us-west-2`), not the
+ *  Neon region id (`aws-us-west-2`). */
+export function projectNameForApp(appId: string, region: string): string {
+  return `bb-${appId}-${region}`;
 }
 
 /** Extracted so the request shape is unit-testable without touching the network. */
 export function buildCreateProjectBody(params: {
   appId: string;
+  /** Butterbase region, e.g. `us-west-2`. Used only for the project name. */
+  region: string;
+  /** Neon region id, e.g. `aws-us-west-2`. Sent as `region_id`. */
   neonRegionId: string;
   databaseName: string;
   ownerRole: string;
@@ -559,7 +570,7 @@ export function buildCreateProjectBody(params: {
   pgVersion?: number;
 }): Record<string, unknown> {
   const project: Record<string, unknown> = {
-    name: projectNameForApp(params.appId),
+    name: projectNameForApp(params.appId, params.region),
     region_id: params.neonRegionId,
     pg_version: params.pgVersion ?? config.neon.pgVersion,
     branch: {
@@ -592,6 +603,9 @@ export function buildCreateProjectBody(params: {
  */
 export async function createProjectForApp(params: {
   appId: string;
+  /** Butterbase region, e.g. `us-west-2`. Used only for the project name. */
+  region: string;
+  /** Neon region id, e.g. `aws-us-west-2`. Sent as `region_id`. */
   neonRegionId: string;
   databaseName: string;
   ownerRole: string;

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -427,6 +427,19 @@ export async function deleteDatabase(
   });
 }
 
+/**
+ * Delete an entire Neon project. Used by the project-per-tenant teardown
+ * paths, where the app owns its project outright and deleting only the
+ * database would leave a billed empty project behind.
+ *
+ * Retry stays on (neonFetch's default): DELETE is idempotent, and a repeat
+ * after a lost response either succeeds or 404s, which callers treat as
+ * already-gone.
+ */
+export async function deleteProject(projectId: string): Promise<void> {
+  await neonFetch(`/projects/${projectId}`, { method: 'DELETE' });
+}
+
 export interface NeonDatabaseSummary {
   name: string;
   createdAt: string;

--- a/services/control-api/src/services/provisioner-app-db.test.ts
+++ b/services/control-api/src/services/provisioner-app-db.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const provisionNeonDbForApp = vi.fn();
+const runtimeQuery = vi.fn().mockResolvedValue({ rows: [] });
+
+vi.mock('./app-db-provision.js', () => ({
+  provisionNeonDbForApp: (...args: unknown[]) => provisionNeonDbForApp(...args),
+}));
+
+vi.mock('./runtime-db.js', () => ({
+  getRuntimeDbPool: () => ({ query: runtimeQuery }),
+}));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  // The tenant branch runs before any region/env lookup; stubbing the assert
+  // keeps the test from needing NEON_RUNTIME_PROJECT_ID_* env vars.
+  return { ...actual, assertRuntimeDbConfig: () => {} };
+});
+
+const { provisionAppDb } = await import('./provisioner.js');
+const { config } = await import('../config.js');
+
+const APP_ID = 'app_k3f9x2m1qp0z';
+const REGION = 'us-west-2';
+
+describe('provisionAppDb — tenant branch (projectPerTenant = true)', () => {
+  const original = config.neon.projectPerTenant;
+
+  beforeEach(() => {
+    config.neon.projectPerTenant = true;
+    provisionNeonDbForApp.mockReset().mockResolvedValue({
+      connectionUri: 'postgres://u:p@direct/db_app',
+      poolerConnectionString: 'postgres://u:p@pooler/db_app',
+      neonProjectId: 'tenant-proj-1',
+      neonDatabaseName: `db_${APP_ID}`,
+    });
+    runtimeQuery.mockClear();
+  });
+
+  afterEach(() => { config.neon.projectPerTenant = original; });
+
+  it('delegates to provisionNeonDbForApp rather than creating a cust_* database', async () => {
+    const out = await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(provisionNeonDbForApp).toHaveBeenCalledWith(REGION, APP_ID);
+    expect(out.neonDbName).toBe(`db_${APP_ID}`);
+    expect(out.neonDbName).not.toMatch(/^cust_/);
+    expect(out.connectionUri).toBe('postgres://u:p@direct/db_app');
+  });
+
+  it('still writes the app_db_connections row step-restore-data depends on', async () => {
+    await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(runtimeQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = runtimeQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO app_db_connections');
+    expect(sql).toContain('ON CONFLICT (app_id) DO UPDATE');
+    expect(params).toEqual([
+      APP_ID,
+      'postgres://u:p@direct/db_app',
+      'postgres://u:p@pooler/db_app',
+      'tenant-proj-1',
+      `db_${APP_ID}`,
+    ]);
+  });
+});

--- a/services/control-api/src/services/provisioner-app-db.test.ts
+++ b/services/control-api/src/services/provisioner-app-db.test.ts
@@ -7,8 +7,13 @@ vi.mock('./app-db-provision.js', () => ({
   provisionNeonDbForApp: (...args: unknown[]) => provisionNeonDbForApp(...args),
 }));
 
+// Captures its arguments: step-restore-data reads app_db_connections from the
+// DEST region's runtime DB, so writing it to the wrong region's pool would be
+// silently invisible to a mock that ignored them.
+const getRuntimeDbPool = vi.fn(() => ({ query: runtimeQuery }));
+
 vi.mock('./runtime-db.js', () => ({
-  getRuntimeDbPool: () => ({ query: runtimeQuery }),
+  getRuntimeDbPool: (...args: unknown[]) => getRuntimeDbPool(...(args as [])),
 }));
 
 vi.mock('../config.js', async (importOriginal) => {
@@ -36,6 +41,7 @@ describe('provisionAppDb — tenant branch (projectPerTenant = true)', () => {
       neonDatabaseName: `db_${APP_ID}`,
     });
     runtimeQuery.mockClear();
+    getRuntimeDbPool.mockClear();
   });
 
   afterEach(() => { config.neon.projectPerTenant = original; });
@@ -54,14 +60,43 @@ describe('provisionAppDb — tenant branch (projectPerTenant = true)', () => {
 
     expect(runtimeQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = runtimeQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain('INSERT INTO app_db_connections');
     expect(sql).toContain('ON CONFLICT (app_id) DO UPDATE');
-    expect(params).toEqual([
-      APP_ID,
-      'postgres://u:p@direct/db_app',
-      'postgres://u:p@pooler/db_app',
-      'tenant-proj-1',
-      `db_${APP_ID}`,
+
+    // Column list and placeholder list asserted together, so a reordered
+    // column list no longer matches even though `params` order would.
+    const columns = /INSERT INTO app_db_connections\s*\(([^)]*)\)/
+      .exec(sql)?.[1]
+      .split(',')
+      .map((c) => c.trim());
+    const placeholders = /VALUES\s*\(([^)]*)\)/
+      .exec(sql)?.[1]
+      .split(',')
+      .map((p) => p.trim());
+    expect(columns).toEqual([
+      'app_id',
+      'connection_string',
+      'pooler_connection_string',
+      'neon_project_id',
+      'neon_database_name',
     ]);
+    expect(placeholders).toEqual(['$1', '$2', '$3', '$4', '$5']);
+
+    // Column -> value correspondence, keyed by name rather than position.
+    const byColumn = Object.fromEntries(
+      columns!.map((c, i) => [c, params[Number(placeholders![i].slice(1)) - 1]]),
+    );
+    expect(byColumn).toEqual({
+      app_id: APP_ID,
+      connection_string: 'postgres://u:p@direct/db_app',
+      pooler_connection_string: 'postgres://u:p@pooler/db_app',
+      neon_project_id: 'tenant-proj-1',
+      neon_database_name: `db_${APP_ID}`,
+    });
+  });
+
+  it('writes app_db_connections to the requested region’s runtime pool', async () => {
+    await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(getRuntimeDbPool).toHaveBeenCalledWith(expect.anything(), REGION);
   });
 });

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -422,9 +422,16 @@ async function formatResponse(app: App, runtimeDb: pg.Pool): Promise<InitRespons
 }
 
 /**
- * Phase 5 / E2E: create the customer DB in the region's data plane and return
- * the connection URI. Does NOT write app_db_connections or run customer
- * migrations — the move-app saga's reserving_dest step does that separately.
+ * Phase 5 / E2E: create the customer DB in the region's data plane, write the
+ * `app_db_connections` row for it, and return the connection URI. Does NOT run
+ * customer migrations — the move-app saga's restoring_data step does that.
+ *
+ * Two shapes, selected by `config.neon.projectPerTenant`:
+ *
+ *   tenant — delegates to `provisionNeonDbForApp`, which creates a dedicated
+ *            Neon project per app (adopt-before-create on retry).
+ *   legacy — a `cust_<appId>_<region>` database inside the region's shared
+ *            project. Byte-for-byte unchanged; this is the deployed path.
  *
  * Idempotent: returns the same name + URI on re-run; CREATE DATABASE is
  * guarded by an existence check.
@@ -438,6 +445,35 @@ export async function provisionAppDb(
   // already asserted) and cron-scheduler (which never registers the
   // plugin). Idempotent guard handles the first case.
   assertRuntimeDbConfig();
+
+  if (config.neon.projectPerTenant) {
+    // One Neon project per app. The shared helper owns adopt-before-create,
+    // the queryability wait and the pooled-URI lookup; all this branch adds is
+    // the app_db_connections row, which step-restore-data reads in the dest
+    // region to find its restore target.
+    const provisioned = await provisionNeonDbForApp(region, appId);
+    const tenantPool = getRuntimeDbPool(config.runtimeDb, region);
+    await tenantPool.query(
+      `INSERT INTO app_db_connections (app_id, connection_string, pooler_connection_string, neon_project_id, neon_database_name)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (app_id) DO UPDATE
+         SET connection_string = EXCLUDED.connection_string,
+             pooler_connection_string = EXCLUDED.pooler_connection_string,
+             neon_project_id = EXCLUDED.neon_project_id,
+             neon_database_name = EXCLUDED.neon_database_name`,
+      [
+        appId,
+        provisioned.connectionUri,
+        provisioned.poolerConnectionString,
+        provisioned.neonProjectId,
+        provisioned.neonDatabaseName,
+      ],
+    );
+    return {
+      neonDbName: provisioned.neonDatabaseName,
+      connectionUri: provisioned.connectionUri,
+    };
+  }
 
   // NEON_DATA_PROJECT_ID_<REGION> holds a Neon project ID (e.g.
   // "silent-cake-48449293"), NOT a postgres connection string. Use the


### PR DESCRIPTION
Unblocks Phase 3 of the project-per-app migration. **Still dormant** — `BUTTERBASE_PROJECT_PER_TENANT` remains `false`; flag-off behaviour is byte-for-byte unchanged.

## The problem

An app keeps its `app_id` across a region move (`step-reserve-dest.ts` sets `dest_app_id: m.app_id`) and the source database is **retained** after cutover (`source-retention.ts` defers the drop to the deprovision worker). So one app transiently has two storage locations.

Today that's disambiguated by the `cust_<appId>_<region>` database name inside the shared project. Under project-per-app the collision reappears one level up: source and destination would both want a project named `bb-<appId>`. That is not cosmetic — `findProjectByName` matches names **exactly** for adopt-before-create, so two identically-named projects would let a retried provision adopt the wrong side of an in-flight move.

## The change

- **Project names are region-scoped**: `bb-<appId>-<region>`. Removes the collision with no rename step. The `bb-app_` prefix still makes `GET /projects?search=bb-app_` a precise reconciler query. Safe to change now — the convention is deployed but dormant, so there are zero `bb-*` projects in existence.
- **`provisionAppDb` gets a tenant branch** delegating to `provisionNeonDbForApp`, writing the same `app_db_connections` upsert (`step-restore-data` depends on that row). The legacy body is untouched. Its docblock claimed *"Does NOT write app_db_connections"* and then wrote it — corrected.
- **`step-abort` no longer leaks the tenant project.** It previously tore down via `deleteDatabase` against the region's *shared* project, which under project-per-app would delete the database inside a tenant project and leave the project orphaned and billing. Now uses the same data-driven discriminator as the rest of the codebase — read the dest `app_db_connections` row, compare `neon_project_id` against the shared project id, delete the project or the database accordingly. Deliberately not keyed on the feature flag, which can be flipped between provision and abort.
- **Same-region moves are rejected** in `step-reserve-dest`. That's the one residual case where two projects collide on name; `eligibility.ts` already refuses it at migration-create time, so this is a backstop.

`deleteProject(projectId)` added to `neon-client.ts` (DELETE is idempotent, so retry stays on).

## Verification

- Legacy `provisionAppDb` body confirmed byte-for-byte unchanged; the only edit to that hunk is three docblock lines.
- The three assertions that the tenant path never calls `grantSchemaPrivileges` / `ensureRoleExists` / `withNeonProjectLock` are untouched and passing.
- New tests: region-scoped naming, `provisionAppDb` tenant delegation plus the upsert (asserting column-to-param correspondence and the target region's pool), same-region rejection, and both `step-abort` teardown branches.
- `tsc -b` clean; no new suite failures against a baseline on `a0c4024`.

## Known follow-up, not in this PR

`executeDeprovision` has **no** project-vs-database discriminator — it always calls `deleteDatabase`. Correct today, since `neon_project_id` is always the shared project. But it must gain one **before** the flag is enabled, or every app deleted after Phase 3 leaks its tenant project. Recorded in §7 of the design doc as a Phase 3 prerequisite.
