### PR TITLE
feat(admin): paid-conversion metric on /admin/overview + daily snapshots

### DIFF
--- a/db/control-plane/108_paid_conversion_snapshots.sql
+++ b/db/control-plane/108_paid_conversion_snapshots.sql
@@ -1,0 +1,28 @@
+-- @scope: platform
+-- Daily snapshot of the paid-conversion metric.
+--
+-- Subscription rows carry created_at/updated_at but no status history, so a
+-- past conversion rate cannot be reconstructed after the fact. Without this
+-- table the Overview card can only ever answer "what is it right now".
+-- One row per day, written by the nightly billing task.
+
+CREATE TABLE IF NOT EXISTS paid_conversion_snapshots (
+    snapshot_date       DATE PRIMARY KEY,
+
+    -- Strict: active paid subscription with no scheduled cancellation.
+    paying_users        INTEGER NOT NULL,
+    paying_orgs         INTEGER NOT NULL,
+
+    -- Broad: additionally counts past_due (dunning).
+    broad_paying_users  INTEGER NOT NULL,
+    broad_paying_orgs   INTEGER NOT NULL,
+
+    -- Denominators, internal/staff/seed accounts already excluded.
+    eligible_users      INTEGER NOT NULL,
+    eligible_orgs       INTEGER NOT NULL,
+
+    captured_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE paid_conversion_snapshots IS
+  'Daily paid-conversion history. Written by the nightly billing task; see services/control-api/src/services/paid-conversion.ts for the metric definition.';

--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -153,6 +153,7 @@ import { runtimePoolFor, listRuntimeRegions } from './services/runtime-pool-regi
 import { redisFor } from './services/redis-registry.js';
 import { auditRuntimeTablesForPool } from './services/move-app/runtime-table-audit.js';
 import { waitForReplicationCaughtUp, promoteSourceToPrimary } from './services/move-app/neon-replication.js';
+import { writePaidConversionSnapshot } from './services/paid-conversion.js';
 
 // Initialize Sentry
 if (config.sentry.enabled) {
@@ -994,6 +995,12 @@ Promise.resolve(app.ready())
                 });
               }
             }
+            // Daily paid-conversion snapshot. Subscription rows carry no
+            // status history, so a day not captured here is a day of the
+            // trend permanently lost. Idempotent on date.
+            await writePaidConversionSnapshot(app.controlDb).catch((err) => {
+              app.log.error({ err }, 'Failed to write paid-conversion snapshot');
+            });
           } finally {
             await redis.del('lock:nightly-billing').catch(() => {});
           }

