### PR TITLE
feat(neon): make project-per-tenant flag resolvable per region

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -158,6 +158,12 @@ NEON_DATA_PROJECT_ID_US_EAST_1=prod-data-use1
 NEON_ORG_ID=org-round-cell-11808374
 # Provision each new app into its own Neon project. Default false.
 BUTTERBASE_PROJECT_PER_TENANT=false
+# Per-region override, for a staged one-region-at-a-time rollout, e.g.:
+#   BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1=true
+#   BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2=false
+# When set to 'true' or 'false' it overrides the global flag above for that
+# region, in both directions. When unset (or empty) it falls back to the
+# global flag.
 # Butterbase region -> Neon region_id. Defaults to aws-<region> when unset.
 NEON_REGION_US_EAST_1=aws-us-east-1
 NEON_REGION_US_WEST_2=aws-us-west-2

--- a/services/control-api/src/services/__tests__/neon-task-worker.test.ts
+++ b/services/control-api/src/services/__tests__/neon-task-worker.test.ts
@@ -50,6 +50,9 @@ vi.mock('../neon-projects.js', () => ({
   // defaultDeps() eagerly reads every member of neon-projects.js; unused on
   // the legacy path but required or the mock factory throws "No export".
   getNeonPgVersionForRegion: vi.fn(() => 17),
+  // provisionNeonDbForApp branches on this directly. These tests exercise the
+  // legacy path, so it stays off.
+  isProjectPerTenantForRegion: vi.fn(() => false),
 }));
 
 vi.mock('../provisioner.js', () => ({

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -175,4 +175,43 @@ describe('provisionNeonDbForApp', () => {
       expect(calls).not.toContain('createProjectForApp');
     });
   });
+
+  describe('per-region override', () => {
+    afterEach(() => {
+      delete process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1;
+      delete process.env.BUTTERBASE_PROJECT_PER_TENANT_EU_WEST_1;
+    });
+
+    it('takes the tenant path when the region is on and the global is off', async () => {
+      config.neon.projectPerTenant = false;
+      process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'true';
+
+      const { deps, calls } = makeDeps();
+      const result = await provisionNeonDbForApp('us-east-1', APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('tenant-proj-1');
+      expect(calls).toContain('createProjectForApp');
+    });
+
+    it('takes the legacy path when the region is off even though the global is on', async () => {
+      config.neon.projectPerTenant = true;
+      process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'false';
+
+      const { deps, calls } = makeDeps();
+      const result = await provisionNeonDbForApp('us-east-1', APP_ID, deps);
+
+      expect(result.neonProjectId).toBe('shared-proj-us-east-1');
+      expect(calls).not.toContain('createProjectForApp');
+    });
+
+    it('leaves other regions on the global flag — one region at a time', async () => {
+      config.neon.projectPerTenant = false;
+      process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'true';
+
+      const { deps, calls } = makeDeps();
+      await provisionNeonDbForApp('eu-west-1', APP_ID, deps);
+
+      expect(calls).not.toContain('createProjectForApp');
+    });
+  });
 });

--- a/services/control-api/src/services/app-db-provision.test.ts
+++ b/services/control-api/src/services/app-db-provision.test.ts
@@ -205,13 +205,17 @@ describe('provisionNeonDbForApp', () => {
     });
 
     it('leaves other regions on the global flag — one region at a time', async () => {
-      config.neon.projectPerTenant = false;
-      process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'true';
+      // Global is ON; only us-east-1 is explicitly overridden OFF. If the
+      // override leaked across regions, eu-west-1 would wrongly take the
+      // legacy path too — this pins that it stays on the (true) global.
+      config.neon.projectPerTenant = true;
+      process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'false';
 
       const { deps, calls } = makeDeps();
-      await provisionNeonDbForApp('eu-west-1', APP_ID, deps);
+      const result = await provisionNeonDbForApp('eu-west-1', APP_ID, deps);
 
-      expect(calls).not.toContain('createProjectForApp');
+      expect(result.neonProjectId).toBe('tenant-proj-1');
+      expect(calls).toContain('createProjectForApp');
     });
   });
 });

