### PR TITLE
fix(gateway): attribute AI spend to the caller's active organization

### DIFF
--- a/services/control-api/src/routes/gateway.org-attribution.test.ts
+++ b/services/control-api/src/routes/gateway.org-attribution.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { gatewayRoutes } from './gateway.js';
+
+vi.mock('../services/ai-router/responses.js', () => ({
+  routeResponses: vi.fn().mockResolvedValue({
+    status: 200, chosen: 'openrouter',
+    body: { id: 'rsp_x', object: 'response', created_at: 1, status: 'completed',
+            model: 'openai/gpt-4o', previous_response_id: null, output: [],
+            usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 } },
+  }),
+}));
+vi.mock('../services/redis.js', () => ({ getRedisClient: vi.fn(() => ({})) }));
+vi.mock('../services/runtime-db.js', () => ({ getRuntimeDbPool: vi.fn(() => ({})) }));
+vi.mock('../services/ai-router/catalog.js', () => ({
+  listCatalogModels: vi.fn(async () => []),
+  readCatalogEntry: vi.fn(async () => null),
+  readEnabledRouters: vi.fn(async () => []),
+}));
+vi.mock('../services/ai-router/router.js', async (orig) => {
+  const actual = await orig<typeof import('../services/ai-router/router.js')>();
+  return { ...actual, routeChatCompletion: vi.fn(), routeEmbedding: vi.fn() };
+});
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>();
+  return { ...actual, config: { ...actual.config, aiRouter: { ...actual.config.aiRouter, v2EndpointsEnabled: true } } };
+});
+
+/**
+ * Builds the gateway with a caller whose auth carries `organizationId`.
+ * The control DB always answers with the caller's PERSONAL org, so a test that
+ * sees the personal org proves the active org was ignored.
+ */
+async function buildApp(organizationId: string | null) {
+  const app = Fastify({ logger: false });
+  app.decorate('controlDb', {
+    query: async () => ({ rows: [{ personal_organization_id: 'org-personal' }] }),
+  } as any);
+  app.addHook('onRequest', async (req) => {
+    (req as any).auth = { appId: null, userId: 'u', authMethod: 'jwt', scopes: ['*'], organizationId };
+  });
+  await app.register(gatewayRoutes);
+  return app;
+}
+
+describe('gateway org attribution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('bills the active organization when auth carries one', async () => {
+    const { routeResponses } = await import('../services/ai-router/responses.js');
+    const app = await buildApp('org-team');
+
+    const res = await app.inject({
+      method: 'POST', url: '/v1/responses',
+      payload: { model: 'openai/gpt-4o', input: 'hi' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The org threaded into routing/billing must be the ACTIVE org, not personal.
+    // auth.organizationId is already membership-validated in plugins/auth.ts.
+    expect((routeResponses as any).mock.calls[0][0].organizationId).toBe('org-team');
+    await app.close();
+  });
+
+  it('falls back to the personal organization when auth carries none', async () => {
+    const { routeResponses } = await import('../services/ai-router/responses.js');
+    const app = await buildApp(null);
+
+    await app.inject({
+      method: 'POST', url: '/v1/responses',
+      payload: { model: 'openai/gpt-4o', input: 'hi' },
+    });
+
+    expect((routeResponses as any).mock.calls[0][0].organizationId).toBe('org-personal');
+    await app.close();
+  });
+});

--- a/services/control-api/src/routes/gateway.ts
+++ b/services/control-api/src/routes/gateway.ts
@@ -30,7 +30,28 @@ import { stripThinkingSuffix } from '../services/ai-router/reasoning.js';
 
 const GATEWAY_SCOPE = 'ai:gateway';
 