--- a/services/control-api/src/routes/__tests__/admin-overview-conversion.test.ts
+++ b/services/control-api/src/routes/__tests__/admin-overview-conversion.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import fp from 'fastify-plugin';
+
+vi.mock('../admin-auth.js', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('../../services/region-resolver.js', () => ({
+  fanOutQuery: vi.fn(),
+  fanOutRuntimeRegions: vi.fn(),
+  getRuntimeDbForApp: vi.fn(),
+}));
+
+import { requireAdmin } from '../admin-auth.js';
+import { fanOutQuery } from '../../services/region-resolver.js';
+import { adminRoutes } from '../admin.js';
+
+const mockRequireAdmin = vi.mocked(requireAdmin);
+const mockFanOutQuery = vi.mocked(fanOutQuery);
+
+// The SQL semantics are covered against real Postgres in
+// services/paid-conversion.db.test.ts. This file covers only the wiring: that
+// /admin/overview runs the conversion query and shapes the response.
+function makeControlDbMock(conversionRow: Record<string, number> | null) {
+  return {
+    query: vi.fn().mockImplementation(async (sql: string) => {
+      if (sql.includes('strict_orgs')) {
+        return { rows: conversionRow ? [conversionRow] : [] };
+      }
+      if (sql.includes('count(*)::int AS c')) return { rows: [{ c: 0 }] };
+      return { rows: [] };
+    }),
+  };
+}
+
+async function makeApp(controlDb: any) {
+  const app = Fastify({ logger: false });
+  await app.register(
+    fp(
+      async (i: any) => {
+        i.decorate('controlDb', controlDb);
+      },
+      { name: 'shim' },
+    ),
+  );
+  await app.register(adminRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue('admin-uid');
+  mockFanOutQuery.mockResolvedValue([]);
+});
+
+describe('GET /admin/overview conversion block', () => {
+  it('returns counts and derived percentages', async () => {
+    const controlDb = makeControlDbMock({
+      eligible_users: 889,
+      eligible_orgs: 901,
+      paying_users: 55,
+      paying_orgs: 55,
+      broad_paying_users: 89,
+      broad_paying_orgs: 89,
+    });
+    const app = await makeApp(controlDb);
+
+    const r = await app.inject({ method: 'GET', url: '/admin/overview' });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.conversion).toBeDefined();
+    expect(body.conversion.payingUsers).toBe(55);
+    expect(body.conversion.eligibleUsers).toBe(889);
+    expect(body.conversion.payingOrgs).toBe(55);
+    expect(body.conversion.eligibleOrgs).toBe(901);
+    expect(body.conversion.payingUsersPct).toBeCloseTo(6.187, 2);
+    expect(body.conversion.payingOrgsPct).toBeCloseTo(6.104, 2);
+    expect(body.conversion.broadPayingUsers).toBe(89);
+    expect(body.conversion.broadPayingOrgs).toBe(89);
+  });
+
+  it('reports zero percent rather than NaN when there are no eligible users', async () => {
+    const controlDb = makeControlDbMock({
+      eligible_users: 0,
+      eligible_orgs: 0,
+      paying_users: 0,
+      paying_orgs: 0,
+      broad_paying_users: 0,
+      broad_paying_orgs: 0,
+    });
+    const app = await makeApp(controlDb);
+
+    const r = await app.inject({ method: 'GET', url: '/admin/overview' });
+
+    expect(r.statusCode).toBe(200);
+    expect(r.json().conversion.payingUsersPct).toBe(0);
+    expect(r.json().conversion.payingOrgsPct).toBe(0);
+  });
+});

