### PR TITLE
fix(regions): tell callers when provisioning was redirected to another region

### DIFF
--- a/services/control-api/src/__tests__/clone-routes.test.ts
+++ b/services/control-api/src/__tests__/clone-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 describe('GET /v1/clone-jobs/:job_id — warnings field', () => {
   it('round-trips warnings from the JSONB column', async () => {
@@ -93,6 +93,19 @@ vi.mock('../plugins/quota-enforcement.js', () => ({ default: { name: 'quota-enfo
 vi.mock('../services/auth/email-service.js', () => ({ sendBillingEmail: vi.fn() }));
 vi.mock('../services/redis.js', () => ({ getRedisClient: vi.fn(() => null) }));
 vi.mock('../services/app-plan-resolver.js', () => ({ getLimitsForApp: vi.fn(async () => ({ maxRequestsPerMin: 100 })) }));
+
+// The route gained org resolution and a project-quota check after this suite was
+// written. Both read the control DB, and the stub below returns `{ rows: [] }`
+// for everything, so unmocked they throw and every case 500s regardless of what
+// it was asserting. Mock them to the "allowed" answer so the assertions test what
+// they claim to.
+vi.mock('../services/org-resolver.js', () => ({
+  resolveOrganizationId: vi.fn(async () => 'org_test'),
+  assertOrgMember: vi.fn(async () => undefined),
+}));
+vi.mock('../services/project-quota.js', () => ({
+  checkProjectQuota: vi.fn(async () => ({ ok: true, current: 0, limit: 100 })),
+}));
 
 // A fixed "good" source app row returned by the runtime pool query.
 const GOOD_SRC_ROW = {
@@ -256,6 +269,81 @@ describe('POST /v1/templates/:source_app_id/clone — new fields', () => {
         pendingEnvVarValues: undefined,
         autoMintRequests: undefined,
       }),
+    );
+
+    await app.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Region placement — a redirect must be visible to the caller
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/templates/:source_app_id/clone — region placement', () => {
+  const saved = {
+    allowed: process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS,
+    regions: process.env.BUTTERBASE_REGIONS,
+    dflt: process.env.BUTTERBASE_DEFAULT_REGION,
+  };
+
+  afterEach(() => {
+    const restore = (k: string, v: string | undefined) => {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    };
+    restore('BUTTERBASE_PROVISION_ALLOWED_REGIONS', saved.allowed);
+    restore('BUTTERBASE_REGIONS', saved.regions);
+    restore('BUTTERBASE_DEFAULT_REGION', saved.dflt);
+  });
+
+  it('reports dest_region and no redirect marker when the region is open', async () => {
+    process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS = 'us-east-1,us-west-2';
+    delete process.env.BUTTERBASE_DEFAULT_REGION;
+
+    const app = await buildCloneApp();
+    mockRuntimePoolQuery.mockResolvedValueOnce({ rows: [GOOD_SRC_ROW] });
+    mockCreateCloneJob.mockResolvedValueOnce({ id: 'cj_open', status: 'pending' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/templates/app_src/clone',
+      payload: { dest_region: 'us-east-1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().dest_region).toBe('us-east-1');
+    expect(res.json().dest_region_redirected_from).toBeUndefined();
+    expect(res.json().notice).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('tells the caller when the clone was redirected to another region', async () => {
+    // The point of the fix: a closed region still yields a working clone, but
+    // the caller is told it moved rather than discovering it later — or never.
+    process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS = 'us-west-2';
+    delete process.env.BUTTERBASE_DEFAULT_REGION;
+
+    const app = await buildCloneApp();
+    mockRuntimePoolQuery.mockResolvedValueOnce({ rows: [GOOD_SRC_ROW] });
+    mockCreateCloneJob.mockResolvedValueOnce({ id: 'cj_moved', status: 'pending' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/templates/app_src/clone',
+      payload: { dest_region: 'us-east-1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().dest_region).toBe('us-west-2');
+    expect(res.json().dest_region_redirected_from).toBe('us-east-1');
+    expect(res.json().notice).toMatch(/us-east-1.*closed.*us-west-2/);
+
+    // The job must actually be created in the region we reported, not the one
+    // that was asked for — a mismatch would make the response a lie.
+    expect(mockCreateCloneJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ destRegion: 'us-west-2' }),
     );
 
     await app.close();

--- a/services/control-api/src/routes/clone.ts
+++ b/services/control-api/src/routes/clone.ts
@@ -18,6 +18,7 @@ import { AppNotFoundError } from '../services/app-resolver.js';
 import { createAgentError, getDocUrl } from '../services/error-handler.js';
 import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
 import { checkProjectQuota } from '../services/project-quota.js';
+import { getProvisionAllowedRegions, resolveProvisionRegion } from '../services/provision-region.js';
 import { quotaErrors } from '../utils/quota-errors.js';
 import {
   VALIDATION_INVALID_SCHEMA,
@@ -246,24 +247,19 @@ export function cloneRoutes(app: FastifyInstance) {
       process.env.BUTTERBASE_DEFAULT_REGION ??
       src.region;
 
-    // If the caller pinned a region temporarily closed to new apps (e.g.
-    // dashboard clone form defaults to source.region), silently redirect
-    // to the first open region rather than 400ing. Silent-failing clones
-    // during a hackathon is worse UX than a transparent cross-region
-    // clone. We log the override so operators can audit it.
-    const provisionAllowed = (
-      process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS
-        ?? process.env.BUTTERBASE_REGIONS
-        ?? ''
-    ).split(',').map((s) => s.trim()).filter(Boolean);
-    let destRegion = requestedDestRegion;
-    if (provisionAllowed.length > 0 && !provisionAllowed.includes(destRegion)) {
-      const fallback = provisionAllowed[0];
+    // If the caller pinned a region temporarily closed to new apps (e.g. the
+    // dashboard clone form defaulting to source.region), redirect to the first
+    // open region rather than 400ing — see services/provision-region.ts. The
+    // redirect is reported on the job response so the clone never lands in a
+    // different region without the caller being told.
+    const provisionAllowed = getProvisionAllowedRegions();
+    const placement = resolveProvisionRegion(requestedDestRegion, provisionAllowed);
+    const destRegion = placement.region;
+    if (placement.redirected) {
       request.log.warn(
-        { requestedDestRegion, destRegion: fallback, sourceRegion: src.region, allowed: provisionAllowed },
+        { requestedDestRegion, destRegion, sourceRegion: src.region, allowed: provisionAllowed },
         '[clone] redirecting new clone to open region',
       );
-      destRegion = fallback;
     }
     const job = await createCloneJob(app.controlDb, {
       sourceAppId: source_app_id,
@@ -279,7 +275,17 @@ export function cloneRoutes(app: FastifyInstance) {
 
     await enqueueCloneTask(source_app_id, src.region, job.id);
 
-    return reply.send({ job_id: job.id, status: 'pending' });
+    return reply.send({
+      job_id: job.id,
+      status: 'pending',
+      dest_region: destRegion,
+      ...(placement.redirected
+        ? {
+            dest_region_redirected_from: placement.requestedRegion,
+            notice: `Region "${placement.requestedRegion}" is temporarily closed to new apps; this clone will be created in "${destRegion}" instead.`,
+          }
+        : {}),
+    });
   });
 
   // GET /v1/clone-jobs/:job_id

--- a/services/control-api/src/routes/init.ts
+++ b/services/control-api/src/routes/init.ts
@@ -7,6 +7,11 @@ import { requireUserId } from '../utils/require-auth.js';
 import { quotaErrors } from '../utils/quota-errors.js';
 import { logFromRequest } from '../services/audit/with-audit.js';
 import { getDataProjectIdForRegion } from '../services/neon-projects.js';
+import {
+  parseRegionList,
+  getProvisionAllowedRegions,
+  resolveProvisionRegion,
+} from '../services/provision-region.js';
 import { addOrgAppIndex, removeOrgAppIndex, listAppsForUserAcrossOrgs } from '../services/org-app-index.js';
 import { resolveOrganizationId, assertOrgMember } from '../services/org-resolver.js';
 import { checkProjectQuota } from '../services/project-quota.js';
@@ -147,18 +152,9 @@ export async function initRoutes(app: FastifyInstance) {
     // geographically nearest, so a user in California silently got their
     // app provisioned in us-west-2 even when they didn't pick a region.
     // The default needs to be deterministic across machines.
-    const allowedRegions = (process.env.BUTTERBASE_REGIONS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
-    // Regions that accept NEW app provisioning. Defaults to allowedRegions
-    // (BUTTERBASE_REGIONS gates both serving and provisioning). Setting
-    // BUTTERBASE_PROVISION_ALLOWED_REGIONS to a subset (e.g. "us-west-2")
-    // lets operators temporarily close a region to new writes without
-    // breaking traffic to apps already homed there — needed when one
-    // region has hit an infra ceiling (Neon's 500 databases-per-branch).
-    const provisionAllowed = (
-      process.env.BUTTERBASE_PROVISION_ALLOWED_REGIONS
-        ?? process.env.BUTTERBASE_REGIONS
-        ?? ''
-    ).split(',').map((s) => s.trim()).filter(Boolean);
+    const allowedRegions = parseRegionList(process.env.BUTTERBASE_REGIONS);
+    // Regions that accept NEW app provisioning — see services/provision-region.ts.
+    const provisionAllowed = getProvisionAllowedRegions();
     const bodyRegion = (request.body as { region?: string } | undefined)?.region;
     const requestedRegion =
       bodyRegion ??
@@ -173,20 +169,18 @@ export async function initRoutes(app: FastifyInstance) {
         allowed: allowedRegions,
       });
     }
-    // If the caller asked for a region that's temporarily closed to new
-    // apps, silently redirect to the first open region rather than 400ing.
-    // Dashboard/CLI flows often pin a region from the template's source and
-    // failing them mid-hackathon is worse UX than a transparent move. The
-    // response body doesn't currently expose region, so callers see nothing
-    // surprising; we log the override so operators can audit it.
-    let provisionRegion = requestedRegion;
-    if (provisionAllowed.length > 0 && !provisionAllowed.includes(requestedRegion)) {
-      const fallback = provisionAllowed[0];
+    // If the caller asked for a region that's temporarily closed to new apps,
+    // redirect to the first open region rather than 400ing — a working app in
+    // another region beats a failed request. The redirect is reported back to
+    // the caller (`region` / `region_redirected_from` below) so it is never a
+    // silent relocation of their data.
+    const placement = resolveProvisionRegion(requestedRegion, provisionAllowed);
+    const provisionRegion = placement.region;
+    if (placement.redirected) {
       request.log.warn(
-        { requestedRegion, provisionRegion: fallback, allowed: provisionAllowed },
+        { requestedRegion, provisionRegion, allowed: provisionAllowed },
         '[init] redirecting new app to open region',
       );
-      provisionRegion = fallback;
     }
     try {
       getDataProjectIdForRegion(provisionRegion);
@@ -274,6 +268,9 @@ export async function initRoutes(app: FastifyInstance) {
         api_url: `${config.apiBaseUrl}/v1/${appRow.id}`,
         subdomain: existingSubdomain,
         url: `https://${existingSubdomain}.${config.subdomain.baseDomain}`,
+        // The app already existed, so its home region is whatever it was
+        // provisioned into originally — not this request's placement.
+        region: (appRow as any).region ?? provisionRegion,
         created_at: appRow.created_at.toISOString(),
       });
     }
@@ -343,8 +340,17 @@ export async function initRoutes(app: FastifyInstance) {
       api_url: `${config.apiBaseUrl}/v1/${appId}`,
       subdomain,
       url: `https://${subdomain}.${config.subdomain.baseDomain}`,
+      region: provisionRegion,
+      // Only present when the app did NOT land in the requested region, so
+      // clients can branch on its presence alone.
+      ...(placement.redirected ? { region_redirected_from: placement.requestedRegion } : {}),
       created_at: new Date().toISOString(),
       _meta: {
+        ...(placement.redirected
+          ? {
+              notice: `Region "${placement.requestedRegion}" is temporarily closed to new apps; this app was provisioned in "${provisionRegion}" instead.`,
+            }
+          : {}),
         next_actions: [
           { action: 'poll_status', description: 'Poll GET /apps/:app_id/status until provisioning_status is "ready"', recommended: true },
           { action: 'apply_schema', description: 'Define your database tables (after provisioning completes)', recommended: true },

--- a/services/control-api/src/services/provision-region.test.ts
+++ b/services/control-api/src/services/provision-region.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseRegionList,
+  getProvisionAllowedRegions,
+  resolveProvisionRegion,
+} from './provision-region.js';
+
+describe('parseRegionList', () => {
+  it('splits, trims, and drops empties', () => {
+    expect(parseRegionList(' us-east-1 , us-west-2 ,, ')).toEqual(['us-east-1', 'us-west-2']);
+  });
+
+  it('returns an empty list for undefined or blank', () => {
+    expect(parseRegionList(undefined)).toEqual([]);
+    expect(parseRegionList('')).toEqual([]);
+    expect(parseRegionList('   ')).toEqual([]);
+  });
+});
+
+describe('getProvisionAllowedRegions', () => {
+  it('prefers the provisioning-specific var', () => {
+    expect(getProvisionAllowedRegions({
+      BUTTERBASE_PROVISION_ALLOWED_REGIONS: 'us-west-2',
+      BUTTERBASE_REGIONS: 'us-east-1,us-west-2',
+    } as NodeJS.ProcessEnv)).toEqual(['us-west-2']);
+  });
+
+  it('falls back to BUTTERBASE_REGIONS when the specific var is unset', () => {
+    expect(getProvisionAllowedRegions({
+      BUTTERBASE_REGIONS: 'us-east-1,us-west-2',
+    } as NodeJS.ProcessEnv)).toEqual(['us-east-1', 'us-west-2']);
+  });
+
+  it('returns empty when neither is set', () => {
+    expect(getProvisionAllowedRegions({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+});
+
+describe('resolveProvisionRegion', () => {
+  it('keeps the requested region when it is open', () => {
+    expect(resolveProvisionRegion('us-east-1', ['us-east-1', 'us-west-2'])).toEqual({
+      region: 'us-east-1',
+      requestedRegion: 'us-east-1',
+      redirected: false,
+    });
+  });
+
+  it('redirects to the first open region when the requested one is closed', () => {
+    expect(resolveProvisionRegion('us-east-1', ['us-west-2'])).toEqual({
+      region: 'us-west-2',
+      requestedRegion: 'us-east-1',
+      redirected: true,
+    });
+  });
+
+  it('treats an empty allow-list as no restriction, NOT as everything-closed', () => {
+    // A missing/blank env var must not take provisioning down. If this ever
+    // inverted, every /init would redirect to provisionAllowed[0] === undefined.
+    expect(resolveProvisionRegion('us-east-1', [])).toEqual({
+      region: 'us-east-1',
+      requestedRegion: 'us-east-1',
+      redirected: false,
+    });
+  });
+
+  it('never reports redirected when the region did not change', () => {
+    // Guards the response contract: `region_redirected_from` is only emitted
+    // when redirected is true, so a false positive would tell a customer their
+    // app moved when it did not.
+    const r = resolveProvisionRegion('us-west-2', ['us-west-2', 'us-east-1']);
+    expect(r.redirected).toBe(false);
+    expect(r.region).toBe(r.requestedRegion);
+  });
+
+  it('redirects both regions to the single open one when only one is open', () => {
+    expect(resolveProvisionRegion('us-west-2', ['us-east-1']).region).toBe('us-east-1');
+    expect(resolveProvisionRegion('us-east-1', ['us-west-2']).region).toBe('us-west-2');
+  });
+});

--- a/services/control-api/src/services/provision-region.ts
+++ b/services/control-api/src/services/provision-region.ts
@@ -1,0 +1,70 @@
+/**
+ * Region selection for NEW app provisioning (`POST /init`, `POST /clone`).
+ *
+ * `BUTTERBASE_PROVISION_ALLOWED_REGIONS` lets an operator close a region to new
+ * apps without disturbing traffic to apps already homed there. It existed
+ * because us-east-1 was approaching Neon's 500-databases-per-branch ceiling;
+ * project-per-app removed that ceiling, so the lever now covers the rarer case
+ * (a region outage, a bad Neon region) rather than routine capacity pressure.
+ *
+ * The lever is kept. What is removed is its silence: a redirect used to be
+ * invisible to the caller, because the `/init` response carried no region field
+ * at all. A customer who asked for us-east-1 got an app in us-west-2 and had no
+ * way to find out — which is a data-residency decision being made on their
+ * behalf, without telling them. Callers now get `region` on every response, and
+ * an explicit `region_redirected_from` when it differs from what they asked for.
+ *
+ * Redirecting still beats rejecting: when a region really is down, placing the
+ * app somewhere that works and saying so is better than failing the request.
+ */
+
+export interface RegionResolution {
+  /** Where the app will actually be provisioned. */
+  region: string;
+  /** What the caller asked for (explicitly or by default resolution). */
+  requestedRegion: string;
+  /** True when `region !== requestedRegion` because the request was redirected. */
+  redirected: boolean;
+}
+
+/** Parse a comma-separated region list env var into trimmed, non-empty entries. */
+export function parseRegionList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Regions currently accepting new apps.
+ *
+ * Falls back to `BUTTERBASE_REGIONS` when the provisioning-specific var is
+ * unset, so `BUTTERBASE_REGIONS` gates both serving and provisioning by
+ * default. An empty result means "no restriction configured" — callers treat
+ * that as everything-open rather than everything-closed, which is what keeps a
+ * missing env var from taking provisioning down entirely.
+ */
+export function getProvisionAllowedRegions(env: NodeJS.ProcessEnv = process.env): string[] {
+  return parseRegionList(
+    env.BUTTERBASE_PROVISION_ALLOWED_REGIONS ?? env.BUTTERBASE_REGIONS,
+  );
+}
+
+/**
+ * Resolve the region an app will be provisioned into, redirecting away from a
+ * closed region when necessary and reporting whether that happened.
+ */
+export function resolveProvisionRegion(
+  requestedRegion: string,
+  provisionAllowed: string[],
+): RegionResolution {
+  const open = provisionAllowed.length === 0 || provisionAllowed.includes(requestedRegion);
+  if (open) {
+    return { region: requestedRegion, requestedRegion, redirected: false };
+  }
+  return {
+    region: provisionAllowed[0],
+    requestedRegion,
+    redirected: true,
+  };
+}


### PR DESCRIPTION
## Problem

`BUTTERBASE_PROVISION_ALLOWED_REGIONS` lets an operator close a region to new apps without disturbing traffic to apps already homed there. It existed because us-east-1 was approaching Neon's 500-databases-per-branch ceiling.

When the requested region was closed, `/init` and `/clone` redirected to the first open region **and said nothing**. `/init`'s response carried no `region` field at all, so a customer who asked for us-east-1 got an app in us-west-2 with no way to find out. That is a data-residency decision made on their behalf, silently.

This was live, not hypothetical: `BUTTERBASE_PROVISION_ALLOWED_REGIONS` was `us-west-2` alone until 2026-08-22, so every us-east-1 request during that window was quietly relocated.

## Approach

**Keep the lever, remove the silence.** Rejecting instead of redirecting would convert a degraded-but-working path into an outage during exactly the incident the lever exists for — a region outage, a bad Neon region. Project-per-app has removed the capacity pressure that originally motivated it, but those rarer cases remain. The harm was never the redirect; it was that the redirect was invisible.

## Changes

- **New `services/provision-region.ts`** — `parseRegionList`, `getProvisionAllowedRegions`, `resolveProvisionRegion`, with unit tests. This logic was duplicated across `init.ts` and `clone.ts` and untested at both sites.
- **`POST /init`** returns `region` on every response, plus `region_redirected_from` and a `_meta.notice` when the app did not land in the requested region.
- **`POST /clone`** returns `dest_region`, plus `dest_region_redirected_from` and a `notice` on redirect.
- Operator warn logs unchanged.

Both redirect markers are omitted entirely when no redirect happened, so clients can branch on presence alone.

An empty allow-list means **"no restriction"**, not "everything closed", and is pinned by test — were it to invert, a blank env var would redirect every `/init` to `provisionAllowed[0] === undefined`.

## Also: repairs `clone-routes.test.ts`

All 6 route cases in this suite fail on `main` today. The route gained org resolution and a project-quota check after the suite was written; neither was mocked, so both hit a `controlDb` stub returning `{ rows: [] }` and threw. **Every case 500'd regardless of what it asserted** — the suite was masking the entire clone route surface rather than testing it.

Verified pre-existing by restoring the tree to `HEAD` and re-running: identical 6 failed / 2 passed.

With `org-resolver` and `project-quota` mocked the suite passes and covers the route again, including the new region fields.

## Testing

```
src/__tests__/clone-routes.test.ts      10 passed  (was 6 failed / 2 passed)
src/services/provision-region.test.ts   10 passed  (new)
tsc --noEmit                            clean
```

No migrations, no new env vars — code-only.
