### PR TITLE
fix(ai-router): emit event type and streamed tool calls on /v1/responses

### DIFF
--- a/services/control-api/src/services/ai-router/responses-sse.test.ts
+++ b/services/control-api/src/services/ai-router/responses-sse.test.ts
@@ -130,4 +130,77 @@ describe('translateCcStreamToResponsesSse', () => {
     // onClose receives the same final body
     expect(captured.previous_response_id).toBe('rsp_prev');
   });
+
+  // --- Codex/Responses-API conformance (spike 2026-08-24) ---
+  //
+  // Two defects, both proven against the live gateway with real Codex CLI:
+  //   1. `type` was only on the SSE `event:` line, never inside the JSON data.
+  //      Clients (Codex among them) dispatch on the data field and so saw
+  //      nothing, then timed out with "stream closed before response.completed".
+  //   2. `delta.tool_calls` was not read at all, so every streamed tool call was
+  //      silently dropped -- from the wire AND from the persisted final body
+  //      that `previous_response_id` continuation replays.
+
+  const CC_TOOL_PAYLOAD = [
+    'data: {"id":"1","choices":[{"delta":{"role":"assistant"}}]}\n\n',
+    // arguments deliberately split across chunks -- that is why an accumulator exists
+    'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"shell","arguments":"{\\"command\\":"}}]}}]}\n\n',
+    'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"[\\"ls\\"]}"}}]}}]}\n\n',
+    'data: {"id":"1","choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":7}}\n\n',
+    'data: [DONE]\n\n',
+  ].join('');
+
+  it('includes the event type inside the data payload, not only on the event line', async () => {
+    const out = await collect(
+      translateCcStreamToResponsesSse({
+        id: 'rsp_t',
+        model: 'm',
+        createdAt: 0,
+        ccStream: streamOf(CC_PAYLOAD),
+        onClose: async () => {},
+      }),
+    );
+    const created = JSON.parse(out.match(/event: response\.created\ndata: (.+)/)![1]);
+    expect(created.type).toBe('response.created');
+    const completed = JSON.parse(out.match(/event: response\.completed\ndata: (.+)/)![1]);
+    expect(completed.type).toBe('response.completed');
+  });
+
+  it('emits a function_call item for a tool call streamed across chunks', async () => {
+    const out = await collect(
+      translateCcStreamToResponsesSse({
+        id: 'rsp_tool',
+        model: 'm',
+        createdAt: 0,
+        ccStream: streamOf(CC_TOOL_PAYLOAD),
+        onClose: async () => {},
+      }),
+    );
+    expect(extractEventNames(out)).toContain('response.function_call_arguments.done');
+    const doneEvt = out.match(/event: response\.function_call_arguments\.done\ndata: (.+)/);
+    expect(doneEvt).not.toBeNull();
+    // the two argument fragments must be concatenated, in order
+    expect(JSON.parse(doneEvt![1]).arguments).toBe('{"command":["ls"]}');
+  });
+
+  it('carries streamed tool calls into the final body persisted by onClose', async () => {
+    let captured: any;
+    await collect(
+      translateCcStreamToResponsesSse({
+        id: 'rsp_tool2',
+        model: 'm',
+        createdAt: 0,
+        ccStream: streamOf(CC_TOOL_PAYLOAD),
+        onClose: async (b) => {
+          captured = b;
+        },
+      }),
+    );
+    const call = captured.output.find((o: any) => o.type === 'function_call');
+    expect(call).toBeDefined();
+    expect(call.call_id).toBe('call_abc');
+    expect(call.name).toBe('shell');
+    expect(call.arguments).toBe('{"command":["ls"]}');
+  });
+
 });