--- a/services/control-api/src/routes/admin.ts
+++ b/services/control-api/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { requireAdmin } from './admin-auth.js';
+import { queryPaidConversion } from '../services/paid-conversion.js';
 async function getStripeClient(): Promise<any> {
   // Stripe client lives in the cloud overlay; OSS builds reach an explicit failure.
   // @ts-expect-error — overlay path resolved at runtime
@@ -66,6 +67,7 @@ export async function adminRoutes(app: FastifyInstance) {
       planDist,
       recentSignups,
       aiDailyRows,
+      conversion,
     ] = await Promise.all([
       app.controlDb.query(`SELECT count(*)::int AS c FROM platform_users`),
       fanOutQuery<{ c: number }>(`SELECT count(*)::int AS c FROM apps`),
@@ -106,6 +108,10 @@ export async function adminRoutes(app: FastifyInstance) {
          GROUP BY date(created_at)
          ORDER BY date ASC`
       ),
+      // Paid-conversion metric. Reads the subscriptions table rather than
+      // organizations.plan_id, which disagrees in both directions. See
+      // services/paid-conversion.ts for the full definition.
+      queryPaidConversion(app.controlDb),
     ]);
 
     // Merge daily ai_usage_logs rows by date across regions.
@@ -135,6 +141,7 @@ export async function adminRoutes(app: FastifyInstance) {
       planDistribution: planDist.rows,
       recentSignups: recentSignups.rows,
       aiUsageLast30Days: aiDaily,
+      conversion,
     };
   });
 

--- a/services/control-api/src/services/paid-conversion.db.test.ts
+++ b/services/control-api/src/services/paid-conversion.db.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { queryPaidConversion, writePaidConversionSnapshot } from './paid-conversion.js';
+
+// Real-Postgres test. The conversion figures are pure SQL semantics — who counts
+// as internal, which subscription states count as paying — so a mocked query
+// layer would assert nothing about the thing that can actually break.
+//
+// Every fixture is created inside a transaction that is rolled back at the end,
+// and assertions are on the DELTA from a baseline measured in the same
+// transaction, so the test is correct regardless of what else lives in the
+// shared control-plane test DB.
+
+const pool = new pg.Pool({
+  connectionString:
+    process.env.CONTROL_TEST_DATABASE_URL ??
+    'postgresql://butterbase:butterbase_dev@localhost:5433/butterbase_control',
+});
+
+let client: pg.PoolClient;
+
+// Every real user has a personal org (platform_users.personal_organization_id
+// is NOT NULL, FK to organizations), and organizations.owner_id points back at
+// the user. Creating one means breaking the cycle: org first with a placeholder
+// owner, then the user, then point the org at its owner. owner_id has no FK,
+// which is what makes the placeholder legal — and is also why prod contains
+// orgs whose owner no longer exists.
+const PLACEHOLDER_OWNER = '00000000-0000-4000-8000-000000000001';
+
+interface Fixture {
+  userId: string;
+  orgId: string;
+}
+
+async function mkUser(email: string, isAdmin = false): Promise<Fixture> {
+  const org = await client.query(
+    `INSERT INTO organizations (name, owner_id, personal) VALUES ($1, $2, true) RETURNING id`,
+    [`${email} personal`, PLACEHOLDER_OWNER],
+  );
+  const orgId = org.rows[0].id;
+  const user = await client.query(
+    `INSERT INTO platform_users (email, is_admin, personal_organization_id)
+     VALUES ($1, $2, $3) RETURNING id`,
+    [email, isAdmin, orgId],
+  );
+  const userId = user.rows[0].id;
+  await client.query(`UPDATE organizations SET owner_id = $1 WHERE id = $2`, [userId, orgId]);
+  return { userId, orgId };
+}
+
+async function mkOrg(ownerId: string, name: string): Promise<string> {
+  const r = await client.query(
+    `INSERT INTO organizations (name, owner_id) VALUES ($1, $2) RETURNING id`,
+    [name, ownerId],
+  );
+  return r.rows[0].id;
+}
+
+async function mkSub(
+  orgId: string,
+  userId: string,
+  planId: string,
+  status: string,
+  cancelAt: string | null = null,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO subscriptions (organization_id, user_id, plan_id, status, cancel_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [orgId, userId, planId, status, cancelAt],
+  );
+}
+
+beforeAll(async () => {
+  client = await pool.connect();
+  await client.query('BEGIN');
+});
+
+afterAll(async () => {
+  await client.query('ROLLBACK');
+  client.release();
+  await pool.end();
+});
+
+describe('queryPaidConversion', () => {
+  it('counts an external owner with an active launch sub as paying', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('customer-active@example.com');
+    await mkSub(u.orgId, u.userId, 'launch', 'active');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(1);
+    expect(after.payingOrgs - before.payingOrgs).toBe(1);
+    expect(after.eligibleUsers - before.eligibleUsers).toBe(1);
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(1);
+  });
+
+  it('excludes an is_admin owner from both numerator and denominator', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('staff-admin@example.com', true);
+    await mkSub(u.orgId, u.userId, 'launch', 'active');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(0);
+    expect(after.eligibleUsers - before.eligibleUsers).toBe(0);
+    expect(after.payingOrgs - before.payingOrgs).toBe(0);
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(0);
+  });
+
+  it('excludes an @butterbase.ai owner even when not flagged is_admin', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('contractor@butterbase.ai', false);
+    await mkSub(u.orgId, u.userId, 'launch', 'active');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(0);
+    expect(after.eligibleUsers - before.eligibleUsers).toBe(0);
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(0);
+  });
+
+  it('excludes a portal-cancelled sub from strict but keeps the owner eligible', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('portal-cancelled@example.com');
+    await mkSub(u.orgId, u.userId, 'launch', 'active', '2099-01-01T00:00:00Z');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(0);
+    expect(after.payingOrgs - before.payingOrgs).toBe(0);
+    // Still a real external user with a real org, so the denominator grows.
+    expect(after.eligibleUsers - before.eligibleUsers).toBe(1);
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(1);
+  });
+
+  it('counts past_due in broad but not in strict', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('dunning@example.com');
+    await mkSub(u.orgId, u.userId, 'launch', 'past_due');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(0);
+    expect(after.payingOrgs - before.payingOrgs).toBe(0);
+    expect(after.broadPayingUsers - before.broadPayingUsers).toBe(1);
+    expect(after.broadPayingOrgs - before.broadPayingOrgs).toBe(1);
+  });
+
+  it('does not count playground or enterprise as paying', async () => {
+    const before = await queryPaidConversion(client);
+
+    const free = await mkUser('free-user@example.com');
+    await mkSub(free.orgId, free.userId, 'playground', 'active');
+
+    const ent = await mkUser('ent-user@example.com');
+    await mkSub(ent.orgId, ent.userId, 'enterprise', 'active');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(0);
+    expect(after.broadPayingUsers - before.broadPayingUsers).toBe(0);
+    expect(after.eligibleUsers - before.eligibleUsers).toBe(2);
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(2);
+  });
+
+  it('counts an owner of two paying orgs once as a user but twice as orgs', async () => {
+    const before = await queryPaidConversion(client);
+
+    const u = await mkUser('multi-org@example.com');
+    const a = await mkOrg(u.userId, 'Multi A');
+    const b = await mkOrg(u.userId, 'Multi B');
+    await mkSub(a, u.userId, 'launch', 'active');
+    await mkSub(b, u.userId, 'certified', 'active');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.payingUsers - before.payingUsers).toBe(1);
+    expect(after.payingOrgs - before.payingOrgs).toBe(2);
+    // personal org (unpaid) + the two paying orgs
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(3);
+  });
+
+  it('ignores an org whose owner_id has no platform_users row', async () => {
+    // organizations.owner_id has no FK, and prod contains 4 such orphans.
+    const before = await queryPaidConversion(client);
+
+    await mkOrg('00000000-0000-4000-8000-0000000000ff', 'Orphaned Owner Org');
+
+    const after = await queryPaidConversion(client);
+
+    expect(after.eligibleOrgs - before.eligibleOrgs).toBe(0);
+    expect(after.payingOrgs - before.payingOrgs).toBe(0);
+  });
+
+  it('reports percentages derived from the counts', async () => {
+    const r = await queryPaidConversion(client);
+
+    expect(r.payingUsersPct).toBeCloseTo((r.payingUsers / r.eligibleUsers) * 100, 6);
+    expect(r.payingOrgsPct).toBeCloseTo((r.payingOrgs / r.eligibleOrgs) * 100, 6);
+  });
+});
+
+describe('writePaidConversionSnapshot', () => {
+  const DAY = '2031-03-04';
+
+  it('records the current conversion figures for the given date', async () => {
+    const expected = await queryPaidConversion(client);
+
+    await writePaidConversionSnapshot(client, DAY);
+
+    const { rows } = await client.query(
+      `SELECT * FROM paid_conversion_snapshots WHERE snapshot_date = $1`,
+      [DAY],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].paying_users).toBe(expected.payingUsers);
+    expect(rows[0].eligible_users).toBe(expected.eligibleUsers);
+    expect(rows[0].paying_orgs).toBe(expected.payingOrgs);
+    expect(rows[0].eligible_orgs).toBe(expected.eligibleOrgs);
+    expect(rows[0].broad_paying_users).toBe(expected.broadPayingUsers);
+    expect(rows[0].broad_paying_orgs).toBe(expected.broadPayingOrgs);
+  });
+
+  it('is idempotent: a second run on the same date updates rather than duplicates', async () => {
+    await writePaidConversionSnapshot(client, DAY);
+
+    // A new paying customer appears after the first snapshot of the day.
+    const u = await mkUser('late-signup@example.com');
+    await mkSub(u.orgId, u.userId, 'launch', 'active');
+
+    await writePaidConversionSnapshot(client, DAY);
+
+    const { rows } = await client.query(
+      `SELECT * FROM paid_conversion_snapshots WHERE snapshot_date = $1`,
+      [DAY],
+    );
+    expect(rows).toHaveLength(1);
+    const live = await queryPaidConversion(client);
+    expect(rows[0].paying_users).toBe(live.payingUsers);
+  });
+});

--- a/services/control-api/src/services/paid-conversion.ts
+++ b/services/control-api/src/services/paid-conversion.ts
@@ -1,0 +1,151 @@
+/**
+ * Paid-conversion metric — what share of real customers are on a paid plan.
+ *
+ * Source of truth is the `subscriptions` table, NOT `organizations.plan_id`.
+ * The two disagree in both directions: orgs soft-locked to playground while a
+ * launch sub is still in dunning, and orgs left on launch after the sub was
+ * cancelled. Reading plan_id would over-report paying orgs.
+ *
+ * Ownership is `organizations.owner_id` (NOT NULL, exactly one per org) rather
+ * than organization_members(role='owner'), which permits several owners per org
+ * and is missing rows for some orgs. owner_id has no FK, so the join through
+ * platform_users is what drops orgs whose owner no longer exists.
+ *
+ * "Internal" covers staff and seeded demo accounts. is_admin alone is not
+ * enough — two internal accounts are not flagged admin, and one of them owns
+ * eleven demo orgs carrying live Stripe subscriptions. Both rules are applied.
+ */
+
+const INTERNAL_EMAILS = ['kcflexigbo@gmail.com', 'hi.networksage@gmail.com'];
+
+/** Plans that represent actual recurring revenue. */
+const PAID_PLANS = ['launch', 'certified'];
+
+/**
+ * Strict counts a subscription only while it is active AND has no scheduled
+ * end date. Stripe sets `cancel_at` on portal-initiated cancellations, which we
+ * would otherwise keep reporting as revenue — including some whose date has
+ * already passed. Broad additionally counts past_due (dunning).
+ */
+export const PAID_CONVERSION_SQL = `
+WITH internal AS (
+  SELECT id FROM platform_users
+  WHERE email LIKE '%@butterbase.ai'
+     OR email = ANY($1::text[])
+     OR is_admin
+),
+ext_users AS (
+  SELECT id FROM platform_users WHERE id NOT IN (SELECT id FROM internal)
+),
+ext_orgs AS (
+  SELECT o.id, o.owner_id
+  FROM organizations o
+  JOIN ext_users u ON u.id = o.owner_id
+),
+strict_orgs AS (
+  SELECT eo.id, eo.owner_id FROM ext_orgs eo
+  WHERE EXISTS (
+    SELECT 1 FROM subscriptions s
+    WHERE s.organization_id = eo.id
+      AND s.plan_id = ANY($2::text[])
+      AND s.status = 'active'
+      AND s.cancel_at IS NULL
+  )
+),
+broad_orgs AS (
+  SELECT eo.id, eo.owner_id FROM ext_orgs eo
+  WHERE EXISTS (
+    SELECT 1 FROM subscriptions s
+    WHERE s.organization_id = eo.id
+      AND s.plan_id = ANY($2::text[])
+      AND s.status IN ('active', 'past_due')
+  )
+)
+SELECT
+  (SELECT count(*)::int FROM ext_users)                        AS eligible_users,
+  (SELECT count(*)::int FROM ext_orgs)                         AS eligible_orgs,
+  (SELECT count(DISTINCT owner_id)::int FROM strict_orgs)      AS paying_users,
+  (SELECT count(*)::int FROM strict_orgs)                      AS paying_orgs,
+  (SELECT count(DISTINCT owner_id)::int FROM broad_orgs)       AS broad_paying_users,
+  (SELECT count(*)::int FROM broad_orgs)                       AS broad_paying_orgs
+`;
+
+export interface PaidConversion {
+  eligibleUsers: number;
+  eligibleOrgs: number;
+  payingUsers: number;
+  payingOrgs: number;
+  payingUsersPct: number;
+  payingOrgsPct: number;
+  broadPayingUsers: number;
+  broadPayingOrgs: number;
+  broadPayingUsersPct: number;
+  broadPayingOrgsPct: number;
+}
+
+function pct(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : (numerator / denominator) * 100;
+}
+
+interface Queryable {
+  query(sql: string, params?: unknown[]): Promise<{ rows: any[] }>;
+}
+
+export async function queryPaidConversion(db: Queryable): Promise<PaidConversion> {
+  const { rows } = await db.query(PAID_CONVERSION_SQL, [INTERNAL_EMAILS, PAID_PLANS]);
+  const r = rows[0];
+  const eligibleUsers = r.eligible_users;
+  const eligibleOrgs = r.eligible_orgs;
+  return {
+    eligibleUsers,
+    eligibleOrgs,
+    payingUsers: r.paying_users,
+    payingOrgs: r.paying_orgs,
+    payingUsersPct: pct(r.paying_users, eligibleUsers),
+    payingOrgsPct: pct(r.paying_orgs, eligibleOrgs),
+    broadPayingUsers: r.broad_paying_users,
+    broadPayingOrgs: r.broad_paying_orgs,
+    broadPayingUsersPct: pct(r.broad_paying_users, eligibleUsers),
+    broadPayingOrgsPct: pct(r.broad_paying_orgs, eligibleOrgs),
+  };
+}
+
+/**
+ * Records the current conversion figures for one day. Keyed on date and
+ * idempotent, so re-running it (a retry, or a second process winning the
+ * nightly lock) overwrites that day rather than duplicating it.
+ *
+ * `snapshotDate` defaults to the current UTC date. It is a parameter so tests
+ * can pin a date without stubbing the clock.
+ */
+export async function writePaidConversionSnapshot(
+  db: Queryable,
+  snapshotDate?: string,
+): Promise<PaidConversion> {
+  const conversion = await queryPaidConversion(db);
+  await db.query(
+    `INSERT INTO paid_conversion_snapshots (
+       snapshot_date, paying_users, paying_orgs,
+       broad_paying_users, broad_paying_orgs,
+       eligible_users, eligible_orgs
+     ) VALUES (COALESCE($1::date, (now() AT TIME ZONE 'utc')::date), $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (snapshot_date) DO UPDATE SET
+       paying_users       = EXCLUDED.paying_users,
+       paying_orgs        = EXCLUDED.paying_orgs,
+       broad_paying_users = EXCLUDED.broad_paying_users,
+       broad_paying_orgs  = EXCLUDED.broad_paying_orgs,
+       eligible_users     = EXCLUDED.eligible_users,
+       eligible_orgs      = EXCLUDED.eligible_orgs,
+       captured_at        = now()`,
+    [
+      snapshotDate ?? null,
+      conversion.payingUsers,
+      conversion.payingOrgs,
+      conversion.broadPayingUsers,
+      conversion.broadPayingOrgs,
+      conversion.eligibleUsers,
+      conversion.eligibleOrgs,
+    ],
+  );
+  return conversion;
+}

--- a/services/control-api/vitest.integration.config.ts
+++ b/services/control-api/vitest.integration.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'src/routes/storage.test.ts',
       'src/services/dashboard-agent/__tests__/store.test.ts',
       'src/services/fork-count-sweeper.test.ts',
+      'src/services/paid-conversion.db.test.ts',
       'src/services/kv/kv-scope.test.ts',
     ],
   },


### PR DESCRIPTION
Adds a paid-conversion metric to `/admin/overview` — what share of real customers are on a paid plan — plus a daily snapshot table so the figure can be tracked over time.

## Why the subscriptions table, not `organizations.plan_id`

The two disagree in both directions:

- **13 orgs** are soft-locked to `playground` while a `launch` subscription is still in dunning
- **3 orgs** are still marked `launch` after the subscription was cancelled

Reading `plan_id` over-reports paying orgs.

## Definition

- **Paying org** — `plan_id IN ('launch','certified')`, `status='active'`, `cancel_at IS NULL`
- **Paying user** — owns at least one such org via `organizations.owner_id`, joined through `platform_users` so orgs whose owner no longer exists drop out (`owner_id` has no FK)
- **Excluded** — `email LIKE '%@butterbase.ai' OR email IN (...) OR is_admin`

Strict requires `cancel_at IS NULL` because Stripe sets `cancel_at` on portal-initiated cancellations, which would otherwise keep reading as revenue — some with dates already in the past. A broad variant additionally counts `past_due`, reported alongside so the dunning gap stays visible.

`is_admin` alone is not sufficient: two internal accounts are not flagged admin, and one of them owns eleven seeded demo orgs carrying live Stripe subscriptions.

## Snapshots

Subscription rows carry `created_at`/`updated_at` but no status history, so past conversion rates cannot be reconstructed after the fact. Migration `108` adds `paid_conversion_snapshots`, written by the existing nightly billing task (which already holds a Redis lock). Idempotent on date.

## Tests

11 real-Postgres cases covering the SQL semantics (internal exclusion, `cancel_at`, `past_due`, multi-org owners, orphaned `owner_id`) and 2 for the endpoint shape. The SQL suite is mutation-tested: removing `is_admin`, ignoring `cancel_at`, and letting `past_due` into strict each fail exactly one test.

## Deploy note

Migration `108` must be applied before the image ships. It only creates a new table, so it is pre-deploy-safe — the current image never touches it.