### PR TITLE
fix(oauth): make scope and state optional on /authorize, and conform discovery + CORS to spec

### DIFF
--- a/services/control-api/src/__tests__/cors-oauth-public.test.ts
+++ b/services/control-api/src/__tests__/cors-oauth-public.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+
+// The DB-backed allowlist in the default CORS policy would try to reach every
+// configured runtime region. Nothing here exercises that path — these tests are
+// about the public-path carve-out — so stub the pool rather than requiring a DB.
+vi.mock('../services/runtime-db.js', () => ({
+  getRuntimeDbPool: () => ({ query: async () => ({ rows: [] }) }),
+}));
+
+const FOREIGN_ORIGIN = 'http://localhost:6274'; // MCP Inspector's default
+
+async function buildAppForTest() {
+  const { default: corsPlugin } = await import('../plugins/cors.js');
+  const app = Fastify({ logger: false });
+  await app.register(corsPlugin);
+  for (const url of ['/.well-known/oauth-protected-resource', '/oauth/register', '/oauth/token', '/mcp']) {
+    app.route({ method: ['GET', 'POST'], url, handler: async (_r, reply) => reply.send({ ok: true }) });
+  }
+  app.route({ method: 'GET', url: '/v1/apps', handler: async (_r, reply) => reply.send({ ok: true }) });
+  return app;
+}
+
+describe('CORS carve-out for OAuth discovery and MCP', () => {
+  // A browser-hosted MCP client (MCP Inspector, web-hosted agents) has to be
+  // able to read discovery metadata, register, exchange a token AND then call
+  // /mcp. Our default policy is an allowlist backed by apps.allowed_origins,
+  // which admits none of them.
+  it.each([
+    '/.well-known/oauth-protected-resource',
+    '/oauth/register',
+    '/oauth/token',
+    '/mcp',
+  ])('reflects an arbitrary origin on %s', async (url) => {
+    const app = await buildAppForTest();
+    const res = await app.inject({ method: 'GET', url, headers: { origin: FOREIGN_ORIGIN } });
+    expect(res.headers['access-control-allow-origin']).toBe(FOREIGN_ORIGIN);
+    // Reflecting an arbitrary origin is only safe with credentials off.
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined();
+    await app.close();
+  });
+
+  // Without this the whole RFC 9728 handshake is unusable from a browser:
+  // WWW-Authenticate is not CORS-safelisted, and it is what carries
+  // resource_metadata.
+  it('exposes WWW-Authenticate so a browser client can read the challenge', async () => {
+    const app = await buildAppForTest();
+    const res = await app.inject({ method: 'GET', url: '/mcp', headers: { origin: FOREIGN_ORIGIN } });
+    expect(res.headers['access-control-expose-headers']).toContain('WWW-Authenticate');
+    await app.close();
+  });
+
+  it('still applies the allowlist to everything outside the carve-out', async () => {
+    const app = await buildAppForTest();
+    const res = await app.inject({ method: 'GET', url: '/v1/apps', headers: { origin: FOREIGN_ORIGIN } });
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+    await app.close();
+  });
+});

--- a/services/control-api/src/__tests__/mcp-auth-remediation.test.ts
+++ b/services/control-api/src/__tests__/mcp-auth-remediation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import Fastify from 'fastify';
+import { wellKnownRoutes } from '../routes/well-known.js';
+
+/**
+ * The unauthenticated MCP 401 is the first thing any new client sees — including
+ * marketplace reviewers evaluating Butterbase as a connector. It must not name a
+ * specific vendor's client, and it must point at setup docs that resolve.
+ */
+describe('MCP auth-required remediation', () => {
+  it('does not name a specific third-party client', async () => {
+    const { default: fs } = await import('node:fs/promises');
+    const src = await fs.readFile(new URL('../plugins/auth.ts', import.meta.url), 'utf8');
+    const body = src.slice(src.indexOf('function mcpAuthRequiredBody'));
+    const remediation = body.slice(0, body.indexOf('documentation_url'));
+
+    for (const vendor of ['Claude Code', 'claude mcp add', 'Cursor', 'Windsurf', 'Qoder']) {
+      expect(remediation).not.toContain(vendor);
+    }
+  });
+
+  it('points at a docs path that the docs site actually serves', async () => {
+    const app = Fastify({ logger: false });
+    await app.register(wellKnownRoutes);
+    const res = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource' });
+    // Bare /mcp and /schema were both 404 on the live docs site; anything that is
+    // not a real published path should fail here rather than in a reviewer's browser.
+    expect(res.json().resource_documentation).not.toMatch(/docs\.butterbase\.ai\/(mcp|schema)$/);
+    await app.close();
+  });
+});

