### PR TITLE
fix(neon): drop obsolete :6543 pooler port; let the orphan reconciler see cust_* databases

### DIFF
--- a/services/control-api/src/services/__tests__/neon-orphan-reconciler.test.ts
+++ b/services/control-api/src/services/__tests__/neon-orphan-reconciler.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../config.js', () => ({
 }));
 
 // After mocks
-import { reconcileOrphansForRegion, reconcileOrphans } from '../neon-orphan-reconciler.js';
+import { reconcileOrphansForRegion, reconcileOrphans, custDbNameFor } from '../neon-orphan-reconciler.js';
 
 type QueryRow = Record<string, unknown>;
 
@@ -166,6 +166,159 @@ describe('reconcileOrphansForRegion', () => {
 
     expect(res.neonDbCount).toBe(1);
     expect(res.dropped).toEqual(['db_app_orphan']);
+  });
+});
+
+/**
+ * cust_<appId>_<region> — the move-app destination database shape created by
+ * `provisionAppDb`. Before the fix these were invisible to the reconciler.
+ */
+describe('reconcileOrphansForRegion — cust_* databases', () => {
+  const OLD = new Date(nowMs - 48 * 3600 * 1000).toISOString();
+
+  /** Mock pool honouring all four queries the reconciler issues. */
+  function custPool(opts: {
+    regionApps?: string[];      // apps.db_name for this region (db_app_ path)
+    allAppIds?: string[];       // apps.id, any region (cust_ forward match)
+    registered?: string[];      // app_db_connections.neon_database_name
+    inflight?: string[];        // neon_tasks.app_id
+  }) {
+    return makePool((sql) => {
+      if (sql.includes('FROM app_db_connections')) {
+        return { rows: (opts.registered ?? []).map((n) => ({ neon_database_name: n })) };
+      }
+      if (sql.includes('FROM neon_tasks')) {
+        return { rows: (opts.inflight ?? []).map((a) => ({ app_id: a })) };
+      }
+      if (sql.includes('SELECT id FROM apps')) {
+        return { rows: (opts.allAppIds ?? []).map((id) => ({ id })) };
+      }
+      if (sql.includes('FROM apps')) {
+        return { rows: (opts.regionApps ?? []).map((db_name) => ({ db_name })) };
+      }
+      return { rows: [] };
+    });
+  }
+
+  it('custDbNameFor reproduces provisionAppDb exactly', () => {
+    expect(custDbNameFor('app_k3f9x2m1qp0z', 'us-west-2')).toBe('cust_app_k3f9x2m1qp0z_us_west_2');
+    expect(custDbNameFor('app-With-Dashes', 'us-east-1')).toBe('cust_app_with_dashes_us_east_1');
+    expect(custDbNameFor('app_' + 'z'.repeat(80), 'us-west-2').length).toBe(63);
+  });
+
+  it('does NOT consider a cust_* database an orphan while its app is live', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_live1_us_west_2', createdAt: OLD },
+    ]);
+    runtimePoolHolder.value = custPool({ allAppIds: ['app_live1'] });
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.neonDbCount).toBe(1);
+    expect(res.orphanCount).toBe(0);
+    expect(res.dropped).toEqual([]);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('does NOT consider a cust_* database an orphan while app_db_connections still registers it (mid-move)', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_moving_us_west_2', createdAt: OLD },
+    ]);
+    // apps row still lives in the SOURCE region's runtime DB, so no id match —
+    // only the app_db_connections registration protects it.
+    runtimePoolHolder.value = custPool({ registered: ['cust_app_moving_us_west_2'] });
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.dropped).toEqual([]);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('DOES consider a cust_* database with no matching app an orphan', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_ghost_us_west_2', createdAt: OLD },
+    ]);
+    runtimePoolHolder.value = custPool({ allAppIds: ['app_someoneelse'] });
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.orphanCount).toBe(1);
+    expect(res.dropped).toEqual(['cust_app_ghost_us_west_2']);
+    expect(deleteDatabase).toHaveBeenCalledWith('neon-proj-us-west-2', 'cust_app_ghost_us_west_2');
+  });
+
+  it('applies the grace window to cust_* orphans', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_fresh_us_west_2', createdAt: new Date(nowMs - 2 * 3600 * 1000).toISOString() },
+    ]);
+    runtimePoolHolder.value = custPool({});
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.skippedYoung).toBe(1);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('applies the in-flight neon_tasks guard to cust_* orphans', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_busy_us_west_2', createdAt: OLD },
+    ]);
+    runtimePoolHolder.value = custPool({ inflight: ['app_busy'] });
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.skippedInflight).toBe(1);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('never drops a cust_* database whose name is ambiguous', async () => {
+    listDatabases.mockResolvedValue([
+      // At the 63-byte limit: possibly truncated, so the app id is unrecoverable.
+      { name: custDbNameFor('app_' + 'a'.repeat(80), 'us-west-2'), createdAt: OLD },
+      // Region suffix does not belong to the region being scanned.
+      { name: 'cust_app_elsewhere_eu_central_1', createdAt: OLD },
+      // Empty app-id segment.
+      { name: 'cust__us_west_2', createdAt: OLD },
+    ]);
+    runtimePoolHolder.value = custPool({});
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger, DEFAULTS,
+    );
+
+    expect(res.skippedAmbiguous).toBe(3);
+    expect(res.orphanCount).toBe(0);
+    expect(res.dropped).toEqual([]);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('honours dry-run and the max-drops cap for cust_* orphans too', async () => {
+    listDatabases.mockResolvedValue([
+      { name: 'cust_app_g1_us_west_2', createdAt: new Date(nowMs - 100 * 3600 * 1000).toISOString() },
+      { name: 'cust_app_g2_us_west_2', createdAt: new Date(nowMs - 80 * 3600 * 1000).toISOString() },
+      { name: 'db_app_g3', createdAt: new Date(nowMs - 60 * 3600 * 1000).toISOString() },
+    ]);
+    runtimePoolHolder.value = custPool({});
+
+    const res = await reconcileOrphansForRegion(
+      'us-west-2', controlPoolHolder.value as never, RUNTIME_CFG, silentLogger,
+      { ...DEFAULTS, dryRun: true, maxDropsPerRun: 2 },
+    );
+
+    expect(res.eligibleCount).toBe(3);
+    expect(res.wouldDrop).toEqual(['cust_app_g1_us_west_2', 'cust_app_g2_us_west_2']);
+    expect(res.dropped).toEqual([]);
+    expect(deleteDatabase).not.toHaveBeenCalled();
   });
 });
 

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -46,12 +46,11 @@ function defaultDeps(): ProvisionDeps {
 
 /** Pick the pooled connection string for `app_db_connections`.
  *
- *  This function does not itself append the historical `:6543` port. It does
- *  NOT, however, guarantee the port is absent: `getConnectionString` in
- *  neon-client.ts still sets `url.port = '6543'` on its cached-pooler-host
- *  branch, and the `pooled` value is returned here verbatim. So the obsolete
- *  `:6543` convention (design doc §6.2) is not yet fixed — the rewrite just
- *  lives upstream.
+ *  This function does not append the historical `:6543` port, and as of the
+ *  fix to `getConnectionString` in neon-client.ts neither does the upstream
+ *  cached-pooler-host branch — it now swaps the host only. Neon's pooled host
+ *  (`ep-<id>-pooler.<region>.aws.neon.tech`) carries no explicit port, so the
+ *  obsolete `:6543` convention (design doc §6.2) is gone from both paths.
  *
  *  Because `getConnectionString` never returns a truthy `poolerHost` without
  *  also returning `pooledConnectionUri`, the host-construct branch below is

--- a/services/control-api/src/services/neon-client-connection-string.test.ts
+++ b/services/control-api/src/services/neon-client-connection-string.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getConnectionString } from './neon-client.js';
+
+/**
+ * Regression guard for the obsolete `:6543` pooler port.
+ *
+ * A live probe against the Neon API returns the pooled host as
+ * `ep-<id>-pooler.<region>.aws.neon.tech` with NO explicit port (default
+ * 5432). `getConnectionString` used to inject `url.port = '6543'` when it
+ * built the pooled URI from a cached pooler host, producing an unusable
+ * connection string in `app_db_connections.pooler_connection_string`.
+ */
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const DIRECT_URI =
+  'postgresql://butterbase:pw@ep-still-frost-12345678.us-east-1.aws.neon.tech/db_app_k3f9x2m1qp0z?sslmode=require';
+const POOLER_HOST = 'ep-still-frost-12345678-pooler.us-east-1.aws.neon.tech';
+
+describe('getConnectionString pooled URI construction', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds the pooled URI by swapping the host only — never injects :6543', async () => {
+    // Neon hands back the pooler host inline, so the construct branch runs and
+    // the second (pooled=true) request is skipped.
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        uri: DIRECT_URI,
+        connection_parameters: { pooler_host: POOLER_HOST },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Fresh project id per run so the module-level poolerHostCache can't
+    // leak state between tests.
+    const projectId = `proj-construct-${Math.random().toString(36).slice(2)}`;
+    const res = await getConnectionString(projectId, 'db_app_k3f9x2m1qp0z', 'butterbase');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res.connectionUri).toBe(DIRECT_URI);
+    expect(res.poolerHost).toBe(POOLER_HOST);
+    expect(res.pooledConnectionUri).toBe(
+      'postgresql://butterbase:pw@ep-still-frost-12345678-pooler.us-east-1.aws.neon.tech/db_app_k3f9x2m1qp0z?sslmode=require',
+    );
+    expect(res.pooledConnectionUri).not.toContain('6543');
+    expect(new URL(res.pooledConnectionUri!).port).toBe('');
+  });
+
+  it('reuses the cached pooler host on a later call and still emits no port', async () => {
+    const projectId = `proj-cache-${Math.random().toString(36).slice(2)}`;
+
+    // 1st call: no pooler_host inline → falls through to the pooled=true
+    // endpoint, whose URI (port-free, as the real API returns) is used
+    // verbatim and seeds the cache.
+    const first = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ uri: DIRECT_URI }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uri: `postgresql://butterbase:pw@${POOLER_HOST}/db_app_k3f9x2m1qp0z?sslmode=require`,
+        }),
+      );
+    vi.stubGlobal('fetch', first);
+    const seeded = await getConnectionString(projectId, 'db_app_k3f9x2m1qp0z', 'butterbase');
+    expect(seeded.pooledConnectionUri).not.toContain('6543');
+    expect(first).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+
+    // 2nd call for another database on the same project: cache hit → the
+    // construct branch, which is the one that used to append :6543.
+    const second = vi.fn().mockResolvedValue(
+      jsonResponse({
+        uri: 'postgresql://butterbase:pw@ep-still-frost-12345678.us-east-1.aws.neon.tech/cust_app_k3f9x2m1qp0z_us_west_2?sslmode=require',
+      }),
+    );
+    vi.stubGlobal('fetch', second);
+    const res = await getConnectionString(projectId, 'cust_app_k3f9x2m1qp0z_us_west_2', 'butterbase');
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(res.pooledConnectionUri).toBe(
+      `postgresql://butterbase:pw@${POOLER_HOST}/cust_app_k3f9x2m1qp0z_us_west_2?sslmode=require`,
+    );
+    expect(res.pooledConnectionUri).not.toContain('6543');
+    expect(new URL(res.pooledConnectionUri!).port).toBe('');
+  });
+});

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -516,10 +516,13 @@ export async function getConnectionString(
   const cachedPoolerHost = direct.poolerHost ?? poolerHostCache.get(projectId);
 
   if (cachedPoolerHost) {
-    // Build pooled URI from cached pooler host — skip the extra API call
+    // Build pooled URI from cached pooler host — skip the extra API call.
+    // Swap the HOST only. Neon's pooled endpoint returns
+    // `ep-<id>-pooler.<region>.aws.neon.tech` with no explicit port (i.e. the
+    // default 5432); the `:6543` we used to inject here is an obsolete
+    // convention and produced an unusable URI.
     const url = new URL(direct.connectionUri);
     url.hostname = cachedPoolerHost;
-    url.port = '6543';
     pooledConnectionUri = url.toString();
   } else {
     // No pooler host known yet — fetch via pooled=true endpoint

--- a/services/control-api/src/services/neon-orphan-reconciler.ts
+++ b/services/control-api/src/services/neon-orphan-reconciler.ts
@@ -31,6 +31,14 @@ interface Logger {
  *     go first.
  *   - dry-run default: unless `NEON_ORPHAN_DRY_RUN=false` is explicit, we just
  *     log what we WOULD drop.
+ *   - ambiguity bail-out (cust_* only): if we cannot reconstruct the database
+ *     name exactly from a known app id, we treat it as NOT an orphan. A missed
+ *     orphan costs storage; a wrong drop destroys customer data.
+ *
+ * Two naming shapes exist:
+ *   - `db_app_<id>`            — provisionAppBackground / executeProvision.
+ *   - `cust_<appId>_<region>`  — provisionAppDb, the move-app destination DB.
+ * See `custDbNameFor` for why the second is matched forwards, never inverted.
  */
 
 export interface ReconcileResult {
@@ -43,6 +51,9 @@ export interface ReconcileResult {
   wouldDrop: string[];
   skippedYoung: number;
   skippedInflight: number;
+  /** cust_* databases we refused to classify because the name could not be
+   *  reconstructed unambiguously. Always treated as NOT orphans. */
+  skippedAmbiguous: number;
   dropErrors: { db: string; error: string }[];
 }
 
@@ -57,6 +68,36 @@ export interface ReconcileOptions {
 /** Named prefix for per-app data-plane databases — matches provisioner.ts:145. */
 const APP_DB_PREFIX = 'db_app_';
 
+/** Prefix for move-app destination databases — matches `provisionAppDb`. */
+const CUST_DB_PREFIX = 'cust_';
+
+/** Postgres `datname` limit. `provisionAppDb` truncates to this. */
+const PG_MAX_DATNAME = 63;
+
+/**
+ * Reproduce `provisionAppDb`'s destination-database name EXACTLY.
+ *
+ * We match forwards (compute the expected name for every known app id and
+ * compare) rather than inverting the name back to an app id, because the
+ * transform is not injective:
+ *   - `-` → `_` collapses two distinct characters into one,
+ *   - `.toLowerCase()` collapses case,
+ *   - `.slice(0, 63)` is outright lossy.
+ * Inverting would mean guessing, and a wrong guess here drops a live customer
+ * database. Forward-matching cannot produce a false positive.
+ */
+export function custDbNameFor(appId: string, region: string): string {
+  return `cust_${appId.replace(/-/g, '_')}_${region.replace(/-/g, '_')}`
+    .toLowerCase()
+    .slice(0, PG_MAX_DATNAME);
+}
+
+/** Same normalisation applied to the app-id segment alone — used to line a
+ *  cust_* name up with `neon_tasks.app_id` for the in-flight guard. */
+function appIdSlug(appId: string): string {
+  return appId.replace(/-/g, '_').toLowerCase();
+}
+
 export async function reconcileOrphansForRegion(
   region: string,
   controlDb: pg.Pool,
@@ -70,9 +111,10 @@ export async function reconcileOrphansForRegion(
   const nowMs = opts.now ? new Date(opts.now).getTime() : Date.now();
   const graceMs = opts.graceHours * 3600 * 1000;
 
-  // 1. Full Neon inventory for this project's default branch.
+  // 1. Full Neon inventory for this project's default branch. Both naming
+  //    shapes are in scope; anything else (neondb, internal dbs) is ignored.
   const neonDbs = (await neonClient.listDatabases(projectId))
-    .filter((db) => db.name.startsWith(APP_DB_PREFIX));
+    .filter((db) => db.name.startsWith(APP_DB_PREFIX) || db.name.startsWith(CUST_DB_PREFIX));
 
   // 2. Every app row currently registered for this region.
   const liveRes = await runtimePool.query<{ db_name: string }>(
@@ -80,6 +122,25 @@ export async function reconcileOrphansForRegion(
     [region],
   );
   const liveDbNames = new Set(liveRes.rows.map((r) => r.db_name));
+
+  // 2b. cust_* liveness. Deliberately NOT region-filtered: a move-app
+  //     destination database is created in the target region before the app's
+  //     `apps.region` flips over, so filtering by region here would make a
+  //     mid-move database look like an orphan.
+  const custAppsRes = await runtimePool.query<{ id: string }>(`SELECT id FROM apps`);
+  const liveCustNames = new Set(
+    custAppsRes.rows.map((r) => r.id).filter(Boolean).map((id) => custDbNameFor(id, region)),
+  );
+
+  // 2c. Anything already registered in app_db_connections is owned by an app,
+  //     even if the corresponding `apps` row lives in the source region's
+  //     runtime DB. `provisionAppDb` writes this row as its first durable act.
+  const registeredRes = await runtimePool.query<{ neon_database_name: string | null }>(
+    `SELECT neon_database_name FROM app_db_connections`,
+  );
+  const registeredDbNames = new Set(
+    registeredRes.rows.map((r) => r.neon_database_name).filter((n): n is string => Boolean(n)),
+  );
 
   // 3. In-flight provision/deprovision tasks — do NOT touch their app_ids.
   //    A pending 'provision' task means the DB may exist but the app row
@@ -91,15 +152,54 @@ export async function reconcileOrphansForRegion(
         AND status IN ('pending', 'processing')`,
   );
   const inflightAppIds = new Set(inflightRes.rows.map((r) => r.app_id));
+  const inflightAppIdSlugs = new Set([...inflightAppIds].map(appIdSlug));
 
-  // 4. Diff. Neon db_app_<id> ↔ apps.db_name is 'app_<id>' — strip the 'db_' prefix.
+  // 4. Diff.
+  //    db_app_<id> ↔ apps.db_name is 'app_<id>' — strip the 'db_' prefix.
+  //    cust_<appId>_<region> is matched forwards against custDbNameFor().
+  const custSuffix = `_${region.replace(/-/g, '_').toLowerCase()}`;
   const orphans: { name: string; appId: string; createdAt: string; ageMs: number }[] = [];
   let skippedYoung = 0;
   let skippedInflight = 0;
+  let skippedAmbiguous = 0;
   let unmatchedNeonCount = 0; // Neon dbs with no live app row (before grace/inflight filters)
   for (const db of neonDbs) {
-    const appId = db.name.slice('db_'.length); // 'db_app_XXX' → 'app_XXX'
-    if (liveDbNames.has(appId)) continue;
+    let appId: string;
+
+    if (db.name.startsWith(APP_DB_PREFIX)) {
+      appId = db.name.slice('db_'.length); // 'db_app_XXX' → 'app_XXX'
+      if (liveDbNames.has(appId)) continue;
+    } else {
+      // cust_* — a move-app destination database.
+      if (registeredDbNames.has(db.name) || liveCustNames.has(db.name)) continue;
+
+      // Everything below is a reason we cannot *prove* the database is
+      // unowned, so we decline to classify it rather than risk a bad drop.
+      //
+      //  - length >= 63: the name may have been truncated, so the app-id
+      //    segment (and possibly the region suffix) is incomplete.
+      //  - missing region suffix: not the shape provisionAppDb produces for
+      //    this region, so we do not understand who created it.
+      //  - empty app-id segment: nothing to guard the in-flight check with.
+      if (db.name.length >= PG_MAX_DATNAME || !db.name.endsWith(custSuffix)) {
+        skippedAmbiguous++;
+        continue;
+      }
+      const slug = db.name.slice(CUST_DB_PREFIX.length, db.name.length - custSuffix.length);
+      if (!slug) {
+        skippedAmbiguous++;
+        continue;
+      }
+      // The slug is only used for the in-flight guard and for logging — never
+      // to decide liveness, which was settled by the forward match above.
+      appId = slug;
+      if (inflightAppIdSlugs.has(slug)) {
+        unmatchedNeonCount++;
+        skippedInflight++;
+        continue;
+      }
+    }
+
     unmatchedNeonCount++;
     if (inflightAppIds.has(appId)) {
       skippedInflight++;
@@ -114,9 +214,11 @@ export async function reconcileOrphansForRegion(
   }
   // Live apps whose db_name doesn't exist in Neon — the inverse orphan class
   // (broken app that will 3D000 on query). We only log the count; fixing them
-  // is out of scope for this reconciler.
+  // is out of scope for this reconciler. Scoped to the db_app_ shape only.
   const missingNeonForLive = liveDbNames.size
-    - neonDbs.filter((db) => liveDbNames.has(db.name.slice('db_'.length))).length;
+    - neonDbs.filter((db) =>
+        db.name.startsWith(APP_DB_PREFIX) && liveDbNames.has(db.name.slice('db_'.length)),
+      ).length;
 
   // Oldest first — pick from the most-clearly-orphaned end when the cap bites.
   orphans.sort((a, b) => a.ageMs - b.ageMs > 0 ? -1 : 1);
@@ -133,6 +235,7 @@ export async function reconcileOrphansForRegion(
     wouldDrop: [],
     skippedYoung,
     skippedInflight,
+    skippedAmbiguous,
     dropErrors: [],
   };
 
@@ -149,6 +252,7 @@ export async function reconcileOrphansForRegion(
       eligibleCount,
       skippedYoung,
       skippedInflight,
+      skippedAmbiguous,
       cappedAt: opts.maxDropsPerRun,
       willProcess: toProcess.length,
       mode: opts.dryRun ? 'dry-run' : 'drop',
@@ -219,9 +323,10 @@ export async function reconcileOrphans(
       wouldDrop: a.wouldDrop + r.wouldDrop.length,
       skippedYoung: a.skippedYoung + r.skippedYoung,
       skippedInflight: a.skippedInflight + r.skippedInflight,
+      skippedAmbiguous: a.skippedAmbiguous + r.skippedAmbiguous,
       errors: a.errors + r.dropErrors.length,
     }),
-    { dropped: 0, wouldDrop: 0, skippedYoung: 0, skippedInflight: 0, errors: 0 },
+    { dropped: 0, wouldDrop: 0, skippedYoung: 0, skippedInflight: 0, skippedAmbiguous: 0, errors: 0 },
   );
   logger.info(
     { ...totals, regionsScanned: results.length, mode: opts.dryRun ? 'dry-run' : 'drop' },

--- a/services/control-api/src/services/neon-orphan-reconciler.ts
+++ b/services/control-api/src/services/neon-orphan-reconciler.ts
@@ -3,6 +3,7 @@ import { config } from '../config.js';
 import { getDataProjectIdForRegion } from './neon-projects.js';
 import { getRuntimeDbPool, type RuntimeDbConfig } from './runtime-db.js';
 import * as neonClient from './neon-client.js';
+import { custDbNameFor, PG_MAX_DATNAME } from './provisioner.js';
 
 interface Logger {
   info(obj: unknown, msg?: string): void;
@@ -71,11 +72,11 @@ const APP_DB_PREFIX = 'db_app_';
 /** Prefix for move-app destination databases — matches `provisionAppDb`. */
 const CUST_DB_PREFIX = 'cust_';
 
-/** Postgres `datname` limit. `provisionAppDb` truncates to this. */
-const PG_MAX_DATNAME = 63;
-
 /**
- * Reproduce `provisionAppDb`'s destination-database name EXACTLY.
+ * `custDbNameFor` reproduces `provisionAppDb`'s destination-database name
+ * EXACTLY — it is imported from provisioner.ts (the single source of truth
+ * for that naming), not reimplemented here. Re-exported so existing callers
+ * (and this file's tests) can keep importing it from the reconciler.
  *
  * We match forwards (compute the expected name for every known app id and
  * compare) rather than inverting the name back to an app id, because the
@@ -86,11 +87,7 @@ const PG_MAX_DATNAME = 63;
  * Inverting would mean guessing, and a wrong guess here drops a live customer
  * database. Forward-matching cannot produce a false positive.
  */
-export function custDbNameFor(appId: string, region: string): string {
-  return `cust_${appId.replace(/-/g, '_')}_${region.replace(/-/g, '_')}`
-    .toLowerCase()
-    .slice(0, PG_MAX_DATNAME);
-}
+export { custDbNameFor };
 
 /** Same normalisation applied to the app-id segment alone — used to line a
  *  cust_* name up with `neon_tasks.app_id` for the in-flight guard. */

--- a/services/control-api/src/services/provisioner-app-db.test.ts
+++ b/services/control-api/src/services/provisioner-app-db.test.ts
@@ -23,7 +23,23 @@ vi.mock('../config.js', async (importOriginal) => {
   return { ...actual, assertRuntimeDbConfig: () => {} };
 });
 
-const { provisionAppDb } = await import('./provisioner.js');
+vi.mock('./neon-projects.js', () => ({
+  getDataProjectIdForRegion: vi.fn(() => 'legacy-shared-proj-1'),
+}));
+
+vi.mock('./neon-client.js', () => ({
+  withNeonProjectLock: async (_projectId: string, fn: () => Promise<void>) => fn(),
+  ensureRoleExists: vi.fn().mockResolvedValue(undefined),
+  createDatabase: vi.fn().mockResolvedValue(undefined),
+  grantSchemaPrivileges: vi.fn().mockResolvedValue(undefined),
+  getConnectionString: vi.fn().mockResolvedValue({
+    connectionUri: 'postgres://u:p@direct/legacy-db',
+    poolerHost: undefined,
+    pooledConnectionUri: undefined,
+  }),
+}));
+
+const { provisionAppDb, custDbNameFor } = await import('./provisioner.js');
 const { config } = await import('../config.js');
 
 const APP_ID = 'app_k3f9x2m1qp0z';
@@ -98,5 +114,32 @@ describe('provisionAppDb — tenant branch (projectPerTenant = true)', () => {
     await provisionAppDb(REGION, APP_ID, 'owner');
 
     expect(getRuntimeDbPool).toHaveBeenCalledWith(expect.anything(), REGION);
+  });
+});
+
+describe('provisionAppDb — legacy branch (projectPerTenant = false)', () => {
+  const original = config.neon.projectPerTenant;
+
+  beforeEach(() => {
+    config.neon.projectPerTenant = false;
+    runtimeQuery.mockClear();
+    getRuntimeDbPool.mockClear();
+  });
+
+  afterEach(() => { config.neon.projectPerTenant = original; });
+
+  // Regression guard for the reconciler's orphan detection: the reconciler
+  // decides which cust_* databases are live by recomputing this same name
+  // via the shared `custDbNameFor` export. If provisionAppDb's actual
+  // database name ever drifts from `custDbNameFor`'s output — e.g. someone
+  // reintroduces a second inline copy of the naming instead of calling the
+  // shared helper — every live cust_* database becomes a false orphan and
+  // gets deleted. This test calls the real `provisionAppDb` legacy path
+  // (not just the helper in isolation) and asserts the two stay identical.
+  it('names the cust_* database exactly as custDbNameFor computes it', async () => {
+    const out = await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(out.neonDbName).toBe(custDbNameFor(APP_ID, REGION));
+    expect(out.neonDbName).toBe('cust_app_k3f9x2m1qp0z_us_west_2');
   });
 });

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -288,9 +288,10 @@ export async function provisionApp(
     if (pooledConnectionUri) {
       poolerConnectionString = pooledConnectionUri;
     } else if (poolerHost) {
+      // Host swap only — Neon's pooled host carries no explicit port. (The
+      // obsolete `:6543` convention used to be injected here.)
       const url = new URL(connectionUri);
       url.hostname = poolerHost;
-      url.port = '6543';
       poolerConnectionString = url.toString();
     }
 
@@ -511,9 +512,10 @@ export async function provisionAppDb(
   if (pooledConnectionUri) {
     poolerConnectionString = pooledConnectionUri;
   } else if (poolerHost) {
+    // Host swap only — Neon's pooled host carries no explicit port. (The
+    // obsolete `:6543` convention used to be injected here.)
     const url = new URL(connectionUri);
     url.hostname = poolerHost;
-    url.port = '6543';
     poolerConnectionString = url.toString();
   }
   const runtimePool = getRuntimeDbPool(config.runtimeDb, region);

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -22,6 +22,24 @@ export function generateAppId(): string {
   return `${APP_ID_PREFIX}${generateId()}`;
 }
 
+/** Postgres `datname` limit. `custDbNameFor` truncates to this. */
+export const PG_MAX_DATNAME = 63;
+
+/**
+ * The `cust_<appId>_<region>` move-app destination database name used by the
+ * legacy (non-project-per-tenant) branch of `provisionAppDb` below.
+ *
+ * Exported so `neon-orphan-reconciler.ts` can reproduce it EXACTLY when
+ * deciding which `cust_*` databases belong to live apps — any drift here
+ * silently reclassifies live customer databases as orphans and deletes them.
+ * Keep this the single source of truth for the naming; do not fork a copy.
+ */
+export function custDbNameFor(appId: string, region: string): string {
+  return `cust_${appId.replace(/-/g, '_')}_${region.replace(/-/g, '_')}`
+    .toLowerCase()
+    .slice(0, PG_MAX_DATNAME);
+}
+
 /**
  * Retries runDataPlaneMigrations with exponential backoff for transient errors that occur while
  * Neon is waking up a cold compute or finishing async DB creation:
@@ -484,10 +502,7 @@ export async function provisionAppDb(
   if (!dataProjectId) throw new Error(`No data project for region ${region}`);
 
   const owner = config.neon.databaseOwner;
-  // Postgres datname max length = 63 bytes
-  const neonDbName = `cust_${appId.replace(/-/g, '_')}_${region.replace(/-/g, '_')}`
-    .toLowerCase()
-    .slice(0, 63);
+  const neonDbName = custDbNameFor(appId, region);
 
   // Serialize Neon API calls per project; idempotent on "already exists".
   await neonClient.withNeonProjectLock(dataProjectId, async () => {


### PR DESCRIPTION
Two long-standing defects, both recorded in the project-per-app design doc. Independent of the feature flag — these are correct today and stay correct after it flips.

## A — pooled connection strings carried an obsolete `:6543` port

A live probe of Neon's API returned pooled hosts as `ep-<id>-pooler.<region>.aws.neon.tech` with **no explicit port** (default 5432). Three sites injected `:6543`, an obsolete Neon convention:

- `neon-client.ts` — `getConnectionString`'s cache-hit branch
- `provisioner.ts:293` — `provisionAppBackground`
- `provisioner.ts:516` — `provisionAppDb` (**reachable**, this is the move-app destination path)

All three now leave the port as Neon gives it. Each was an `else if (poolerHost)` fallback taken only when Neon's own pooled URI was absent, so the correct value was already used on the common path.

**This changes the value written to `app_db_connections.pooler_connection_string`.** Verified there is no reachable reader: the only `SELECT` of that column is in `formatResponse` (`provisioner.ts:373`), called only from `provisionApp`, which `routes/init.ts` imports but never calls. We are replacing an unread wrong value with an unread right value — but the write path was reachable, so the fix is not cosmetic.

## B — the orphan reconciler could not see `cust_*` databases

`neon-orphan-reconciler.ts` filtered the Neon inventory on `db_app_` only, so move-app destination databases named `cust_<appId>_<region>` were invisible and never reclaimed. At least one exists in production today (us-west-2).

The transform is **not invertible** — the app id is lowercased, has `-`→`_` applied, and the whole name is truncated to 63 bytes. So it is never inverted. Instead the reconciler reproduces it **forwards** from known app ids and matches by set membership, with `app_db_connections` as a second liveness signal. Anything it cannot derive confidently — truncation at 63 bytes, a foreign region suffix, an empty id segment — is reported as `skippedAmbiguous` and **never dropped**. A missed orphan costs storage; a wrongly dropped one destroys customer data.

The `db_app_*` path is untouched, and all four safeties are preserved: grace-hours window, in-flight `neon_tasks` guard, max-drops-per-run cap, dry-run by default.

The naming logic is now **single-sourced** — `custDbNameFor` is exported from `provisioner.ts` and imported by the reconciler, with a test that calls the real `provisionAppDb` path and asserts byte-identity. Two independent copies would have been the highest residual risk in this diff: if they ever diverged, every live `cust_*` database would silently become a false orphan.

## Verification

- Reviewed against six reconciler scenarios, including an app mid-move whose `apps` row is in the source region while its database sits in the destination. That case is safe because `step-reserve-dest` INSERTs the dest `apps` row *before* provisioning the database, with `app_db_connections` and the 24h grace window as further backstops.
- The liveness guard is mutation-verified: removing it fails a test.
- `tsc -b` clean; failing-file set byte-identical to the baseline on `cad28f5`, zero new failures.