-async function resolveGatewayOrg(controlDb: pg.Pool, userId: string): Promise<string> {
+/**
+ * The organization AI spend is attributed to: usage rows, credit gating, and
+ * markup all key off this.
+ *
+ * Prefers the caller's ACTIVE organization over their personal one. Every other
+ * route already honours that org — `plugins/auth.ts` resolves it from
+ * `X-Organization-Id` for JWT sessions and from the bound org for `bb_sk_*`
+ * keys, and it is membership-validated there before it ever reaches us (a
+ * header naming an org the caller does not belong to is dropped, not honoured).
+ * The gateway previously ignored it and always billed personal, so a team's AI
+ * spend landed on whichever member happened to make the call and team-scoped
+ * pricing never applied.
+ *
+ * Falls back to the personal org when no active org is present, which is the
+ * pre-existing behaviour for callers that send no org context.
+ */
+async function resolveGatewayOrg(
+  controlDb: pg.Pool,
+  userId: string,
+  activeOrgId?: string | null,
+): Promise<string> {
+  if (activeOrgId) return activeOrgId;
   const r = await controlDb.query<{ personal_organization_id: string }>(
     'SELECT personal_organization_id FROM platform_users WHERE id = $1',
     [userId],
@@ -254,7 +275,7 @@ export async function gatewayRoutes(app: FastifyInstance) {
         startedAt,
       };
       const runtimePool = getRuntimeDbPool(config.runtimeDb, user.region);
-      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId);
+      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId, request.auth.organizationId);
       const { pct: markupPct, source: markupSource } = await resolveMarkupPct(app.controlDb, organizationId, body.model);
       const result = await routeChatCompletion(
         {
@@ -357,7 +378,7 @@ export async function gatewayRoutes(app: FastifyInstance) {
         startedAt,
       };
       const runtimePool = getRuntimeDbPool(config.runtimeDb, user.region);
-      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId);
+      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId, request.auth.organizationId);
       const { model: markupModel } = stripThinkingSuffix(body.model);
       const { pct: markupPct, source: markupSource } = await resolveMarkupPct(app.controlDb, organizationId, markupModel);
       const result = await routeMessages(
@@ -467,7 +488,7 @@ export async function gatewayRoutes(app: FastifyInstance) {
         startedAt,
       };
       const runtimePool = getRuntimeDbPool(config.runtimeDb, user.region);
-      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId);
+      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId, request.auth.organizationId);
       const { pct: markupPct, source: markupSource } = await resolveMarkupPct(app.controlDb, organizationId, body.model);
       const result = await routeResponses(
         { platformPool: app.controlDb, runtimePool, redis: getRedisClient(),
@@ -531,7 +552,7 @@ export async function gatewayRoutes(app: FastifyInstance) {
         startedAt,
       };
       const runtimePool = getRuntimeDbPool(config.runtimeDb, user.region);
-      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId);
+      const organizationId = await resolveGatewayOrg(app.controlDb, user.userId, request.auth.organizationId);
       const { pct: markupPct, source: markupSource } = await resolveMarkupPct(app.controlDb, organizationId, body.model);
       const result = await routeEmbedding(
         {


### PR DESCRIPTION
## Problem

The gateway resolved the billing organization as the caller's `personal_organization_id` on **all four** endpoints (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`), ignoring the active organization every other route already honours.

`plugins/auth.ts` resolves **and membership-validates** an active org before a request reaches any route — from `X-Organization-Id` for JWT sessions (silently dropping a header naming an org the caller isn't a member of) and from the bound org for `bb_sk_*` keys. The gateway then discarded it.

Two consequences:
- A team's AI spend was attributed to whichever member happened to make the call, rather than to the team.
- Org-scoped pricing never applied to team usage, because markup and credit gating both key off the organization threaded through here.

## Fix

Prefer the active organization; fall back to the personal one when the caller sends no org context — which preserves today's behaviour for every caller that sends none. No new authz surface: membership is already enforced upstream, so this only stops the override.

## Testing

- New `gateway.org-attribution.test.ts`: written first, watched fail (returned `org-personal` where `org-team` was expected), then passed. Covers both the active-org case and the personal-org fallback.
- `ai-router` + gateway routes: **375 passed**, no regressions.
- Production build order (`@butterbase/shared` → `mcp-server` → `control-api`) compiles clean.

## ⚠️ Rollout note

Team organizations that have never been billed for AI usage will begin consuming their own credits from the moment this ships. Any team already near its limit can hit a credits-exhausted soft-lock **without prior warning**. Worth a look at current team balances before merging.