--- a/services/control-api/src/services/ai-router/responses-sse.ts
+++ b/services/control-api/src/services/ai-router/responses-sse.ts
@@ -14,8 +14,23 @@ export function translateCcStreamToResponsesSse(args: {
   let opened = false;
   let textAcc = '';
   let usage: { prompt_tokens?: number; completion_tokens?: number } | null = null;
-  const evt = (name: string, p: unknown) =>
-    enc.encode(`event: ${name}\ndata: ${JSON.stringify(p)}\n\n`);
+  /**
+   * Streamed tool calls, keyed by the upstream `tool_calls[].index`. Chat
+   * Completions splits `function.arguments` across chunks, so the fragments are
+   * concatenated here and only emitted once the upstream stream ends.
+   */
+  const toolCalls = new Map<number, { call_id: string; name: string; arguments: string }>();
+  let seq = 0;
+  /**
+   * `type` MUST appear inside the JSON body, not only on the SSE `event:` line.
+   * Responses-API clients dispatch on the data field -- a client reading only
+   * the event line is the exception, not the rule -- so omitting it makes every
+   * event unclassifiable and the stream looks like it ended without completing.
+   */
+  const evt = (name: string, p: Record<string, unknown>) =>
+    enc.encode(
+      `event: ${name}\ndata: ${JSON.stringify({ type: name, sequence_number: seq++, ...p })}\n\n`,
+    );
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -75,6 +90,21 @@ export function translateCcStreamToResponsesSse(args: {
               );
               textAcc += c;
             }
+            for (const tc of (p.choices?.[0]?.delta?.tool_calls ?? []) as Array<{
+              index?: number;
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>) {
+              const k = typeof tc.index === 'number' ? tc.index : 0;
+              let cur = toolCalls.get(k);
+              if (!cur) {
+                cur = { call_id: '', name: '', arguments: '' };
+                toolCalls.set(k, cur);
+              }
+              if (tc.id) cur.call_id = tc.id;
+              if (tc.function?.name) cur.name = tc.function.name;
+              if (tc.function?.arguments) cur.arguments += tc.function.arguments;
+            }
             if (p.usage) usage = p.usage;
           }
         }
@@ -82,25 +112,60 @@ export function translateCcStreamToResponsesSse(args: {
         controller.error(e);
         return;
       }
+      const output: ResponsesResponseBody['output'] = [];
+      let outputIndex = 0;
       if (opened) {
         controller.enqueue(
           evt('response.output_text.done', {
-            output_index: 0,
+            output_index: outputIndex,
             content_index: 0,
             text: textAcc,
           }),
         );
+        const messageItem = {
+          type: 'message' as const,
+          id: `msg_${args.id.slice(4, 12)}`,
+          role: 'assistant' as const,
+          content: [{ type: 'output_text' as const, text: textAcc }],
+        };
         controller.enqueue(
-          evt('response.output_item.done', {
-            output_index: 0,
-            item: {
-              type: 'message',
-              id: `msg_${args.id.slice(4, 12)}`,
-              role: 'assistant',
-              content: [{ type: 'output_text', text: textAcc }],
-            },
+          evt('response.output_item.done', { output_index: outputIndex, item: messageItem }),
+        );
+        output.push(messageItem);
+        outputIndex += 1;
+      }
+      /**
+       * Tool calls are emitted after the upstream stream closes because the
+       * arguments are only complete then. They also go into `output` -- the
+       * body handed to `onClose` and replayed by `previous_response_id`, so
+       * dropping them here loses the call from stored history too.
+       */
+      for (const call of toolCalls.values()) {
+        const item = {
+          type: 'function_call' as const,
+          id: `fc_${args.id.slice(4, 12)}_${outputIndex}`,
+          call_id: call.call_id,
+          name: call.name,
+          arguments: call.arguments,
+        };
+        controller.enqueue(evt('response.output_item.added', { output_index: outputIndex, item }));
+        controller.enqueue(
+          evt('response.function_call_arguments.delta', {
+            item_id: item.id,
+            output_index: outputIndex,
+            delta: call.arguments,
           }),
         );
+        controller.enqueue(
+          evt('response.function_call_arguments.done', {
+            item_id: item.id,
+            output_index: outputIndex,
+            arguments: call.arguments,
+          }),
+        );
+        controller.enqueue(evt('response.output_item.done', { output_index: outputIndex, item }));
+        output.push(item);
+        outputIndex += 1;
       }
       const final: ResponsesResponseBody = {
         id: args.id,
@@ -109,16 +174,7 @@ export function translateCcStreamToResponsesSse(args: {
         status: 'completed',
         model: args.model,
         previous_response_id: args.previousResponseId ?? null,
-        output: opened
-          ? [
-              {
-                type: 'message',
-                id: `msg_${args.id.slice(4, 12)}`,
-                role: 'assistant',
-                content: [{ type: 'output_text', text: textAcc }],
-              },
-            ]
-          : [],
+        output,
         usage: {
           input_tokens: usage?.prompt_tokens ?? 0,
           output_tokens: usage?.completion_tokens ?? 0,

--- a/services/control-api/src/services/ai-router/responses-translate.ts
+++ b/services/control-api/src/services/ai-router/responses-translate.ts
@@ -80,6 +80,8 @@ export interface ResponsesResponseBody {
     content: Array<{ type: 'output_text'; text: string }>;
   } | {
     type: 'function_call';
+    /** Item id. Optional: the non-streaming path does not mint one. */
+    id?: string;
     call_id: string; name: string; arguments: string;
   }>;
   usage: { input_tokens: number; output_tokens: number; total_tokens: number; reasoning_tokens?: number };


### PR DESCRIPTION
## Problem

Two defects in the Responses SSE translator made streaming tool calls unusable on `/v1/responses`:

1. **`type` was missing from the data payload.** It was written only on the SSE `event:` line, never inside the JSON body. Responses-API clients dispatch on the data field, so every event was unclassifiable and the stream appeared to end without completing.

2. **`delta.tool_calls` was never read** — only `delta.content`. Every streamed tool call was silently dropped.

Reproduced against the live gateway on `qwen/qwen3.8-max`. Identical request:

- `stream: false` → correct `function_call` in `output`
- `stream: true` → `output: []`, **while still billing the tokens**

Defect 2 also reached stored state: the final body is handed to `onClose` and replayed by `previous_response_id`, so multi-turn Responses conversations lost the assistant's function calls from history too.

## Fix

Accumulate `tool_call` fragments by index (upstream splits `function.arguments` across chunks), emit them as `function_call` items once upstream closes, and include them in the final persisted body. `output_index` now advances instead of being pinned to `0`.

## Testing

- 3 new tests, written first and watched fail for the right reasons — including arguments split across chunks, which is the case the accumulator exists for.
- Full `ai-router` suite green on this commit with no unrelated changes in the tree: **335 passed**.
- Production build order (`@butterbase/shared` → `mcp-server` → `control-api`) builds clean.
- Verified end-to-end by driving these modules with OpenAI Codex CLI 0.149.1 against a live Qwen route: a full multi-step tool loop completes where it previously failed with `stream closed before response.completed`.

## Impact

Customer-facing. Anyone streaming tool calls through `/v1/responses` today receives an empty response and is billed for it.