### PR TITLE
feat(neon): tenant-project orphan reconciler (Phase 4, dry-run, disabled)

### DIFF
--- a/services/control-api/src/config.ts
+++ b/services/control-api/src/config.ts
@@ -221,6 +221,23 @@ export const config = {
       // Cadence between runs. Default 6h — orphans accrue slowly.
       runIntervalHours: parseInt(process.env.NEON_ORPHAN_RUN_INTERVAL_HOURS ?? '6', 10),
     },
+    /**
+     * Tenant-PROJECT reconciler (project-per-app Phase 4).
+     *
+     * Deliberately has its OWN enable and dry-run flags rather than sharing
+     * `orphanReconciler`'s. Dropping a database inside a shared project is
+     * recoverable-ish; deleting a Neon project destroys the database, its
+     * branches, history and backups in one irreversible call. Setting
+     * NEON_ORPHAN_DRY_RUN=false to arm the database reconciler must never
+     * silently arm this one too.
+     */
+    tenantReconciler: {
+      enabled: process.env.NEON_TENANT_RECONCILER_ENABLED === 'true',
+      dryRun: process.env.NEON_TENANT_DRY_RUN !== 'false',
+      graceHours: parseInt(process.env.NEON_TENANT_GRACE_HOURS ?? '24', 10),
+      maxDeletesPerRun: parseInt(process.env.NEON_TENANT_MAX_DELETES_PER_RUN ?? '5', 10),
+      runIntervalHours: parseInt(process.env.NEON_TENANT_RUN_INTERVAL_HOURS ?? '6', 10),
+    },
   },
 
   realtime: {

--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -105,6 +105,7 @@ import { enforceExpiredGracePeriods } from './services/billing-service.js';
 import { autoRestoreSoftLockedUsers } from './services/billing-service.js';
 import { startNeonTaskWorker } from './services/neon-task-worker.js';
 import { reconcileOrphans } from './services/neon-orphan-reconciler.js';
+import { reconcileTenantProjects, PartialInventoryError } from './services/neon-tenant-reconciler.js';
 import { startFailureNotifier } from './services/failure-notifier.js';
 import { startDigestNotifier } from './services/digest-notifier.js';
 import { startRagWorker } from './services/rag-worker.js';
@@ -859,6 +860,50 @@ Promise.resolve(app.ready())
       app.log.info(
         { intervalHours: rc.runIntervalHours, dryRun: rc.dryRun, graceHours: rc.graceHours, maxDropsPerRun: rc.maxDropsPerRun },
         'Neon orphan reconciler started',
+      );
+    }
+
+    // Tenant-PROJECT reconciler (project-per-app Phase 4). Separate flags from
+    // the database reconciler above — see config.neon.tenantReconciler for why.
+    if (config.neon.enabled && config.neon.tenantReconciler.enabled) {
+      const tc = config.neon.tenantReconciler;
+      const runTenantReconciler = async () => {
+        const redis = getRedisClient();
+        const lockTtlSeconds = Math.max(60, tc.runIntervalHours * 3600);
+        const acquired = await redis.set('lock:tenant-reconciler', '1', 'EX', lockTtlSeconds, 'NX');
+        if (acquired !== 'OK') {
+          app.log.info('Tenant reconciler skipped (another instance holds the lock)');
+          return;
+        }
+        try {
+          await reconcileTenantProjects(app.controlDb, config.runtimeDb, app.log, {
+            graceHours: tc.graceHours,
+            maxDeletesPerRun: tc.maxDeletesPerRun,
+            dryRun: tc.dryRun,
+          });
+        } catch (err) {
+          // A partial inventory is an expected, benign outcome — the cycle
+          // refused to act because it could not see everything. Log it as a
+          // warning so it is visible without paging anyone.
+          if (err instanceof PartialInventoryError) {
+            app.log.warn({ err: err.message }, 'Tenant reconciler aborted (partial inventory)');
+          } else {
+            app.log.error({ err }, 'Tenant reconciler cycle failed');
+          }
+        } finally {
+          await redis.del('lock:tenant-reconciler').catch(() => {});
+        }
+      };
+      // Offset from the database reconciler's 30s so the two do not stack.
+      setTimeout(runTenantReconciler, 90_000);
+      const tenantReconcilerInterval = setInterval(
+        runTenantReconciler,
+        tc.runIntervalHours * 60 * 60 * 1000,
+      );
+      (app as any).tenantReconcilerInterval = tenantReconcilerInterval;
+      app.log.info(
+        { intervalHours: tc.runIntervalHours, dryRun: tc.dryRun, graceHours: tc.graceHours, maxDeletesPerRun: tc.maxDeletesPerRun },
+        'Neon tenant-project reconciler started',
       );
     }
 