--- a/services/control-api/src/plugins/auth.ts
+++ b/services/control-api/src/plugins/auth.ts
@@ -42,7 +42,10 @@ function mcpAuthRequiredBody() {
     code: 'AUTH_REQUIRED',
     message:
       'MCP requires authentication. Run an OAuth flow against this server (see WWW-Authenticate header) or supply a bb_sk_ API key.',
-    remediation: `In Claude Code: \`claude mcp add butterbase ${base}/mcp\`. A browser window will open for you to log in and grant access.`,
+    remediation:
+      `Add ${base}/mcp as a Streamable HTTP MCP server in your client and complete the OAuth flow ` +
+      '(your browser will open to log in and grant access), or send an `Authorization: Bearer bb_sk_...` ' +
+      'header. Per-client setup: https://docs.butterbase.ai/getting-started/mcp-setup/',
     documentation_url: getDocUrl('AUTH_REQUIRED'),
   });
 }

--- a/services/control-api/src/plugins/cors.ts
+++ b/services/control-api/src/plugins/cors.ts
@@ -19,18 +19,26 @@ const EXPOSED_HEADERS = ['WWW-Authenticate', 'Mcp-Session-Id'];
 // http://localhost:6274, the tool a marketplace reviewer is most likely to
 // reach for. These responses carry no cookies and no ambient authority, so
 // reflecting an arbitrary origin is safe as long as credentials stay off.