--- a/services/control-api/src/services/app-db-provision.ts
+++ b/services/control-api/src/services/app-db-provision.ts
@@ -4,6 +4,7 @@ import {
   getDataProjectIdForRegion,
   getNeonRegionIdForRegion,
   getNeonPgVersionForRegion,
+  isProjectPerTenantForRegion,
 } from './neon-projects.js';
 
 export interface ProvisionedDb {
@@ -76,7 +77,9 @@ function pooledFrom(
  * Provision the customer Postgres database for one app and return everything
  * the caller needs to write `app_db_connections`.
  *
- * Two shapes, selected by `config.neon.projectPerTenant`:
+ * Two shapes, selected by `isProjectPerTenantForRegion(region)` — the
+ * per-region override `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` when set,
+ * otherwise the global `config.neon.projectPerTenant`:
  *
  *   tenant — one Neon project per app. Single POST creates project, database
  *            and owner role. No role bootstrap, no schema grant, no lock.
@@ -94,7 +97,7 @@ export async function provisionNeonDbForApp(
   const neonDbName = `db_${appId}`;
   const owner = config.neon.databaseOwner;
 
-  if (config.neon.projectPerTenant) {
+  if (isProjectPerTenantForRegion(region)) {
     // Idempotency: a retried neon_task must adopt the project a crashed
     // earlier attempt already created, or we leak a billed project per retry.
     // This lookup runs on EVERY tenant provision, not just retries, and an

--- a/services/control-api/src/services/neon-projects.test.ts
+++ b/services/control-api/src/services/neon-projects.test.ts
@@ -5,6 +5,7 @@ import {
   assertNeonProjectsConfig,
   getNeonRegionIdForRegion,
   getNeonPgVersionForRegion,
+  isProjectPerTenantForRegion,
   __resetNeonProjectsCache,
 } from './neon-projects.js';
 import { config } from '../config.js';
@@ -104,5 +105,62 @@ describe('getNeonPgVersionForRegion', () => {
   it('falls back to the global default on a non-numeric value', () => {
     process.env.NEON_PG_VERSION_US_WEST_2 = 'not-a-number';
     expect(getNeonPgVersionForRegion('us-west-2')).toBe(config.neon.pgVersion);
+  });
+});
+
+describe('isProjectPerTenantForRegion', () => {
+  const original = config.neon.projectPerTenant;
+  afterEach(() => { config.neon.projectPerTenant = original; });
+
+  it('enables the region when BUTTERBASE_PROJECT_PER_TENANT_<REGION> is "true"', () => {
+    config.neon.projectPerTenant = false;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'true';
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(true);
+  });
+
+  it('is a true override: per-region "false" disables even when the global is true', () => {
+    config.neon.projectPerTenant = true;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = 'false';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(false);
+  });
+
+  it('treats any non-"true" value as off', () => {
+    config.neon.projectPerTenant = true;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = '1';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(false);
+  });
+
+  it("does not leak one region's override into another", () => {
+    config.neon.projectPerTenant = false;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'true';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(false);
+  });
+
+  it('falls back to the global flag when unset (global true)', () => {
+    config.neon.projectPerTenant = true;
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(true);
+  });
+
+  it('falls back to the global flag when unset (global false)', () => {
+    config.neon.projectPerTenant = false;
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(false);
+  });
+
+  it('derives the env key by upper-casing and underscoring the region', () => {
+    config.neon.projectPerTenant = false;
+    // us-west-2 -> US_WEST_2; the raw-region key must NOT be consulted.
+    process.env['BUTTERBASE_PROJECT_PER_TENANT_us-west-2'] = 'true';
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(false);
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'true';
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(true);
+  });
+
+  it('reads env on every call — no caching', () => {
+    config.neon.projectPerTenant = false;
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(false);
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'true';
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(true);
+    delete process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2;
+    expect(isProjectPerTenantForRegion('us-west-2')).toBe(false);
   });
 });

--- a/services/control-api/src/services/neon-projects.test.ts
+++ b/services/control-api/src/services/neon-projects.test.ts
@@ -163,4 +163,25 @@ describe('isProjectPerTenantForRegion', () => {
     delete process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2;
     expect(isProjectPerTenantForRegion('us-west-2')).toBe(false);
   });
+
+  it('treats an empty-string value as unset and falls back to the global (global true) — the footgun case', () => {
+    // A Fly secret declared with no value, or a bare `- VAR` line in
+    // docker-compose, passes through as ''. It must NOT resolve to false
+    // and silently disable a region the global flag had enabled.
+    config.neon.projectPerTenant = true;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = '';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(true);
+  });
+
+  it('treats an empty-string value as unset and falls back to the global (global false)', () => {
+    config.neon.projectPerTenant = false;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = '';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(false);
+  });
+
+  it('treats a whitespace-only value as unset and falls back to the global (global true)', () => {
+    config.neon.projectPerTenant = true;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1 = '   ';
+    expect(isProjectPerTenantForRegion('us-east-1')).toBe(true);
+  });
 });

--- a/services/control-api/src/services/neon-projects.ts
+++ b/services/control-api/src/services/neon-projects.ts
@@ -68,11 +68,21 @@ export function getNeonPgVersionForRegion(region: string): number {
  * and one may be closed to new provisioning), so the flag must be flippable
  * one region at a time rather than globally.
  *
- * `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` — when set — DECIDES, in both
- * directions: `'true'` enables, any other value disables even if the global
- * flag is on. It is an override, not an OR. When unset we fall back to the
- * global `config.neon.projectPerTenant`, so with no per-region vars set the
- * behaviour is exactly what it is today.
+ * `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` — when set to a non-empty,
+ * non-whitespace value — DECIDES, in both directions: `'true'` enables, any
+ * other non-empty value disables even if the global flag is on. It is an
+ * override, not an OR. When unset, OR set to `''`/whitespace-only, we fall
+ * back to the global `config.neon.projectPerTenant`.
+ *
+ * The empty-string case matters operationally: a Fly secret declared as
+ * `BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1=` (no value), or a bare
+ * `- BUTTERBASE_PROJECT_PER_TENANT_US_EAST_1` line in docker-compose, is
+ * "set" from the shell's point of view but passes through as `''`. Unlike
+ * the sibling resolvers below (which use truthiness and therefore already
+ * treat `''` as unset), this one cannot use plain truthiness — truthiness
+ * can't express an explicit `false` override. So it special-cases blank
+ * strings to fall back instead of silently resolving to `false` and
+ * disabling a region the global flag had enabled.
  *
  * Reads env on every call — no caching, matching getNeonRegionIdForRegion.
  *
@@ -82,7 +92,7 @@ export function getNeonPgVersionForRegion(region: string): number {
  */
 export function isProjectPerTenantForRegion(region: string): boolean {
   const raw = process.env[envKey('BUTTERBASE_PROJECT_PER_TENANT', region)];
-  if (raw !== undefined) return raw === 'true';
+  if (raw !== undefined && raw.trim() !== '') return raw === 'true';
   return config.neon.projectPerTenant;
 }
 

--- a/services/control-api/src/services/neon-projects.ts
+++ b/services/control-api/src/services/neon-projects.ts
@@ -61,6 +61,31 @@ export function getNeonPgVersionForRegion(region: string): number {
   return config.neon.pgVersion;
 }
 
+/**
+ * Is project-per-app provisioning enabled for `region`?
+ *
+ * Staged rollout: the regions are not equivalent (different Neon PG majors,
+ * and one may be closed to new provisioning), so the flag must be flippable
+ * one region at a time rather than globally.
+ *
+ * `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` — when set — DECIDES, in both
+ * directions: `'true'` enables, any other value disables even if the global
+ * flag is on. It is an override, not an OR. When unset we fall back to the
+ * global `config.neon.projectPerTenant`, so with no per-region vars set the
+ * behaviour is exactly what it is today.
+ *
+ * Reads env on every call — no caching, matching getNeonRegionIdForRegion.
+ *
+ * Provisioning paths only. Teardown deliberately discriminates on the app's
+ * stored `neon_project_id`, because the flag can change between an app's
+ * provision and its deletion.
+ */
+export function isProjectPerTenantForRegion(region: string): boolean {
+  const raw = process.env[envKey('BUTTERBASE_PROJECT_PER_TENANT', region)];
+  if (raw !== undefined) return raw === 'true';
+  return config.neon.projectPerTenant;
+}
+
 export function assertNeonProjectsConfig(): void {
   const regionsRaw = process.env.BUTTERBASE_REGIONS ?? '';
   const regions = regionsRaw.split(',').map((s) => s.trim()).filter(Boolean);

--- a/services/control-api/src/services/provisioner-app-db.test.ts
+++ b/services/control-api/src/services/provisioner-app-db.test.ts
@@ -23,9 +23,13 @@ vi.mock('../config.js', async (importOriginal) => {
   return { ...actual, assertRuntimeDbConfig: () => {} };
 });
 
-vi.mock('./neon-projects.js', () => ({
-  getDataProjectIdForRegion: vi.fn(() => 'legacy-shared-proj-1'),
-}));
+// Spread the real module so the genuine `isProjectPerTenantForRegion` runs
+// (and so a future export can't break this partial factory); only the
+// shared-project lookup is stubbed, to avoid needing NEON_DATA_PROJECT_ID_*.
+vi.mock('./neon-projects.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./neon-projects.js')>();
+  return { ...actual, getDataProjectIdForRegion: vi.fn(() => 'legacy-shared-proj-1') };
+});
 
 vi.mock('./neon-client.js', () => ({
   withNeonProjectLock: async (_projectId: string, fn: () => Promise<void>) => fn(),
@@ -141,5 +145,45 @@ describe('provisionAppDb — legacy branch (projectPerTenant = false)', () => {
 
     expect(out.neonDbName).toBe(custDbNameFor(APP_ID, REGION));
     expect(out.neonDbName).toBe('cust_app_k3f9x2m1qp0z_us_west_2');
+  });
+});
+
+describe('provisionAppDb — per-region override', () => {
+  const original = config.neon.projectPerTenant;
+
+  beforeEach(() => {
+    provisionNeonDbForApp.mockReset().mockResolvedValue({
+      connectionUri: 'postgres://u:p@direct/db_app',
+      poolerConnectionString: null,
+      neonProjectId: 'tenant-proj-1',
+      neonDatabaseName: `db_${APP_ID}`,
+    });
+    runtimeQuery.mockClear();
+    getRuntimeDbPool.mockClear();
+  });
+
+  afterEach(() => {
+    config.neon.projectPerTenant = original;
+    delete process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2;
+  });
+
+  it('takes the tenant branch when only the region is enabled', async () => {
+    config.neon.projectPerTenant = false;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'true';
+
+    const out = await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(provisionNeonDbForApp).toHaveBeenCalledWith(REGION, APP_ID);
+    expect(out.neonDbName).toBe(`db_${APP_ID}`);
+  });
+
+  it('takes the legacy branch when the region is disabled despite a true global', async () => {
+    config.neon.projectPerTenant = true;
+    process.env.BUTTERBASE_PROJECT_PER_TENANT_US_WEST_2 = 'false';
+
+    const out = await provisionAppDb(REGION, APP_ID, 'owner');
+
+    expect(provisionNeonDbForApp).not.toHaveBeenCalled();
+    expect(out.neonDbName).toBe(custDbNameFor(APP_ID, REGION));
   });
 });

--- a/services/control-api/src/services/provisioner.ts
+++ b/services/control-api/src/services/provisioner.ts
@@ -4,7 +4,7 @@ import { config, assertRegionConfig, assertRuntimeDbConfig } from '../config.js'
 import { getRuntimeDbPool } from './runtime-db.js';
 import { runDataPlaneMigrations } from './migrator.js';
 import * as neonClient from './neon-client.js';
-import { getDataProjectIdForRegion } from './neon-projects.js';
+import { getDataProjectIdForRegion, isProjectPerTenantForRegion } from './neon-projects.js';
 import { provisionNeonDbForApp } from './app-db-provision.js';
 import {
   APP_ID_PREFIX,
@@ -445,7 +445,9 @@ async function formatResponse(app: App, runtimeDb: pg.Pool): Promise<InitRespons
  * `app_db_connections` row for it, and return the connection URI. Does NOT run
  * customer migrations — the move-app saga's restoring_data step does that.
  *
- * Two shapes, selected by `config.neon.projectPerTenant`:
+ * Two shapes, selected by `isProjectPerTenantForRegion(region)` — the
+ * per-region override `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` when set,
+ * otherwise the global `config.neon.projectPerTenant`:
  *
  *   tenant — delegates to `provisionNeonDbForApp`, which creates a dedicated
  *            Neon project per app (adopt-before-create on retry).
@@ -465,7 +467,7 @@ export async function provisionAppDb(
   // plugin). Idempotent guard handles the first case.
   assertRuntimeDbConfig();
 
-  if (config.neon.projectPerTenant) {
+  if (isProjectPerTenantForRegion(region)) {
     // One Neon project per app. The shared helper owns adopt-before-create,
     // the queryability wait and the pooled-URI lookup; all this branch adds is
     // the app_db_connections row, which step-restore-data reads in the dest


### PR DESCRIPTION
Lets the project-per-app rollout be staged one region at a time instead of an all-or-nothing flip. **Ships dormant** — with no per-region variables set, behaviour is exactly what it is today.

## Why

`BUTTERBASE_PROJECT_PER_TENANT` was a single global boolean, so enabling it turned project-per-app on in both regions simultaneously. The two regions are not equivalent:

- **us-east-1** — Neon data project on PG 17, and currently **closed to new provisioning** (`BUTTERBASE_PROVISION_ALLOWED_REGIONS=us-west-2`) because it sits at 394/500 databases
- **us-west-2** — Neon data project on PG 18, taking all new apps today

Staging matters here.

## The change

`isProjectPerTenantForRegion(region)` in `neon-projects.ts`, following the same pattern as the existing `NEON_DATA_PROJECT_ID_<REGION>`, `NEON_REGION_<REGION>` and `NEON_PG_VERSION_<REGION>` — same private `envKey()` helper, no duplicated string munging.

- `BUTTERBASE_PROJECT_PER_TENANT_<REGION>` when set decides, **in both directions**. It is a true override, not an OR with the global — so a region explicitly set to `false` stays off even when the global is `true`. Pinned by tests at three levels.
- Unset **or empty/whitespace-only** falls back to the global. The empty case is deliberate: a Fly secret set to nothing, or a bare `- VAR` in docker-compose, arrives as `''`, and treating that as an explicit `false` would silently disable a region the global had enabled. This diverges from the sibling resolvers (which use truthiness) because truthiness cannot express an explicit `false`; the JSDoc explains it.
- Not cached — reads env per call, matching `getNeonRegionIdForRegion`.

Applied at exactly the two provisioning reads: `app-db-provision.ts`'s `provisionNeonDbForApp` and `provisioner.ts`'s `provisionAppDb`.

## What deliberately did NOT change

**No teardown path reads the flag**, and none was made to. `app-db-teardown.ts`, `executeDeprovision`, `routes/billing.ts` and `step-abort.ts` discriminate on the app's stored `neon_project_id`, precisely because the flag can change between an app's provision and its deletion. Making teardown flag-aware — let alone *region*-flag-aware — would reintroduce the orphaned-project bug that discriminator exists to prevent. Verified by grep; the only executable reads of the flag are the two provisioning sites and the definition in `config.ts`.

## Verification

- The false-override case is tested at the resolver, at `provisionNeonDbForApp`, and at `provisionAppDb`.
- Empty-string fallback is tested **with the global set to true** — a test with the global false would have proven nothing.
- `' true '` resolves false: trimming is used only for the emptiness test, not for the comparison.
- Existing assertions untouched, including the three that the tenant path never calls `grantSchemaPrivileges` / `ensureRoleExists` / `withNeonProjectLock`.
- `.env.production.example` documents the per-region form with both concrete region names.
- `tsc -b` clean; failing-file set diffs empty against a baseline on `885486a`.