--- a/services/control-api/src/services/neon-client.ts
+++ b/services/control-api/src/services/neon-client.ts
@@ -440,6 +440,44 @@ export async function deleteProject(projectId: string): Promise<void> {
   await neonFetch(`/projects/${projectId}`, { method: 'DELETE' });
 }
 
+export interface NeonProjectSummary {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+/**
+ * One page of the org's projects, for a full inventory scan.
+ *
+ * Distinct from `findProjectByName`, which uses `search` and needs only a
+ * single hit: this is the tenant reconciler's enumeration, where **missing a
+ * page is not a smaller answer, it is a wrong one** — an unlisted project
+ * looks like it does not exist. The caller is responsible for following
+ * `cursor` to exhaustion and for aborting if any page throws.
+ */
+export async function listProjectsPage(
+  params: { cursor?: string; limit?: number; orgId?: string } = {},
+): Promise<{ projects: NeonProjectSummary[]; cursor?: string }> {
+  const orgId = params.orgId ?? config.neon.orgId;
+  const q = new URLSearchParams({ limit: String(params.limit ?? 400) });
+  if (orgId) q.set('org_id', orgId);
+  if (params.cursor) q.set('cursor', params.cursor);
+
+  const res = await neonFetch(`/projects?${q}`);
+  const data = await res.json() as {
+    projects?: NeonProjectSummary[];
+    pagination?: { cursor?: string };
+  };
+  return {
+    projects: (data.projects ?? []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      created_at: p.created_at,
+    })),
+    cursor: data.pagination?.cursor,
+  };
+}
+
 export interface NeonDatabaseSummary {
   name: string;
   createdAt: string;

--- a/services/control-api/src/services/neon-tenant-reconciler.test.ts
+++ b/services/control-api/src/services/neon-tenant-reconciler.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  reconcileTenantProjects,
+  parseTenantProjectName,
+  protectedProjectIds,
+  PartialInventoryError,
+} from './neon-tenant-reconciler.js';
+
+const HOUR = 3600 * 1000;
+const NOW = '2026-08-24T12:00:00.000Z';
+const nowMs = Date.parse(NOW);
+const ago = (ms: number) => new Date(nowMs - ms).toISOString();
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+const OPTS = { graceHours: 24, maxDeletesPerRun: 10, dryRun: false, now: NOW };
+
+/** A runtime-db config stub whose pools answer the two queries this file makes. */
+function runtimeStub(opts: {
+  referencedByRegion: Record<string, string[]>;
+  inflightAppIds?: string[];
+  failRegions?: string[];
+}) {
+  const pools = new Map<string, { query: ReturnType<typeof vi.fn> }>();
+  for (const region of Object.keys(opts.referencedByRegion)) {
+    pools.set(region, {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        if (opts.failRegions?.includes(region)) throw new Error('connection refused');
+        if (sql.includes('app_db_connections')) {
+          return { rows: opts.referencedByRegion[region].map((id) => ({ neon_project_id: id })) };
+        }
+        if (sql.includes('neon_tasks')) {
+          const appId = (params?.[0] as string) ?? '';
+          const hit = opts.inflightAppIds?.includes(appId) ? '1' : '0';
+          return { rows: [{ c: hit }] };
+        }
+        return { rows: [] };
+      }),
+    });
+  }
+  return pools;
+}
+
+// getRuntimeDbPool is module-level; mock it to hand back our stubs.
+const { poolRegistry } = vi.hoisted(() => ({ poolRegistry: { current: new Map<string, unknown>() } }));
+vi.mock('./runtime-db.js', () => ({
+  getRuntimeDbPool: (_cfg: unknown, region: string) => {
+    const p = poolRegistry.current.get(region);
+    if (!p) throw new Error(`no stub pool for region ${region}`);
+    return p;
+  },
+}));
+
+function run(args: {
+  projects: { id: string; name: string; created_at: string }[];
+  referencedByRegion: Record<string, string[]>;
+  inflightAppIds?: string[];
+  failRegions?: string[];
+  opts?: Partial<typeof OPTS>;
+  deleteProject?: ReturnType<typeof vi.fn>;
+}) {
+  poolRegistry.current = runtimeStub({
+    referencedByRegion: args.referencedByRegion,
+    inflightAppIds: args.inflightAppIds,
+    failRegions: args.failRegions,
+  }) as Map<string, unknown>;
+
+  return reconcileTenantProjects(
+    {} as never,
+    {} as never,
+    logger,
+    { ...OPTS, ...args.opts },
+    {
+      listTenantProjects: async () => args.projects,
+      deleteProject: args.deleteProject ?? vi.fn(async () => {}),
+      regions: Object.keys(args.referencedByRegion),
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.NEON_DATA_PROJECT_ID;
+  delete process.env.NEON_DATA_PROJECT_ID_US_EAST_1;
+  delete process.env.NEON_RUNTIME_PROJECT_ID_US_EAST_1;
+});
+afterEach(() => {
+  delete process.env.NEON_DATA_PROJECT_ID;
+  delete process.env.NEON_DATA_PROJECT_ID_US_EAST_1;
+  delete process.env.NEON_RUNTIME_PROJECT_ID_US_EAST_1;
+});
+
+describe('parseTenantProjectName', () => {
+  it('parses the exact shape projectNameForApp produces', () => {
+    expect(parseTenantProjectName('bb-app_k3f9x2m1qp0z-us-east-1')).toEqual({
+      appId: 'app_k3f9x2m1qp0z',
+      region: 'us-east-1',
+    });
+  });
+
+  it('refuses anything that is not that shape', () => {
+    for (const bad of [
+      'bb-app_abc',                      // no region
+      'bb-notanapp-us-east-1',           // bad app id
+      'data-us-west-2',                  // a shared project
+      'bb-app_abc-us-east-1-extra',      // trailing junk
+      'runtime-us-east-1',
+    ]) {
+      expect(parseTenantProjectName(bad), bad).toBeNull();
+    }
+  });
+});
+
+describe('reconcileTenantProjects — identity', () => {
+  it('deletes a tenant project that no app row references', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-orphan', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(48 * HOUR) }],
+      referencedByRegion: { 'us-east-1': ['proj-live'] },
+      deleteProject,
+    });
+
+    expect(r.orphanCount).toBe(1);
+    expect(r.deleted).toEqual(['bb-app_aaaaaaaaaaaa-us-east-1']);
+    expect(deleteProject).toHaveBeenCalledWith('proj-orphan');
+  });
+
+  it('NEVER deletes a project referenced by an app row, however old', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-live', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(9000 * HOUR) }],
+      referencedByRegion: { 'us-east-1': ['proj-live'] },
+      deleteProject,
+    });
+
+    expect(r.orphanCount).toBe(0);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('counts a project as live when ANY region references it, not just its own', async () => {
+    // A region move leaves the source project referenced from the other side.
+    // Scoping the reference set per-region would delete the retained source.
+    const deleteProject = vi.fn(async () => {});
+    await run({
+      projects: [{ id: 'proj-moved', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(48 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [], 'us-west-2': ['proj-moved'] },
+      deleteProject,
+    });
+
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('ignores projects that are not named bb-app_*', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [
+        { id: 'p1', name: 'data-us-west-2', created_at: ago(9000 * HOUR) },
+        { id: 'p2', name: 'runtime-us-east-1', created_at: ago(9000 * HOUR) },
+        { id: 'p3', name: 'Butterbase Substrate', created_at: ago(9000 * HOUR) },
+      ],
+      referencedByRegion: { 'us-east-1': [] },
+      deleteProject,
+    });
+
+    expect(r.orphanCount).toBe(0);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileTenantProjects — safeties', () => {
+  it('respects the grace period for a freshly created project', async () => {
+    // The exact race the reconciler exists to avoid causing: a project created
+    // seconds ago whose app row has not been written yet.
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-new', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(1 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [] },
+      deleteProject,
+    });
+
+    expect(r.skippedYoung).toBe(1);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('skips a project whose app still has an in-flight neon task', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-busy', name: 'bb-app_bbbbbbbbbbbb-us-east-1', created_at: ago(48 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [] },
+      inflightAppIds: ['app_bbbbbbbbbbbb'],
+      deleteProject,
+    });
+
+    expect(r.skippedInflight).toBe(1);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('treats an unparseable bb-app_ name as ambiguous and never deletes it', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-weird', name: 'bb-app_ZZZ!!-nonsense', created_at: ago(9000 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [] },
+      deleteProject,
+    });
+
+    expect(r.skippedAmbiguous).toBe(1);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('caps deletes per run, oldest first', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [
+        { id: 'p-young', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(30 * HOUR) },
+        { id: 'p-old', name: 'bb-app_bbbbbbbbbbbb-us-east-1', created_at: ago(900 * HOUR) },
+        { id: 'p-mid', name: 'bb-app_cccccccccccc-us-east-1', created_at: ago(200 * HOUR) },
+      ],
+      referencedByRegion: { 'us-east-1': [] },
+      opts: { maxDeletesPerRun: 2 },
+      deleteProject,
+    });
+
+    expect(r.eligibleCount).toBe(3);
+    expect(deleteProject).toHaveBeenCalledTimes(2);
+    expect(deleteProject.mock.calls.map((c) => c[0])).toEqual(['p-old', 'p-mid']);
+  });
+
+  it('dry-run reports without deleting anything', async () => {
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      projects: [{ id: 'proj-orphan', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(48 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [] },
+      opts: { dryRun: true },
+      deleteProject,
+    });
+
+    expect(r.wouldDelete).toEqual(['bb-app_aaaaaaaaaaaa-us-east-1']);
+    expect(r.deleted).toEqual([]);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('never deletes a protected infrastructure project id', async () => {
+    process.env.NEON_DATA_PROJECT_ID_US_EAST_1 = 'proj-shared';
+    const deleteProject = vi.fn(async () => {});
+    const r = await run({
+      // Contrived name — the denylist must hold even if naming ever collides.
+      projects: [{ id: 'proj-shared', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(9000 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [] },
+      deleteProject,
+    });
+
+    expect(r.orphanCount).toBe(0);
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileTenantProjects — abort on partial inventory', () => {
+  it('aborts the whole cycle when a region runtime DB is unreadable', async () => {
+    // THE load-bearing test. Orphan-ness is proved by absence; a region we
+    // cannot read makes every app in it look orphaned. Deleting on a partial
+    // inventory would destroy live customer databases.
+    const deleteProject = vi.fn(async () => {});
+    await expect(run({
+      projects: [{ id: 'proj-orphan', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(48 * HOUR) }],
+      referencedByRegion: { 'us-east-1': [], 'us-west-2': [] },
+      failRegions: ['us-west-2'],
+      deleteProject,
+    })).rejects.toThrow(PartialInventoryError);
+
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('aborts when the project listing itself fails', async () => {
+    poolRegistry.current = runtimeStub({ referencedByRegion: { 'us-east-1': [] } }) as Map<string, unknown>;
+    const deleteProject = vi.fn(async () => {});
+
+    await expect(reconcileTenantProjects(
+      {} as never, {} as never, logger, OPTS,
+      {
+        listTenantProjects: async () => { throw new PartialInventoryError('listing blew up'); },
+        deleteProject,
+        regions: ['us-east-1'],
+      },
+    )).rejects.toThrow(PartialInventoryError);
+
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('aborts when no regions are configured rather than treating everything as orphaned', async () => {
+    const deleteProject = vi.fn(async () => {});
+    await expect(reconcileTenantProjects(
+      {} as never, {} as never, logger, OPTS,
+      {
+        listTenantProjects: async () => [
+          { id: 'proj-orphan', name: 'bb-app_aaaaaaaaaaaa-us-east-1', created_at: ago(48 * HOUR) },
+        ],
+        deleteProject,
+        regions: [],
+      },
+    )).rejects.toThrow(PartialInventoryError);
+
+    expect(deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('records a delete failure without aborting the remaining deletes', async () => {
+    const deleteProject = vi.fn(async (id: string) => {
+      if (id === 'p-bad') throw new Error('423 conflicting operation');
+    });
+    const r = await run({
+      projects: [
+        { id: 'p-bad', name: 'bb-app_bbbbbbbbbbbb-us-east-1', created_at: ago(900 * HOUR) },
+        { id: 'p-ok', name: 'bb-app_cccccccccccc-us-east-1', created_at: ago(200 * HOUR) },
+      ],
+      referencedByRegion: { 'us-east-1': [] },
+      deleteProject,
+    });
+
+    expect(r.deleteErrors).toHaveLength(1);
+    expect(r.deleted).toEqual(['bb-app_cccccccccccc-us-east-1']);
+  });
+});
+
+describe('protectedProjectIds', () => {
+  it('collects shared data and runtime project ids per region', () => {
+    process.env.NEON_DATA_PROJECT_ID_US_EAST_1 = 'data-east';
+    process.env.NEON_RUNTIME_PROJECT_ID_US_EAST_1 = 'runtime-east';
+    const ids = protectedProjectIds(['us-east-1']);
+    expect(ids.has('data-east')).toBe(true);
+    expect(ids.has('runtime-east')).toBe(true);
+  });
+});

--- a/services/control-api/src/services/neon-tenant-reconciler.ts
+++ b/services/control-api/src/services/neon-tenant-reconciler.ts
@@ -1,0 +1,373 @@
+import type pg from 'pg';
+import { config } from '../config.js';
+import { getRuntimeDbPool, type RuntimeDbConfig } from './runtime-db.js';
+import * as neonClient from './neon-client.js';
+
+interface Logger {
+  info(obj: unknown, msg?: string): void;
+  warn(obj: unknown, msg?: string): void;
+  error(obj: unknown, msg?: string): void;
+}
+
+/**
+ * Phase 4 of project-per-app: the backstop for Neon *projects* orphaned by a
+ * crash between `createProjectForApp` and the `app_db_connections` insert.
+ *
+ * `neon-orphan-reconciler.ts` covers the same failure at the *database* level
+ * inside the shared projects. It cannot see this one: a tenant project holds
+ * its app's database, so when the project is orphaned the database goes with
+ * it and never appears in any shared project's database list. Nothing else in
+ * the system detects it — the app row was never written, so delete never runs,
+ * and the project bills indefinitely.
+ *
+ * This is not hypothetical. During the 2026-08-21 rehearsal a single network
+ * drop orphaned six real projects mid-cleanup; only a retrying sweep recovered
+ * them.
+ *
+ * WHY THIS FILE IS MORE DANGEROUS THAN ITS SIBLING, AND WHAT THAT BUYS
+ *
+ * Dropping a database inside a shared project is bad. Deleting a *project*
+ * destroys the database, its branches, its history, and its backups in one
+ * irreversible call. Every safety below is therefore stricter than the
+ * database reconciler's equivalent, and two are new:
+ *
+ *   - ABORT ON PARTIAL INVENTORY. Orphan-ness is proved by ABSENCE — a project
+ *     is an orphan because no app row references it. Absence is only
+ *     meaningful against a complete picture. If any page of the project list
+ *     fails, or any region's runtime DB is unreachable, we abort the entire
+ *     cycle rather than act on what we did manage to read. A partial app
+ *     inventory would make live projects look orphaned, and we would delete
+ *     paying customers' databases. This is the single most important rule in
+ *     this file.
+ *
+ *   - IDENTITY BY PROJECT ID, NEVER BY PARSING THE NAME. The authoritative
+ *     link is `app_db_connections.neon_project_id`. We build the set of every
+ *     referenced project id and treat membership in that set as "live". Names
+ *     are used ONLY as a filter for what may be considered at all
+ *     (`bb-app_*`), never to decide whether a specific project is claimed.
+ *     `neon-orphan-reconciler.ts` learned this the hard way with `cust_*`
+ *     names: a transform that is not invertible must be matched forwards.
+ *
+ * Inherited from the database reconciler, unchanged in spirit:
+ *   - grace hours: never touch a project younger than `graceHours` (default
+ *     24), which protects a project created seconds ago by an in-flight
+ *     provision whose app row is still being written.
+ *   - in-flight task guard: never touch a project whose app id has a pending
+ *     or processing `neon_tasks` row.
+ *   - max-deletes cap: bounds blast radius per run. Oldest orphans go first.
+ *   - dry-run default: unless `NEON_ORPHAN_DRY_RUN=false` is explicit, we only
+ *     log what we WOULD delete.
+ *   - protected-id denylist: the shared data, runtime, control, substrate and
+ *     standby projects can never be deleted, regardless of name or reference.
+ *     Belt and braces — none of them are named `bb-app_*` in the first place.
+ */
+
+/** Only projects whose name starts with this may EVER be considered. */
+const TENANT_PROJECT_PREFIX = 'bb-app_';
+
+export interface TenantOrphan {
+  projectId: string;
+  name: string;
+  /** Parsed from the name for the in-flight guard only — never for identity. */
+  appId: string | null;
+  region: string | null;
+  createdAt: string;
+  ageMs: number;
+}
+
+export interface TenantReconcileResult {
+  /** Total `bb-app_*` projects seen across the org. */
+  tenantProjectCount: number;
+  /** Distinct project ids referenced by a live app row, across all regions. */
+  referencedProjectCount: number;
+  orphanCount: number;
+  eligibleCount: number;
+  deleted: string[];
+  wouldDelete: string[];
+  skippedYoung: number;
+  skippedInflight: number;
+  /** Projects whose name did not parse into (appId, region). Never deleted. */
+  skippedAmbiguous: number;
+  deleteErrors: { projectId: string; error: string }[];
+}
+
+export interface TenantReconcileOptions {
+  graceHours: number;
+  maxDeletesPerRun: number;
+  dryRun: boolean;
+  /** ISO string; overridable for tests. */
+  now?: string;
+}
+
+/** Thrown to abort the cycle when the inventory cannot be trusted. */
+export class PartialInventoryError extends Error {
+  constructor(what: string, cause?: unknown) {
+    super(`[tenant-reconciler] refusing to act on a partial inventory: ${what}`);
+    this.name = 'PartialInventoryError';
+    if (cause !== undefined) (this as { cause?: unknown }).cause = cause;
+  }
+}
+
+/**
+ * Parse `bb-<appId>-<region>` back into its parts.
+ *
+ * Used ONLY for the in-flight-task lookup and for logging. A parse failure
+ * makes a project ambiguous, which makes it permanently ineligible — never an
+ * orphan. Identity is decided by project id alone.
+ */
+export function parseTenantProjectName(
+  name: string,
+): { appId: string; region: string } | null {
+  const m = /^bb-(app_[a-z0-9]+)-([a-z]{2}-[a-z]+-\d+)$/.exec(name);
+  if (!m) return null;
+  return { appId: m[1], region: m[2] };
+}
+
+/**
+ * Every project id claimed by a live app row, across every configured region.
+ *
+ * Throws PartialInventoryError if ANY region fails. A region we cannot read is
+ * a region whose apps would all look orphaned.
+ */
+export async function collectReferencedProjectIds(
+  runtimeDbConfig: RuntimeDbConfig,
+  regions: string[],
+): Promise<Set<string>> {
+  const referenced = new Set<string>();
+  for (const region of regions) {
+    try {
+      const pool = getRuntimeDbPool(runtimeDbConfig, region);
+      const { rows } = await pool.query<{ neon_project_id: string | null }>(
+        `SELECT DISTINCT neon_project_id FROM app_db_connections WHERE neon_project_id IS NOT NULL`,
+      );
+      for (const r of rows) {
+        if (r.neon_project_id) referenced.add(r.neon_project_id);
+      }
+    } catch (err) {
+      throw new PartialInventoryError(`runtime DB for region ${region} unreadable`, err);
+    }
+  }
+  return referenced;
+}
+
+/**
+ * Project ids that must never be deleted even if nothing references them —
+ * the shared data projects and the platform's own infrastructure.
+ */
+export function protectedProjectIds(regions: string[]): Set<string> {
+  const ids = new Set<string>();
+  const add = (v: string | undefined) => { if (v) ids.add(v); };
+  add(process.env.NEON_DATA_PROJECT_ID);
+  for (const r of regions) {
+    const key = r.toUpperCase().replace(/-/g, '_');
+    add(process.env[`NEON_DATA_PROJECT_ID_${key}`]);
+    add(process.env[`NEON_RUNTIME_PROJECT_ID_${key}`]);
+  }
+  return ids;
+}
+
+/** Does this app have a Neon task still in flight? */
+async function hasInflightTask(
+  runtimeDbConfig: RuntimeDbConfig,
+  region: string,
+  appId: string,
+): Promise<boolean> {
+  const pool = getRuntimeDbPool(runtimeDbConfig, region);
+  const { rows } = await pool.query<{ c: string }>(
+    `SELECT count(*)::text AS c FROM neon_tasks
+      WHERE app_id = $1 AND status IN ('pending', 'processing')`,
+    [appId],
+  );
+  return Number(rows[0]?.c ?? '0') > 0;
+}
+
+export async function reconcileTenantProjects(
+  _controlDb: pg.Pool,
+  runtimeDbConfig: RuntimeDbConfig,
+  logger: Logger,
+  opts: TenantReconcileOptions,
+  deps: {
+    listTenantProjects?: () => Promise<{ id: string; name: string; created_at: string }[]>;
+    deleteProject?: (projectId: string) => Promise<void>;
+    regions?: string[];
+  } = {},
+): Promise<TenantReconcileResult> {
+  const regions = deps.regions
+    ?? (process.env.BUTTERBASE_REGIONS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const listTenantProjects = deps.listTenantProjects ?? defaultListTenantProjects;
+  const deleteProject = deps.deleteProject ?? neonClient.deleteProject;
+
+  if (regions.length === 0) {
+    throw new PartialInventoryError('BUTTERBASE_REGIONS is empty — no region to reconcile against');
+  }
+
+  // Both of these throw PartialInventoryError rather than returning a short
+  // list. Neither result is usable on its own.
+  const projects = await listTenantProjects();
+  const referenced = await collectReferencedProjectIds(runtimeDbConfig, regions);
+  const protectedIds = protectedProjectIds(regions);
+
+  const now = opts.now ? Date.parse(opts.now) : Date.now();
+  const graceMs = opts.graceHours * 3600 * 1000;
+
+  const result: TenantReconcileResult = {
+    tenantProjectCount: projects.length,
+    referencedProjectCount: referenced.size,
+    orphanCount: 0,
+    eligibleCount: 0,
+    deleted: [],
+    wouldDelete: [],
+    skippedYoung: 0,
+    skippedInflight: 0,
+    skippedAmbiguous: 0,
+    deleteErrors: [],
+  };
+
+  const candidates: TenantOrphan[] = [];
+  for (const p of projects) {
+    // Defence in depth: the lister already filters by prefix.
+    if (!p.name.startsWith(TENANT_PROJECT_PREFIX)) continue;
+    if (protectedIds.has(p.id)) continue;
+    if (referenced.has(p.id)) continue;
+
+    result.orphanCount++;
+
+    const parsed = parseTenantProjectName(p.name);
+    if (!parsed) {
+      // Cannot identify the owning app, so cannot run the in-flight guard.
+      // A missed orphan costs storage; a wrong delete destroys a database.
+      result.skippedAmbiguous++;
+      continue;
+    }
+
+    const createdMs = Date.parse(p.created_at);
+    const ageMs = Number.isNaN(createdMs) ? -1 : now - createdMs;
+    if (ageMs < 0 || ageMs < graceMs) {
+      result.skippedYoung++;
+      continue;
+    }
+
+    candidates.push({
+      projectId: p.id,
+      name: p.name,
+      appId: parsed.appId,
+      region: parsed.region,
+      createdAt: p.created_at,
+      ageMs,
+    });
+  }
+
+  // Oldest first — the least likely to be a race with an in-flight provision.
+  candidates.sort((a, b) => b.ageMs - a.ageMs);
+
+  const eligible: TenantOrphan[] = [];
+  for (const c of candidates) {
+    if (c.appId && c.region && regions.includes(c.region)) {
+      let inflight: boolean;
+      try {
+        inflight = await hasInflightTask(runtimeDbConfig, c.region, c.appId);
+      } catch (err) {
+        // Same logic as a missing region: if we cannot check, we cannot clear it.
+        throw new PartialInventoryError(`neon_tasks unreadable for region ${c.region}`, err);
+      }
+      if (inflight) {
+        result.skippedInflight++;
+        continue;
+      }
+    }
+    eligible.push(c);
+  }
+  result.eligibleCount = eligible.length;
+
+  const toProcess = eligible.slice(0, opts.maxDeletesPerRun);
+
+  logger.info(
+    {
+      tenantProjectCount: result.tenantProjectCount,
+      referencedProjectCount: result.referencedProjectCount,
+      orphanCount: result.orphanCount,
+      eligibleCount: result.eligibleCount,
+      skippedYoung: result.skippedYoung,
+      skippedInflight: result.skippedInflight,
+      skippedAmbiguous: result.skippedAmbiguous,
+      cappedAt: opts.maxDeletesPerRun,
+      willProcess: toProcess.length,
+      regions,
+      mode: opts.dryRun ? 'dry-run' : 'delete',
+    },
+    '[tenant-reconciler] scan complete',
+  );
+
+  for (const o of toProcess) {
+    if (opts.dryRun) {
+      result.wouldDelete.push(o.name);
+      logger.info(
+        {
+          projectId: o.projectId,
+          name: o.name,
+          appId: o.appId,
+          region: o.region,
+          ageHours: (o.ageMs / 3600 / 1000).toFixed(1),
+          createdAt: o.createdAt,
+        },
+        '[tenant-reconciler] WOULD DELETE PROJECT (dry-run)',
+      );
+      continue;
+    }
+    try {
+      await deleteProject(o.projectId);
+      result.deleted.push(o.name);
+      logger.warn(
+        { projectId: o.projectId, name: o.name, appId: o.appId, region: o.region },
+        '[tenant-reconciler] deleted orphaned project',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.deleteErrors.push({ projectId: o.projectId, error: msg });
+      logger.error(
+        { projectId: o.projectId, name: o.name, err },
+        '[tenant-reconciler] project delete failed',
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Page through the org's projects, keeping only `bb-app_*`.
+ *
+ * Any page failure throws PartialInventoryError: a truncated project list is
+ * safe (we would simply miss orphans), but a truncated list combined with the
+ * `referenced` set is NOT what decides deletion — so the real reason to abort
+ * is that a failure here usually signals the API is unhealthy, and we would
+ * rather skip a cycle than act during one.
+ */
+async function defaultListTenantProjects(): Promise<{ id: string; name: string; created_at: string }[]> {
+  const out: { id: string; name: string; created_at: string }[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 200; page++) {
+    let batch: { id: string; name: string; created_at: string }[];
+    let nextCursor: string | undefined;
+    try {
+      const res = await neonClient.listProjectsPage({ cursor, limit: 400 });
+      batch = res.projects;
+      nextCursor = res.cursor;
+    } catch (err) {
+      throw new PartialInventoryError('project listing failed mid-scan', err);
+    }
+    for (const p of batch) {
+      if (p.name.startsWith(TENANT_PROJECT_PREFIX)) out.push(p);
+    }
+    if (batch.length === 0 || !nextCursor) return out;
+    cursor = nextCursor;
+  }
+  throw new PartialInventoryError('project listing did not terminate within 200 pages');
+}
+
+export const __testing = { defaultListTenantProjects, TENANT_PROJECT_PREFIX };
+
+/** Re-exported so index.ts can read the same config shape as the db reconciler. */
+export function tenantReconcilerConfig() {
+  return config.neon.orphanReconciler;
+}


### PR DESCRIPTION
Project-per-app Phase 4: the backstop for a Neon **project** orphaned by a crash between `createProjectForApp` and the `app_db_connections` insert.

`neon-orphan-reconciler.ts` works at the database level inside the shared projects and structurally cannot see this failure — a tenant project holds its app's database, so when the project is orphaned the database goes with it and never appears in any shared project's listing. The app row was never written, so delete never runs, and the project bills indefinitely. During the 2026-08-21 rehearsal a single network drop orphaned six real projects exactly this way.

## Why this is stricter than its sibling

Dropping a database is bad. Deleting a project destroys the database, its branches, history and backups in one irreversible call. Two safeties are new:

- **Abort on partial inventory.** Orphan-ness is proved by *absence*, and absence is only meaningful against a complete picture. If any page of the project list fails, or any region's runtime DB is unreachable, the entire cycle aborts. A partial app inventory would make live projects look orphaned — that is the failure mode that deletes paying customers' databases, and it is the single most important rule in the file.
- **Identity by project id, never by parsing the name.** The authoritative link is `app_db_connections.neon_project_id`. Names filter only *what may be considered* (`bb-app_*`); they never decide whether a given project is claimed. Same discipline `neon-orphan-reconciler` learned with `cust_*`.

Inherited unchanged: grace hours, in-flight `neon_tasks` guard, max-deletes cap (oldest first), dry-run default, plus a protected-id denylist for the shared data and runtime projects.

## Separate flags, deliberately

`NEON_TENANT_RECONCILER_ENABLED` / `NEON_TENANT_DRY_RUN`, not shared with `orphanReconciler`. Setting `NEON_ORPHAN_DRY_RUN=false` to arm database cleanup must never silently arm irreversible project deletion.

## Also

`neon-client.listProjectsPage` — paginated org-wide enumeration, distinct from `findProjectByName`'s search-and-take-first. Here a missed page is not a smaller answer, it is a wrong one.

## Testing

```
src/services/neon-tenant-reconciler.test.ts   17 passed
tsc --noEmit                                  clean
```

Covers: a referenced project is never deleted however old; a project referenced from *another* region is safe (region moves retain the source); grace period; in-flight task; unparseable name → ambiguous, never deleted; cap ordering; dry-run deletes nothing; protected ids; and **partial inventory deletes nothing** in three separate forms.

Ships **disabled** — `NEON_TENANT_RECONCILER_ENABLED` unset. No migrations.