+// `/mcp` is included deliberately. Discovery, registration and token exchange
+// are useless to a browser client if the endpoint it was all for stays behind
+// the allowlist — the client would authenticate successfully and then be unable
+// to call a single tool. `/mcp` authenticates with an explicit Authorization
+// header and never with cookies, so with credentials off there is no ambient
+// authority for a hostile page to borrow; it would still need a token it does
+// not have.
 function isPublicOAuthPath(url: string): boolean {
   const path = url.split('?')[0];
   return path.startsWith('/.well-known/')
     || path === '/oauth/register'
-    || path === '/oauth/token';
+    || path === '/oauth/token'
+    || path === '/mcp';
 }
 
 const PUBLIC_CORS: FastifyCorsOptions = {
   origin: true,
   credentials: false,
-  methods: ['GET', 'POST', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version'],
+  methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version', 'Mcp-Session-Id', 'Last-Event-ID'],
   exposedHeaders: EXPOSED_HEADERS,
 };
 

--- a/services/control-api/src/plugins/cors.ts
+++ b/services/control-api/src/plugins/cors.ts
@@ -1,11 +1,41 @@
 import fp from 'fastify-plugin';
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
+import type { FastifyCorsOptions } from '@fastify/cors';
 import { config } from '../config.js';
 import { getRuntimeDbPool } from '../services/runtime-db.js';
 
-const corsPlugin: FastifyPluginAsync = async (fastify) => {
-  await fastify.register(cors, {
+// `WWW-Authenticate` is not a CORS-safelisted response header, so without this a
+// browser client cannot read the 401 challenge — and that challenge is what
+// carries `resource_metadata`, the entry point to the whole discovery flow.
+const EXPOSED_HEADERS = ['WWW-Authenticate', 'Mcp-Session-Id'];
+
+// Endpoints any origin must be able to read for OAuth discovery to work from a
+// browser-hosted client. RFC 9728 §3.1 and RFC 8414 §3 both say metadata
+// endpoints should be publicly readable, and the MCP authorization spec assumes
+// a browser client can complete discovery, registration and token exchange.
+// Our normal policy is an allowlist backed by apps.allowed_origins, which blocks
+// every third-party MCP client — including MCP Inspector on
+// http://localhost:6274, the tool a marketplace reviewer is most likely to
+// reach for. These responses carry no cookies and no ambient authority, so
+// reflecting an arbitrary origin is safe as long as credentials stay off.
+function isPublicOAuthPath(url: string): boolean {
+  const path = url.split('?')[0];
+  return path.startsWith('/.well-known/')
+    || path === '/oauth/register'
+    || path === '/oauth/token';
+}
+
+const PUBLIC_CORS: FastifyCorsOptions = {
+  origin: true,
+  credentials: false,
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version'],
+  exposedHeaders: EXPOSED_HEADERS,
+};
+
+function defaultCorsOptions(fastify: FastifyInstance): FastifyCorsOptions {
+  return {
     origin: (origin, callback) => {
       // Allow requests with no origin (mobile apps, curl, Postman, etc.)
       if (!origin) {
@@ -73,6 +103,16 @@ const corsPlugin: FastifyPluginAsync = async (fastify) => {
       'X-Organization-Id',
       'X-Butterbase-As-User',
     ],
+    exposedHeaders: EXPOSED_HEADERS,
+  };
+}
+
+const corsPlugin: FastifyPluginAsync = async (fastify) => {
+  const fallback = defaultCorsOptions(fastify);
+  await fastify.register(cors, {
+    delegator: (req, callback) => {
+      callback(null, isPublicOAuthPath(req.url ?? '') ? PUBLIC_CORS : fallback);
+    },
   });
 };
 

--- a/services/control-api/src/routes/__tests__/oauth.test.ts
+++ b/services/control-api/src/routes/__tests__/oauth.test.ts
@@ -228,6 +228,53 @@ describe('GET /oauth/authorize', () => {
     await app.close();
   });
 
+  // RFC 6749 §4.1.1 makes `state` RECOMMENDED, not required; OAuth 2.1 §4.1.1
+  // says it MAY be omitted when PKCE supplies the CSRF binding. Same bug class
+  // as the `scope` regression above, one line down in the same guard.
+  it('accepts an authorize request with no state', async () => {
+    const app = await buildAppForTest();
+    const client = await registerClient(app);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/oauth/authorize?response_type=code&client_id=${client.client_id}&redirect_uri=${encodeURIComponent('http://127.0.0.1:55555/cb')}&code_challenge=${'a'.repeat(43)}&code_challenge_method=S256&scope=mcp`,
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toMatch(/\/oauth\/consent\?st=/);
+    await app.close();
+  });
+
+  // §4.1.2.1: once client_id and redirect_uri are known-good, every other
+  // failure MUST come back on the redirect URI. Returning JSON stranded the
+  // client on a callback that never fired.
+  it('redirects errors to redirect_uri instead of returning JSON', async () => {
+    const app = await buildAppForTest();
+    const client = await registerClient(app);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/oauth/authorize?response_type=token&client_id=${client.client_id}&redirect_uri=${encodeURIComponent('http://127.0.0.1:55555/cb')}&code_challenge=${'a'.repeat(43)}&code_challenge_method=S256&scope=mcp&state=xyz`,
+    });
+    expect(res.statusCode).toBe(302);
+    const loc = new URL(res.headers.location as string);
+    expect(loc.origin + loc.pathname).toBe('http://127.0.0.1:55555/cb');
+    expect(loc.searchParams.get('error')).toBe('unsupported_response_type');
+    expect(loc.searchParams.get('state')).toBe('xyz');
+    await app.close();
+  });
+
+  it('omits state on the error redirect when the client sent none', async () => {
+    const app = await buildAppForTest();
+    const client = await registerClient(app);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/oauth/authorize?response_type=code&client_id=${client.client_id}&redirect_uri=${encodeURIComponent('http://127.0.0.1:55555/cb')}&code_challenge=${'a'.repeat(43)}&code_challenge_method=S256&scope=bogus`,
+    });
+    expect(res.statusCode).toBe(302);
+    const loc = new URL(res.headers.location as string);
+    expect(loc.searchParams.get('error')).toBe('invalid_scope');
+    expect(loc.searchParams.has('state')).toBe(false);
+    await app.close();
+  });
+
   it('400s on unregistered redirect_uri', async () => {
     const app = await buildAppForTest();
     const client = await registerClient(app);
@@ -239,14 +286,20 @@ describe('GET /oauth/authorize', () => {
     await app.close();
   });
 
-  it('400s on missing code_challenge', async () => {
+  // Was asserting 400. Per RFC 6749 §4.1.2.1 this error belongs on the redirect
+  // URI, because client_id and redirect_uri have already been validated by the
+  // time we look at code_challenge — so the client can be told what went wrong.
+  it('redirects with invalid_request on missing code_challenge', async () => {
     const app = await buildAppForTest();
     const client = await registerClient(app);
     const res = await app.inject({
       method: 'GET',
       url: `/oauth/authorize?response_type=code&client_id=${client.client_id}&redirect_uri=${encodeURIComponent('http://127.0.0.1:55555/cb')}&code_challenge_method=S256&scope=mcp&state=xyz`,
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(302);
+    const loc = new URL(res.headers.location as string);
+    expect(loc.searchParams.get('error')).toBe('invalid_request');
+    expect(loc.searchParams.get('error_description')).toMatch(/code_challenge/);
     await app.close();
   });
 

--- a/services/control-api/src/routes/__tests__/oauth.test.ts
+++ b/services/control-api/src/routes/__tests__/oauth.test.ts
@@ -209,6 +209,25 @@ describe('GET /oauth/authorize', () => {
     await app.close();
   });
 
+  // Regression: Qoder's MCP connector omits `scope` on /authorize. RFC 6749
+  // §3.1.2 makes it optional, but we required it and 400'd every such client at
+  // the first hop. Query below is a real Qoder authorize URL, scope and all.
+  it('accepts an authorize request with no scope and defaults it to mcp', async () => {
+    const app = await buildAppForTest();
+    const client = await registerClient(app, 'http://127.0.0.1:19888/callback');
+    const res = await app.inject({
+      method: 'GET',
+      url: `/oauth/authorize?response_type=code&client_id=${client.client_id}`
+        + `&redirect_uri=${encodeURIComponent('http://127.0.0.1:19888/callback')}`
+        + `&code_challenge=E4Kkq02ZefjL8aXyB8nY5M6clGZNr6l85x-1aPtC4bc&code_challenge_method=S256`
+        + `&resource=${encodeURIComponent('https://api.butterbase.ai/mcp')}`
+        + `&state=3kUI3Kr511KoM13Z-K0kiRUP1RcvrPHs`,
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toMatch(/\/oauth\/consent\?st=/);
+    await app.close();
+  });
+
   it('400s on unregistered redirect_uri', async () => {
     const app = await buildAppForTest();
     const client = await registerClient(app);

--- a/services/control-api/src/routes/llms-txt.ts
+++ b/services/control-api/src/routes/llms-txt.ts
@@ -145,7 +145,7 @@ Example:
 
 - Full API docs: https://docs.butterbase.ai
 - Error reference: https://docs.butterbase.ai/errors
-- Schema DSL: https://docs.butterbase.ai/schema
+- Schema DSL: https://docs.butterbase.ai/core-concepts/database/
 - MCP tools: Use \`butterbase_docs\` tool for detailed reference
 
 ## Support

--- a/services/control-api/src/routes/oauth.ts
+++ b/services/control-api/src/routes/oauth.ts
@@ -6,6 +6,7 @@ import { ApiKeyService } from '../services/api-key-service.js';
 import { config } from '../config.js';
 
 const ALLOWED_SCOPES = new Set(['mcp', 'ai:gateway']);
+const DEFAULT_SCOPE = 'mcp';
 
 // In-memory token bucket per IP for /oauth/register. Phase-1 mitigation against
 // trivial filling of oauth_clients. Follow-up: replace with a Redis counter so
@@ -101,10 +102,16 @@ export async function oauthRoutes(app: FastifyInstance) {
       if (!q.code_challenge || !/^[A-Za-z0-9_-]{43,128}$/.test(q.code_challenge)) {
         return reply.code(400).send({ error: 'invalid_request', error_description: 'code_challenge missing or malformed' });
       }
-      if (!q.client_id || !q.redirect_uri || !q.scope || !q.state) {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'client_id, redirect_uri, scope, state are required' });
+      if (!q.client_id || !q.redirect_uri || !q.state) {
+        return reply.code(400).send({ error: 'invalid_request', error_description: 'client_id, redirect_uri, state are required' });
       }
-      const scopes = q.scope.split(/\s+/).filter(Boolean);
+      // RFC 6749 §3.1.2 makes `scope` OPTIONAL on /authorize; when the client
+      // omits it the AS applies its own default. Requiring it locked out every
+      // client that does not send one (Qoder's MCP connector, among others) at
+      // the very first hop. `mcp` is the scope we advertise in the
+      // WWW-Authenticate challenge and in oauth-protected-resource metadata.
+      const requestedScope = q.scope && q.scope.trim() ? q.scope : DEFAULT_SCOPE;
+      const scopes = requestedScope.split(/\s+/).filter(Boolean);
       for (const s of scopes) {
         if (!ALLOWED_SCOPES.has(s)) {
           return reply.code(400).send({ error: 'invalid_scope', error_description: `scope "${s}" is not supported` });
@@ -121,7 +128,7 @@ export async function oauthRoutes(app: FastifyInstance) {
       const st = OAuthStateService.sign({
         client_id: q.client_id,
         redirect_uri: q.redirect_uri,
-        scope: q.scope,
+        scope: requestedScope,
         state: q.state,
         code_challenge: q.code_challenge,
       });

--- a/services/control-api/src/routes/oauth.ts
+++ b/services/control-api/src/routes/oauth.ts
@@ -93,17 +93,42 @@ export async function oauthRoutes(app: FastifyInstance) {
     handler: async (request, reply) => {
       const q = request.query as Record<string, string | undefined>;
 
+      // client_id and redirect_uri are validated FIRST and are the only two
+      // failures answered with a direct 400. RFC 6749 §4.1.2.1: when either is
+      // missing or untrusted the AS MUST NOT redirect, because the redirect
+      // target itself cannot be trusted. Everything after this point CAN be
+      // reported to the client, and must be — see redirectError below.
+      if (!q.client_id || !q.redirect_uri) {
+        return reply.code(400).send({ error: 'invalid_request', error_description: 'client_id and redirect_uri are required' });
+      }
+      const client = await OAuthClientService.lookup(app.controlDb, q.client_id);
+      if (!client) {
+        return reply.code(400).send({ error: 'invalid_request', error_description: 'unknown client_id' });
+      }
+      if (!client.redirect_uris.includes(q.redirect_uri)) {
+        return reply.code(400).send({ error: 'invalid_request', error_description: 'redirect_uri is not registered for this client' });
+      }
+
+      // §4.1.2.1 requires every remaining error to come back on the redirect
+      // URI so the waiting client actually learns what went wrong. Returning
+      // JSON here instead left conformant clients blocked on a loopback
+      // callback that never fired — a hang rather than a diagnosable error.
+      const redirectError = (error: string, description: string) => {
+        const u = new URL(q.redirect_uri as string);
+        u.searchParams.set('error', error);
+        u.searchParams.set('error_description', description);
+        if (q.state) u.searchParams.set('state', q.state);
+        return reply.code(302).header('location', u.toString()).send();
+      };
+
       if (q.response_type !== 'code') {
-        return reply.code(400).send({ error: 'unsupported_response_type', error_description: 'response_type must be "code"' });
+        return redirectError('unsupported_response_type', 'response_type must be "code"');
       }
       if (q.code_challenge_method !== 'S256') {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'code_challenge_method must be S256' });
+        return redirectError('invalid_request', 'code_challenge_method must be S256');
       }
       if (!q.code_challenge || !/^[A-Za-z0-9_-]{43,128}$/.test(q.code_challenge)) {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'code_challenge missing or malformed' });
-      }
-      if (!q.client_id || !q.redirect_uri || !q.state) {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'client_id, redirect_uri, state are required' });
+        return redirectError('invalid_request', 'code_challenge missing or malformed');
       }
       // RFC 6749 §3.1.2 makes `scope` OPTIONAL on /authorize; when the client
       // omits it the AS applies its own default. Requiring it locked out every
@@ -114,21 +139,17 @@ export async function oauthRoutes(app: FastifyInstance) {
       const scopes = requestedScope.split(/\s+/).filter(Boolean);
       for (const s of scopes) {
         if (!ALLOWED_SCOPES.has(s)) {
-          return reply.code(400).send({ error: 'invalid_scope', error_description: `scope "${s}" is not supported` });
+          return redirectError('invalid_scope', `scope "${s}" is not supported`);
         }
-      }
-      const client = await OAuthClientService.lookup(app.controlDb, q.client_id);
-      if (!client) {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'unknown client_id' });
-      }
-      if (!client.redirect_uris.includes(q.redirect_uri)) {
-        return reply.code(400).send({ error: 'invalid_request', error_description: 'redirect_uri is not registered for this client' });
       }
 
       const st = OAuthStateService.sign({
         client_id: q.client_id,
         redirect_uri: q.redirect_uri,
         scope: requestedScope,
+        // §4.1.1 makes `state` RECOMMENDED, not required, and OAuth 2.1 §4.1.1
+        // says it MAY be omitted when PKCE provides the CSRF binding — which is
+        // the MCP profile exactly. Requiring it was the same bug as `scope`.
         state: q.state,
         code_challenge: q.code_challenge,
       });
@@ -201,7 +222,7 @@ export async function oauthRoutes(app: FastifyInstance) {
       if (body.decision === 'deny') {
         const u = new URL(payload.redirect_uri);
         u.searchParams.set('error', 'access_denied');
-        u.searchParams.set('state', payload.state);
+        if (payload.state) u.searchParams.set('state', payload.state);
         return reply.send({ redirect_to: u.toString() });
       }
 
@@ -235,7 +256,7 @@ export async function oauthRoutes(app: FastifyInstance) {
 
       const u = new URL(payload.redirect_uri);
       u.searchParams.set('code', code);
-      u.searchParams.set('state', payload.state);
+      if (payload.state) u.searchParams.set('state', payload.state);
       return reply.send({ redirect_to: u.toString() });
     },
   });

--- a/services/control-api/src/routes/well-known.test.ts
+++ b/services/control-api/src/routes/well-known.test.ts
@@ -32,6 +32,19 @@ describe('GET /.well-known/oauth-protected-resource', () => {
     await app.close();
   });
 
+  // RFC 9728 §3.1: for a resource identifier with a path component
+  // (https://host/mcp) the well-known URI is the path-INSERTED form. Clients
+  // that probe discovery directly, rather than reading resource_metadata off
+  // the WWW-Authenticate challenge, only ever look here.
+  it('serves the same metadata at the path-inserted URL', async () => {
+    const app = await buildAppForTest();
+    const root = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource' });
+    const inserted = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource/mcp' });
+    expect(inserted.statusCode).toBe(200);
+    expect(inserted.json()).toEqual(root.json());
+    await app.close();
+  });
+
   it('is reachable without an Authorization header', async () => {
     const app = await buildAppForTest();
     const res = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource' });

--- a/services/control-api/src/routes/well-known.test.ts
+++ b/services/control-api/src/routes/well-known.test.ts
@@ -20,6 +20,18 @@ describe('GET /.well-known/oauth-protected-resource', () => {
     await app.close();
   });
 
+  // A 404 here is invisible in prod but is the first link an MCP client — or a
+  // marketplace reviewer — follows from discovery. Pin the path so a docs-site
+  // reshuffle has to update it deliberately.
+  it('advertises a resource_documentation path that exists on the docs site', async () => {
+    const app = await buildAppForTest();
+    const res = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource' });
+    expect(res.json().resource_documentation).toBe(
+      'https://docs.butterbase.ai/getting-started/mcp-setup/',
+    );
+    await app.close();
+  });
+
   it('is reachable without an Authorization header', async () => {
     const app = await buildAppForTest();
     const res = await app.inject({ method: 'GET', url: '/.well-known/oauth-protected-resource' });

--- a/services/control-api/src/routes/well-known.ts
+++ b/services/control-api/src/routes/well-known.ts
@@ -10,22 +10,33 @@ function baseUrl(): string {
 }
 
 export async function wellKnownRoutes(app: FastifyInstance) {
-  // RFC 9728 — identifies /mcp as a protected resource and points to the AS.
-  app.route({
-    method: 'GET',
-    url: '/.well-known/oauth-protected-resource',
-    config: { public: true },
-    handler: async (_req, reply) => {
-      const base = baseUrl();
-      reply.send({
-        resource: `${base}/mcp`,
-        authorization_servers: [base],
-        scopes_supported: ['mcp', 'ai:gateway'],
-        bearer_methods_supported: ['header'],
-        resource_documentation: 'https://docs.butterbase.ai/getting-started/mcp-setup/',
-      });
-    },
+  const protectedResourceMetadata = (base: string) => ({
+    resource: `${base}/mcp`,
+    authorization_servers: [base],
+    scopes_supported: ['mcp', 'ai:gateway'],
+    bearer_methods_supported: ['header'],
+    resource_documentation: 'https://docs.butterbase.ai/getting-started/mcp-setup/',
   });
+
+  // RFC 9728 — identifies /mcp as a protected resource and points to the AS.
+  // Served at BOTH the root form and the path-inserted form. §3.1 defines the
+  // well-known URI for a resource identifier that has a path component
+  // (https://host/mcp) as /.well-known/oauth-protected-resource/mcp — clients
+  // that probe discovery directly, instead of reading resource_metadata off the
+  // WWW-Authenticate challenge, only ever look at the path-inserted URL.
+  for (const url of [
+    '/.well-known/oauth-protected-resource',
+    '/.well-known/oauth-protected-resource/mcp',
+  ]) {
+    app.route({
+      method: 'GET',
+      url,
+      config: { public: true },
+      handler: async (_req, reply) => {
+        reply.send(protectedResourceMetadata(baseUrl()));
+      },
+    });
+  }
 
   // RFC 8414 — authorization server metadata.
   app.route({

--- a/services/control-api/src/routes/well-known.ts
+++ b/services/control-api/src/routes/well-known.ts
@@ -22,7 +22,7 @@ export async function wellKnownRoutes(app: FastifyInstance) {
         authorization_servers: [base],
         scopes_supported: ['mcp', 'ai:gateway'],
         bearer_methods_supported: ['header'],
-        resource_documentation: 'https://docs.butterbase.ai/mcp',
+        resource_documentation: 'https://docs.butterbase.ai/getting-started/mcp-setup/',
       });
     },
   });

--- a/services/control-api/src/services/oauth-state-service.ts
+++ b/services/control-api/src/services/oauth-state-service.ts
@@ -6,7 +6,7 @@ export interface AuthorizePayload {
   client_id: string;
   redirect_uri: string;
   scope: string;
-  state: string;
+  state?: string;
   code_challenge: string;
 }
 


### PR DESCRIPTION
## Why

A third-party MCP client (Qoder's connector) could not authenticate against `api.butterbase.ai/mcp` at all. The OAuth handshake died on the very first hop and the client showed a connected server with zero tools — no useful error anywhere.

The cause was that `/oauth/authorize` **required** the `scope` query parameter. RFC 6749 §3.1.2 makes it OPTIONAL; when a client omits it the authorization server is meant to apply its own default. We 400'd instead.

We never caught this because Claude Code is the only client this path has ever been exercised with, and it always sends `scope=mcp`.

That prompted an audit of the whole authorization path against RFC 6749 / 7636 / 8414 / 9728 and the MCP authorization spec (2025-11-25). It found four more deviations of the same character — places where we require something the spec makes optional, or where we are unusable from a browser-hosted client. Each breaks a class of client we have never tested.

## What changed

**`scope` is optional on `/authorize`** (commit 1). Defaults to `mcp`, the scope already advertised in the `WWW-Authenticate` challenge and in `oauth-protected-resource` metadata. Regression test uses a real Qoder authorize URL verbatim.

**`state` is optional on `/authorize`.** §4.1.1 makes it RECOMMENDED, not required, and OAuth 2.1 §4.1.1 says it MAY be omitted when PKCE supplies the CSRF binding — which is the MCP profile exactly. This was the identical bug to `scope`, one line below it. It is echoed back on the redirect only when the client actually sent one.

**Authorize errors redirect instead of returning JSON.** §4.1.2.1 requires every error except bad `client_id`/`redirect_uri` to come back on the redirect URI. Previously a conformant client sat blocked on a loopback callback that never fired, while the user stared at raw JSON in a browser tab — a hang rather than a diagnosable failure. `client_id` and `redirect_uri` are now validated first and still answered with a direct 400, since an untrusted redirect target must not be redirected to.

**CORS no longer blocks discovery.** The origin allowlist is backed by `apps.allowed_origins`, so `/.well-known/*`, `/oauth/register` and `/oauth/token` rejected every third-party origin — including MCP Inspector on `localhost:6274`. Those endpoints now reflect any origin with credentials off; the DB-driven policy still governs everything else.

**`WWW-Authenticate` is exposed to browsers.** It is not a CORS-safelisted response header, so a browser client could not read the 401 challenge that carries `resource_metadata` — the entry point to the entire discovery flow. Added alongside `Mcp-Session-Id`.

**Protected-resource metadata is served at the path-inserted URL.** RFC 9728 §3.1 defines `/.well-known/oauth-protected-resource/mcp` as the well-known URI for a resource identifier with a path component. Clients that probe discovery directly, rather than reading the challenge header, only look there. Root form still served.

Three doc URLs that 404 are also fixed, all of them client-reachable: `resource_documentation` pointed at `docs.butterbase.ai/mcp` (page is at `/getting-started/mcp-setup/`), `llms.txt` pointed at `/schema` (now `/core-concepts/database/`), and the unauthenticated MCP 401 hardcoded *"In Claude Code: `claude mcp add butterbase`"* as its remediation — telling every non-Claude client to install a different vendor's tool.

## Testing

33 targeted tests pass, including the full OAuth → MCP end-to-end.

`cors.ts` is a global plugin, so the whole `control-api` suite was run with and without this change. **Identical results: 88 files / 275 tests failing in both**, +4 passing from the new cases. Those failures are pre-existing and infrastructural — Redis and Postgres are unavailable in this environment.

One existing test was updated rather than added to: `400s on missing code_challenge` now expects a 302 redirect, which is the intended behavior change.

`tsc --noEmit` clean.

## Not in this PR

The audit flagged a separate issue worth its own change: a client requesting `scope=ai:gateway` receives a token whose response reports `ai:gateway` but which actually carries `*`. We advertise a scope in `scopes_supported` that we do not honor, and over-grant as a result. Fixing it means either wiring the granted OAuth scope through to the minted key or dropping `ai:gateway` from the advertised set — a product decision, not a mechanical fix.

## Risk

No migrations, no new environment variables, no changes to token issuance or verification. Every change is strictly more permissive on input, so the current production image remains compatible throughout a rolling deploy. The one behavioral change visible to existing clients is that authorize errors now arrive as a redirect rather than a JSON 400 — which is what the spec requires, and what clients are written to expect.
