### PR TITLE
fix(neon): give the app-delete paths a project-vs-database discriminator

### DIFF
--- a/services/control-api/src/routes/billing.ts
+++ b/services/control-api/src/routes/billing.ts
@@ -709,11 +709,15 @@ export async function billingRoutes(app: FastifyInstance) {
             // loses just its database inside the region's shared data project,
             // a project-per-tenant app loses its whole project (deleting only
             // the database would leave the project orphaned and billing).
-            await teardownAppDb({
+            const result = await teardownAppDb({
               region,
               neonProjectId: connRow.rows[0].neon_project_id,
               neonDatabaseName: connRow.rows[0].neon_database_name,
             });
+            app.log.info(
+              { appId: appRow.id, mode: result.mode, alreadyGone: result.alreadyGone, degraded: result.degraded },
+              'Deleted Neon resource during account deletion',
+            );
           } catch (err) {
             app.log.warn({ err, appId: appRow.id }, 'Failed to delete Neon database during account deletion');
           }

--- a/services/control-api/src/routes/billing.ts
+++ b/services/control-api/src/routes/billing.ts
@@ -37,7 +37,7 @@ async function loadSponsorOverlay(): Promise<SponsorOverlay | null> {
 }
 import { requireUserId } from '../utils/require-auth.js';
 import { apiError } from '../utils/api-error.js';
-import * as neonClient from '../services/neon-client.js';
+import { teardownAppDb } from '../services/app-db-teardown.js';
 import * as DeploymentService from '../services/deployment.service.js';
 import { deleteObject } from '../services/s3.js';
 import { config, assertRegionConfig } from '../config.js';
@@ -705,9 +705,15 @@ export async function billingRoutes(app: FastifyInstance) {
         );
         if (connRow.rows.length > 0) {
           try {
-            await neonClient.withNeonProjectLock(connRow.rows[0].neon_project_id, () =>
-              neonClient.deleteDatabase(connRow.rows[0].neon_project_id, connRow.rows[0].neon_database_name)
-            );
+            // Discriminates on the app's stored neon_project_id: a legacy app
+            // loses just its database inside the region's shared data project,
+            // a project-per-tenant app loses its whole project (deleting only
+            // the database would leave the project orphaned and billing).
+            await teardownAppDb({
+              region,
+              neonProjectId: connRow.rows[0].neon_project_id,
+              neonDatabaseName: connRow.rows[0].neon_database_name,
+            });
           } catch (err) {
             app.log.warn({ err, appId: appRow.id }, 'Failed to delete Neon database during account deletion');
           }

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -27,6 +27,9 @@ vi.mock('../neon-client.js', () => ({
   }),
   grantSchemaPrivileges: vi.fn().mockResolvedValue(undefined),
   deleteDatabase: vi.fn().mockResolvedValue(undefined),
+  // executeDeprovision now routes through teardownAppDb, which reads
+  // deleteProject off this module for the project-per-tenant branch.
+  deleteProject: vi.fn().mockResolvedValue(undefined),
   // provisionNeonDbForApp's defaultDeps() reads every member of this module up
   // front, so the mock must define the project-per-tenant members too even
   // though the legacy (flag-off) path never calls them.
@@ -235,6 +238,108 @@ describe('neon-task-worker: executeProvision uses per-region data project', () =
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ error: expect.stringContaining('missing-app') }),
       expect.stringContaining('[neon-task-worker] Task failed'),
+    );
+  });
+});
+
+describe('neon-task-worker: executeDeprovision discriminates project vs database', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    (neonClient.withNeonProjectLock as any).mockImplementation(
+      async (_projectId: string, fn: () => Promise<void>) => fn(),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // runtimePool.query call sequence for a deprovision task:
+  //   1. recoverStaleTasks: reset UPDATE
+  //   2. recoverStaleTasks: fail UPDATE
+  //   3. processNextTask: claim UPDATE            → deprovision task row
+  //   4. executeDeprovision: SELECT app_db_connections
+  //   5. executeDeprovision: DELETE FROM apps
+  //   6. processNextTask: mark completed
+  async function runDeprovision(connRow: Record<string, string>) {
+    const runtimePool = makeMockPool([
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          id: 3,
+          app_id: APP_ID,
+          task_type: 'deprovision',
+          status: 'processing',
+          attempts: 1,
+          max_attempts: 3,
+          last_error: null,
+          locked_at: null,
+          run_after: new Date(),
+          created_at: new Date(),
+        }],
+        rowCount: 1,
+      },
+      { rows: [connRow], rowCount: 1 },
+      { rows: [], rowCount: 1 },
+      { rows: [], rowCount: 1 },
+    ]);
+    (getRuntimeDbPool as any).mockReturnValue(runtimePool);
+    runtimePoolHolder.value = runtimePool;
+
+    const controlDb = makeMockPool();
+    const dataPlaneDb = makeMockPool();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const interval = startNeonTaskWorker(controlDb, dataPlaneDb, logger);
+    await vi.advanceTimersByTimeAsync(1100);
+    clearInterval(interval);
+    return { logger, runtimePool };
+  }
+
+  it('tenant: deletes the whole Neon project, never the database inside it', async () => {
+    const { logger } = await runDeprovision({
+      neon_project_id: 'tenant-proj-9',
+      neon_database_name: `db_${APP_ID}`,
+    });
+
+    expect(neonClient.deleteProject).toHaveBeenCalledWith('tenant-proj-9');
+    expect(neonClient.deleteDatabase).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('[neon-task-worker] Task failed'),
+    );
+  });
+
+  it('legacy: a row on the region shared data project still deletes the database', async () => {
+    await runDeprovision({
+      neon_project_id: 'neon-proj-us-east-1',
+      neon_database_name: `db_${APP_ID}`,
+    });
+
+    expect(neonClient.deleteDatabase).toHaveBeenCalledWith('neon-proj-us-east-1', `db_${APP_ID}`);
+    expect(neonClient.deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('tenant: an already-gone project (404) is success, not a task failure', async () => {
+    (neonClient.deleteProject as any).mockRejectedValueOnce(
+      new Error('Neon API error 404 /projects/tenant-proj-9: not found'),
+    );
+
+    const { logger, runtimePool } = await runDeprovision({
+      neon_project_id: 'tenant-proj-9',
+      neon_database_name: `db_${APP_ID}`,
+    });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('[neon-task-worker] Task failed'),
+    );
+    // Teardown continued: the apps row was still deleted.
+    expect(runtimePool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM apps'),
+      [APP_ID],
     );
   });
 });

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -322,6 +322,23 @@ describe('neon-task-worker: executeDeprovision discriminates project vs database
     expect(neonClient.deleteProject).not.toHaveBeenCalled();
   });
 
+  it('warns when the region config lookup throws, so a degraded legacy fallback is observable', async () => {
+    (getDataProjectIdForRegion as any).mockImplementationOnce(() => {
+      throw new Error('Missing env var NEON_DATA_PROJECT_ID_US_EAST_1 for region us-east-1');
+    });
+
+    const { logger } = await runDeprovision({
+      neon_project_id: 'some-proj',
+      neon_database_name: `db_${APP_ID}`,
+    });
+
+    expect(neonClient.deleteDatabase).toHaveBeenCalledWith('some-proj', `db_${APP_ID}`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'legacy' }),
+      expect.stringContaining('[neon-task-worker] Neon teardown fell back to legacy without verifying tenant status'),
+    );
+  });
+
   it('tenant: an already-gone project (404) is success, not a task failure', async () => {
     (neonClient.deleteProject as any).mockRejectedValueOnce(
       new Error('Neon API error 404 /projects/tenant-proj-9: not found'),

--- a/services/control-api/src/services/app-db-teardown.test.ts
+++ b/services/control-api/src/services/app-db-teardown.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// vi.mock is hoisted before variable declarations, so mocks must use vi.fn() inline.
+vi.mock('./neon-client.js', () => ({
+  withNeonProjectLock: vi.fn().mockImplementation((_id: string, fn: () => Promise<void>) => fn()),
+  deleteDatabase: vi.fn().mockResolvedValue(undefined),
+  deleteProject: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./neon-projects.js', () => ({ getDataProjectIdForRegion: vi.fn() }));
+
+import { teardownAppDb } from './app-db-teardown.js';
+import { withNeonProjectLock, deleteDatabase, deleteProject } from './neon-client.js';
+import { getDataProjectIdForRegion } from './neon-projects.js';
+
+const SHARED = 'shared-proj-us-east-1';
+const REGION = 'us-east-1';
+
+describe('teardownAppDb', () => {
+  beforeEach(() => {
+    vi.mocked(withNeonProjectLock)
+      .mockReset()
+      .mockImplementation((_id: string, fn: () => Promise<unknown>) => fn() as Promise<never>);
+    vi.mocked(deleteDatabase).mockReset().mockResolvedValue(undefined);
+    vi.mocked(deleteProject).mockReset().mockResolvedValue(undefined);
+    vi.mocked(getDataProjectIdForRegion).mockReset().mockReturnValue(SHARED);
+  });
+
+  describe('legacy (project id === the region shared data project)', () => {
+    it('deletes the database under the shared project lock, not the project', async () => {
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: SHARED,
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res).toEqual({
+        mode: 'legacy',
+        projectId: SHARED,
+        databaseName: 'cust_app_x',
+        alreadyGone: false,
+      });
+      expect(deleteDatabase).toHaveBeenCalledWith(SHARED, 'cust_app_x');
+      expect(deleteProject).not.toHaveBeenCalled();
+      expect(withNeonProjectLock).toHaveBeenCalledWith(SHARED, expect.any(Function));
+    });
+
+    it('treats a 404 from Neon as success', async () => {
+      vi.mocked(deleteDatabase).mockRejectedValue(
+        new Error('Neon API error 404 /projects/x/databases/cust_app_x'),
+      );
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: SHARED,
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res.mode).toBe('legacy');
+      expect(res.alreadyGone).toBe(true);
+    });
+
+    it('treats a "not found" message as success', async () => {
+      vi.mocked(deleteDatabase).mockRejectedValue(new Error('database not found'));
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: SHARED,
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res.alreadyGone).toBe(true);
+    });
+
+    it('rethrows non-404 failures so callers keep their error contract', async () => {
+      vi.mocked(deleteDatabase).mockRejectedValue(new Error('Neon API error 500'));
+
+      await expect(
+        teardownAppDb({ region: REGION, neonProjectId: SHARED, neonDatabaseName: 'cust_app_x' }),
+      ).rejects.toThrow('Neon API error 500');
+    });
+
+    it('falls back to the shared project when the app has no stored project id', async () => {
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: null,
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res.mode).toBe('legacy');
+      expect(deleteDatabase).toHaveBeenCalledWith(SHARED, 'cust_app_x');
+      expect(deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('stays legacy when the shared project id cannot be resolved', async () => {
+      vi.mocked(getDataProjectIdForRegion).mockImplementation(() => {
+        throw new Error('Missing env var NEON_DATA_PROJECT_ID_US_EAST_1 for region us-east-1');
+      });
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: 'some-proj',
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res.mode).toBe('legacy');
+      expect(deleteDatabase).toHaveBeenCalledWith('some-proj', 'cust_app_x');
+      expect(deleteProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant (project id !== the region shared data project)', () => {
+    it('deletes the whole project, never the database inside it', async () => {
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: 'tenant-proj-9',
+        neonDatabaseName: 'app_db',
+      });
+
+      expect(res).toEqual({ mode: 'tenant', projectId: 'tenant-proj-9', alreadyGone: false });
+      expect(deleteProject).toHaveBeenCalledWith('tenant-proj-9');
+      expect(deleteDatabase).not.toHaveBeenCalled();
+    });
+
+    it('treats a 404 from Neon as success', async () => {
+      vi.mocked(deleteProject).mockRejectedValue(
+        new Error('Neon API error 404 /projects/tenant-proj-9: not found'),
+      );
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: 'tenant-proj-9',
+        neonDatabaseName: 'app_db',
+      });
+
+      expect(res.mode).toBe('tenant');
+      expect(res.alreadyGone).toBe(true);
+    });
+
+    it('rethrows non-404 failures', async () => {
+      vi.mocked(deleteProject).mockRejectedValue(new Error('Neon API error 423 conflicting operations'));
+
+      await expect(
+        teardownAppDb({ region: REGION, neonProjectId: 'tenant-proj-9', neonDatabaseName: 'app_db' }),
+      ).rejects.toThrow('423');
+    });
+
+    it('does not need a database name', async () => {
+      const res = await teardownAppDb({ region: REGION, neonProjectId: 'tenant-proj-9' });
+
+      expect(res.mode).toBe('tenant');
+      expect(deleteProject).toHaveBeenCalledWith('tenant-proj-9');
+    });
+
+    it('is chosen from stored data, not the projectPerTenant flag', async () => {
+      // config.neon.projectPerTenant is off in tests, yet a stored non-shared
+      // project id must still take the tenant path — the flag can flip between
+      // provisioning and deletion.
+      const { config } = await import('../config.js');
+      expect(config.neon.projectPerTenant).toBe(false);
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: 'tenant-proj-9',
+        neonDatabaseName: 'app_db',
+      });
+
+      expect(res.mode).toBe('tenant');
+    });
+  });
+
+  it('skips when there is nothing identifiable to delete', async () => {
+    const res = await teardownAppDb({ region: REGION, neonProjectId: null, neonDatabaseName: null });
+
+    expect(res).toEqual({ mode: 'skipped', alreadyGone: false });
+    expect(deleteDatabase).not.toHaveBeenCalled();
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+});

--- a/services/control-api/src/services/app-db-teardown.test.ts
+++ b/services/control-api/src/services/app-db-teardown.test.ts
@@ -91,7 +91,7 @@ describe('teardownAppDb', () => {
       expect(deleteProject).not.toHaveBeenCalled();
     });
 
-    it('stays legacy when the shared project id cannot be resolved', async () => {
+    it('stays legacy when the shared project id cannot be resolved, and flags the result as degraded', async () => {
       vi.mocked(getDataProjectIdForRegion).mockImplementation(() => {
         throw new Error('Missing env var NEON_DATA_PROJECT_ID_US_EAST_1 for region us-east-1');
       });
@@ -103,8 +103,22 @@ describe('teardownAppDb', () => {
       });
 
       expect(res.mode).toBe('legacy');
+      expect(res.degraded).toBe(true);
       expect(deleteDatabase).toHaveBeenCalledWith('some-proj', 'cust_app_x');
       expect(deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('is not marked degraded when the region simply has no shared project configured', async () => {
+      vi.mocked(getDataProjectIdForRegion).mockReturnValue(undefined as unknown as string);
+
+      const res = await teardownAppDb({
+        region: REGION,
+        neonProjectId: 'some-proj',
+        neonDatabaseName: 'cust_app_x',
+      });
+
+      expect(res.mode).toBe('legacy');
+      expect(res.degraded).toBeUndefined();
     });
   });
 
@@ -174,5 +188,16 @@ describe('teardownAppDb', () => {
     expect(res).toEqual({ mode: 'skipped', alreadyGone: false });
     expect(deleteDatabase).not.toHaveBeenCalled();
     expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('flags skipped as degraded too when the region config lookup threw', async () => {
+    vi.mocked(getDataProjectIdForRegion).mockImplementation(() => {
+      throw new Error('Missing env var NEON_DATA_PROJECT_ID_US_EAST_1 for region us-east-1');
+    });
+
+    const res = await teardownAppDb({ region: REGION, neonProjectId: null, neonDatabaseName: null });
+
+    expect(res.mode).toBe('skipped');
+    expect(res.degraded).toBe(true);
   });
 });

--- a/services/control-api/src/services/app-db-teardown.ts
+++ b/services/control-api/src/services/app-db-teardown.ts
@@ -1,0 +1,96 @@
+import * as neonClient from './neon-client.js';
+import { getDataProjectIdForRegion } from './neon-projects.js';
+
+/**
+ * Shape of the teardown that ran, so callers can log precisely without
+ * re-deriving the discriminator.
+ *
+ *  - `legacy`   the app's database lives *inside* the region's shared data
+ *               project; only that database was dropped.
+ *  - `tenant`   the app owns its Neon project outright (project-per-tenant);
+ *               the whole project was deleted.
+ *  - `skipped`  nothing identifiable to delete (no project id / db name).
+ */
+export interface AppDbTeardownResult {
+  mode: 'legacy' | 'tenant' | 'skipped';
+  /** Project the teardown acted on. Absent for `skipped`. */
+  projectId?: string;
+  /** Database dropped. Only set for `legacy`. */
+  databaseName?: string;
+  /** True when Neon answered 404 / "not found" — already gone, treated as success. */
+  alreadyGone: boolean;
+}
+
+export interface TeardownAppDbArgs {
+  /** Region whose *shared* data project acts as the legacy discriminator. */
+  region: string;
+  /** `app_db_connections.neon_project_id` for the app, if a row was found. */
+  neonProjectId?: string | null;
+  /** `app_db_connections.neon_database_name` (or the caller's known db name). */
+  neonDatabaseName?: string | null;
+}
+
+function isAlreadyGone(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : '';
+  return msg.includes('404') || msg.includes('not found');
+}
+
+/**
+ * Deletes an app's Neon data-plane storage, picking the right teardown shape.
+ *
+ * The discriminator is deliberately **data-driven** — the app's own stored
+ * `neon_project_id` — and NOT `config.neon.projectPerTenant`. The flag can be
+ * flipped between the moment an app was provisioned and the moment it is
+ * deleted, so the flag says nothing about what this particular app actually
+ * owns; the stored project id is the only reliable truth.
+ *
+ * If the stored project is the region's shared data project, the app is a
+ * legacy tenant: drop just its `cust_*` database, under the per-project lock
+ * that serializes Neon mutations on that busy shared project. Anything else
+ * means provisioning took the project-per-tenant path and created a dedicated
+ * project — deleting only the database inside it would leave the project
+ * orphaned and billing forever, invisible to both the app and the legacy
+ * orphan reconciler, so the whole project goes.
+ *
+ * Idempotent: a 404 / "not found" from Neon is success (`alreadyGone: true`),
+ * matching the existing teardown call sites. Any other failure is rethrown —
+ * callers own the error contract (rethrow vs. warn-and-continue).
+ */
+export async function teardownAppDb(args: TeardownAppDbArgs): Promise<AppDbTeardownResult> {
+  const { region, neonProjectId, neonDatabaseName } = args;
+
+  // A region with no configured shared data project id cannot prove the app is
+  // a tenant, so fall back to legacy — the pre-existing behaviour — rather than
+  // deleting a project we may not own.
+  let sharedProjectId: string | null = null;
+  try {
+    sharedProjectId = getDataProjectIdForRegion(region) || null;
+  } catch {
+    sharedProjectId = null;
+  }
+
+  if (neonProjectId && sharedProjectId && neonProjectId !== sharedProjectId) {
+    try {
+      await neonClient.withNeonProjectLock(neonProjectId, () => neonClient.deleteProject(neonProjectId));
+    } catch (err) {
+      if (!isAlreadyGone(err)) throw err;
+      return { mode: 'tenant', projectId: neonProjectId, alreadyGone: true };
+    }
+    return { mode: 'tenant', projectId: neonProjectId, alreadyGone: false };
+  }
+
+  const projectId = neonProjectId || sharedProjectId;
+  if (!projectId || !neonDatabaseName) {
+    return { mode: 'skipped', alreadyGone: false };
+  }
+
+  try {
+    await neonClient.withNeonProjectLock(projectId, () =>
+      neonClient.deleteDatabase(projectId, neonDatabaseName),
+    );
+  } catch (err) {
+    if (!isAlreadyGone(err)) throw err;
+    return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: true };
+  }
+  return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: false };
+}

--- a/services/control-api/src/services/app-db-teardown.ts
+++ b/services/control-api/src/services/app-db-teardown.ts
@@ -19,6 +19,18 @@ export interface AppDbTeardownResult {
   databaseName?: string;
   /** True when Neon answered 404 / "not found" — already gone, treated as success. */
   alreadyGone: boolean;
+  /**
+   * True when `getDataProjectIdForRegion(region)` threw — the region is no
+   * longer in `BUTTERBASE_REGIONS` — and the teardown fell back to the
+   * legacy branch *unable to prove* this app isn't actually a tenant
+   * project. The fallback direction is correct (see function doc), but if
+   * this app really does own a dedicated Neon project, that project is now
+   * orphaned and `neon-orphan-reconciler.ts` can't see it either, since it
+   * calls the same throwing helper. Only ever set (to `true`) on the
+   * degraded path; absent otherwise, so it never fires for the normal case
+   * where the region simply has no shared data project configured.
+   */
+  degraded?: boolean;
 }
 
 export interface TeardownAppDbArgs {
@@ -61,13 +73,18 @@ export async function teardownAppDb(args: TeardownAppDbArgs): Promise<AppDbTeard
 
   // A region with no configured shared data project id cannot prove the app is
   // a tenant, so fall back to legacy — the pre-existing behaviour — rather than
-  // deleting a project we may not own.
+  // deleting a project we may not own. `degraded` distinguishes "the helper
+  // threw" (region config gap — the risky case, see AppDbTeardownResult) from
+  // the ordinary "no shared project configured for this region" case.
   let sharedProjectId: string | null = null;
+  let degraded = false;
   try {
     sharedProjectId = getDataProjectIdForRegion(region) || null;
   } catch {
     sharedProjectId = null;
+    degraded = true;
   }
+  const degradedFlag = degraded ? { degraded: true as const } : {};
 
   if (neonProjectId && sharedProjectId && neonProjectId !== sharedProjectId) {
     try {
@@ -81,7 +98,7 @@ export async function teardownAppDb(args: TeardownAppDbArgs): Promise<AppDbTeard
 
   const projectId = neonProjectId || sharedProjectId;
   if (!projectId || !neonDatabaseName) {
-    return { mode: 'skipped', alreadyGone: false };
+    return { mode: 'skipped', alreadyGone: false, ...degradedFlag };
   }
 
   try {
@@ -90,7 +107,7 @@ export async function teardownAppDb(args: TeardownAppDbArgs): Promise<AppDbTeard
     );
   } catch (err) {
     if (!isAlreadyGone(err)) throw err;
-    return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: true };
+    return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: true, ...degradedFlag };
   }
-  return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: false };
+  return { mode: 'legacy', projectId, databaseName: neonDatabaseName, alreadyGone: false, ...degradedFlag };
 }

--- a/services/control-api/src/services/move-app/step-abort.ts
+++ b/services/control-api/src/services/move-app/step-abort.ts
@@ -88,10 +88,19 @@ export const executeAbort: StepHandler = async (ctx, m) => {
       neonProjectId: destConn?.neon_project_id,
       neonDatabaseName: neonDbName,
     });
+    if (result.degraded) {
+      // getDataProjectIdForRegion threw for m.dest_region — see
+      // AppDbTeardownResult.degraded — so this took the legacy branch
+      // unable to prove it isn't actually an orphaned tenant project.
+      ctx.log.warn(
+        { migrationId: m.id, mode: result.mode, neonProjectId: result.projectId, neonDbName, destRegion: m.dest_region },
+        '[move-app abort] dest Neon teardown fell back to legacy without verifying tenant status (region config gap)',
+      );
+    }
     if (result.alreadyGone) {
       // Idempotency: an already-deleted project/database (404) is success.
       ctx.log.info(
-        { migrationId: m.id, mode: result.mode, neonProjectId: result.projectId, neonDbName },
+        { migrationId: m.id, mode: result.mode, neonProjectId: result.projectId, neonDbName, degraded: result.degraded },
         '[move-app abort] dest Neon resource already deleted, continuing',
       );
     }

--- a/services/control-api/src/services/move-app/step-abort.ts
+++ b/services/control-api/src/services/move-app/step-abort.ts
@@ -1,7 +1,6 @@
 import type { StepHandler } from './saga-executor.js';
 import { invalidateAppRegion } from '../region-resolver.js';
-import * as neonClient from '../neon-client.js';
-import { getDataProjectIdForRegion } from '../neon-projects.js';
+import { teardownAppDb } from '../app-db-teardown.js';
 import { clearKvBlock } from '../kv/migration-sentinel.js';
 import { kvRedisFor } from '../kv/redis-registry.js';
 import { wrap } from '../kv/redis-client.js';
@@ -79,50 +78,28 @@ export const executeAbort: StepHandler = async (ctx, m) => {
   //     'schema "realtime" already exists' (or similar) because the prior
   //     attempt's restore left objects behind in the same Neon DB.
   //     Under project-per-tenant the dest is a whole project, not a database
-  //     inside the shared one, so the tenant branch deletes the project.
-  const tenantProjectId =
-    destConn?.neon_project_id &&
-    destConn.neon_project_id !== getDataProjectIdForRegion(m.dest_region)
-      ? destConn.neon_project_id
-      : null;
-
-  if (tenantProjectId) {
-    try {
-      await neonClient.withNeonProjectLock(tenantProjectId, async () => {
-        await neonClient.deleteProject(tenantProjectId);
-      });
-    } catch (err) {
-      // Idempotency: an already-deleted project (404) is success, not an error.
-      const msg = err instanceof Error ? err.message : '';
-      if (msg.includes('404') || msg.includes('not found')) {
-        ctx.log.info(
-          { migrationId: m.id, neonProjectId: tenantProjectId },
-          '[move-app abort] dest Neon project already deleted, continuing',
-        );
-      } else {
-        ctx.log.warn(
-          { migrationId: m.id, neonProjectId: tenantProjectId, err: msg },
-          '[move-app abort] dest Neon project delete failed; continuing (manual cleanup may be needed)',
-        );
-      }
+  //     inside the shared one; teardownAppDb picks the shape from destConn's
+  //     stored neon_project_id (see its docs for why the flag is not the test).
+  //     Best-effort: teardown failures warn and continue, never abort the abort.
+  const neonDbName = m.dest_resources.neon_db_name as string | undefined;
+  try {
+    const result = await teardownAppDb({
+      region: m.dest_region,
+      neonProjectId: destConn?.neon_project_id,
+      neonDatabaseName: neonDbName,
+    });
+    if (result.alreadyGone) {
+      // Idempotency: an already-deleted project/database (404) is success.
+      ctx.log.info(
+        { migrationId: m.id, mode: result.mode, neonProjectId: result.projectId, neonDbName },
+        '[move-app abort] dest Neon resource already deleted, continuing',
+      );
     }
-  } else {
-    const neonDbName = m.dest_resources.neon_db_name as string | undefined;
-    if (neonDbName) {
-      const dataProjectId = getDataProjectIdForRegion(m.dest_region);
-      if (dataProjectId) {
-        try {
-          await neonClient.withNeonProjectLock(dataProjectId, async () => {
-            await neonClient.deleteDatabase(dataProjectId, neonDbName);
-          });
-        } catch (err) {
-          ctx.log.warn(
-            { migrationId: m.id, neonDbName, err: (err as Error).message },
-            '[move-app abort] dest Neon DB delete failed; continuing (manual cleanup may be needed)',
-          );
-        }
-      }
-    }
+  } catch (err) {
+    ctx.log.warn(
+      { migrationId: m.id, neonDbName, neonProjectId: destConn?.neon_project_id, err: (err as Error).message },
+      '[move-app abort] dest Neon teardown failed; continuing (manual cleanup may be needed)',
+    );
   }
 
   // 2) Restore source provisioning_status if blocking_writes flipped it.

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -350,9 +350,18 @@ async function executeDeprovision(
         neonProjectId: neon_project_id,
         neonDatabaseName: neon_database_name,
       });
+      if (result.degraded) {
+        // getDataProjectIdForRegion threw for this worker's instance region —
+        // see AppDbTeardownResult.degraded — so this fell back to the legacy
+        // branch unable to prove it isn't actually an orphaned tenant project.
+        logger.warn(
+          { appId, neon_database_name, mode: result.mode, neonProjectId: result.projectId },
+          '[neon-task-worker] Neon teardown fell back to legacy without verifying tenant status (region config gap)',
+        );
+      }
       if (result.alreadyGone) {
         logger.info(
-          { appId, neon_database_name, mode: result.mode, neonProjectId: result.projectId },
+          { appId, neon_database_name, mode: result.mode, neonProjectId: result.projectId, degraded: result.degraded },
           '[neon-task-worker] Neon resource already deleted, continuing',
         );
       }

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/node';
 import { config, assertRegionConfig } from '../config.js';
 import { getRuntimeDbPool } from './runtime-db.js';
 import { getRuntimeDbForApp } from './region-resolver.js';
-import * as neonClient from './neon-client.js';
 import { provisionNeonDbForApp } from './app-db-provision.js';
+import { teardownAppDb } from './app-db-teardown.js';
 import { runMigrationsWithRetry, generateAppId, insertAppRow, provisionAppBackground } from './provisioner.js';
 import { runDataPlaneMigrations } from './migrator.js';
 import { notifyProvisioningFailed, notifyCloneFailed } from './failure-notifications.service.js';
@@ -338,18 +338,23 @@ async function executeDeprovision(
 
     if (connRow.rows.length > 0) {
       const { neon_project_id, neon_database_name } = connRow.rows[0];
-      try {
-        await neonClient.withNeonProjectLock(neon_project_id, () =>
-          neonClient.deleteDatabase(neon_project_id, neon_database_name),
+      // teardownAppDb decides from the app's stored neon_project_id whether
+      // this is a legacy database inside the region's shared data project or a
+      // dedicated project-per-tenant project that must be deleted whole (else
+      // it bills forever). Region is this worker's instance region, which is
+      // the app's home region — see the comment on runtimePool above.
+      // Idempotency (404 = already gone) is handled inside; other errors still
+      // throw so the task retries, exactly as before.
+      const result = await teardownAppDb({
+        region: assertRegionConfig().instanceRegion,
+        neonProjectId: neon_project_id,
+        neonDatabaseName: neon_database_name,
+      });
+      if (result.alreadyGone) {
+        logger.info(
+          { appId, neon_database_name, mode: result.mode, neonProjectId: result.projectId },
+          '[neon-task-worker] Neon resource already deleted, continuing',
         );
-      } catch (err) {
-        // Idempotency: if DB is already gone (404), treat as success
-        const msg = err instanceof Error ? err.message : '';
-        if (msg.includes('404') || msg.includes('not found')) {
-          logger.info({ appId, neon_database_name }, '[neon-task-worker] Database already deleted, continuing');
-        } else {
-          throw err;
-        }
       }
     }
   } else {


### PR DESCRIPTION
Closes the last blocker before `BUTTERBASE_PROJECT_PER_TENANT` can be enabled. **Still dormant** — the flag stays `false` and flag-off behaviour is byte-for-byte unchanged.

## The problem

Teardown paths called `deleteDatabase(neon_project_id, neon_database_name)` unconditionally. That is correct today, because `neon_project_id` is always the shared per-region project.

The moment the flag is enabled, it deletes the *database inside* an app's dedicated project and leaves **the project itself orphaned and billing forever** — invisible both to the app and to the legacy orphan reconciler, which only enumerates databases inside shared projects.

`step-abort.ts` was given a discriminator in the previous change. These two paths were not, and `executeDeprovision` is by far the more frequently travelled:

- `neon-task-worker.ts` — `executeDeprovision`, the normal app-delete path
- `routes/billing.ts` — billing teardown

## The change

Extracts the discriminator into `services/app-db-teardown.ts` — `teardownAppDb({ region, neonProjectId, neonDatabaseName })` — and applies it at all three sites, replacing three would-be copies with one tested implementation.

If `neonProjectId === getDataProjectIdForRegion(region)` → legacy: `withNeonProjectLock` + `deleteDatabase`, exactly as today. Otherwise → tenant: `deleteProject`. 404 / "not found" is success in both.

**The discriminator is deliberately data-driven, not a `config.neon.projectPerTenant` check.** The flag can be flipped between when an app was provisioned and when it is deleted, so the app's own stored `neon_project_id` is the only reliable truth.

**Failure direction is chosen deliberately.** If `getDataProjectIdForRegion` throws — reachable when an app's region has left `BUTTERBASE_REGIONS` — the helper degrades to the *legacy* branch rather than propagating. Deleting a database you cannot prove ownership of is recoverable; deleting a whole project you cannot prove ownership of is not. That path now sets `degraded: true` on the result and is warn-logged at every call site, because an orphan created there would otherwise be invisible to automation — the reconciler calls the same throwing function.

`neon-orphan-reconciler.ts` is deliberately untouched: it operates on the legacy shared project by definition.

## Verification

- Flag off ⇒ stored project id always equals the shared project id ⇒ every path takes the legacy branch and behaves identically. Verified per call site, including that `billing.ts` and `executeDeprovision` still resolve the same region they did before — a changed region would silently flip the branch, since the comparison is against `getDataProjectIdForRegion(region)`.
- Error contracts preserved: `executeDeprovision` still throws so the queue retries; `step-abort` and `billing.ts` still warn-and-continue.
- 14 helper tests + 6 worker tests; both suites assert the *negative* (`deleteProject` not called in legacy, `deleteDatabase` not called in tenant), so a swapped branch fails immediately. All 8 pre-existing `step-abort` tests pass unmodified.
- `tsc -b` clean; zero new suite failures against a baseline on `5eb390f`.
