### PR TITLE
fix(ai-router): stop dropping namespace-typed tools on /v1/responses

### DIFF
--- a/services/control-api/src/services/ai-router/responses-schema.ts
+++ b/services/control-api/src/services/ai-router/responses-schema.ts
@@ -14,6 +14,8 @@ const messageItem = z.object({
 const fnCall = z.object({
   type: z.literal('function_call'),
   call_id: z.string(), name: z.string(), arguments: z.string(),
+  /** Set when the tool came from a `type: "namespace"` group (e.g. Codex MCP tools). */
+  namespace: z.string().optional(),
 }).passthrough();
 
 const fnCallOut = z.object({
@@ -28,6 +30,8 @@ const tool = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
   parameters: z.record(z.unknown()).optional(),
+  /** Nested tools of a `type: "namespace"` group. */
+  tools: z.array(z.record(z.unknown())).optional(),
 }).passthrough();
 
 export const responsesRequestSchema = z.object({

--- a/services/control-api/src/services/ai-router/responses-sse.test.ts
+++ b/services/control-api/src/services/ai-router/responses-sse.test.ts
@@ -204,3 +204,53 @@ describe('translateCcStreamToResponsesSse', () => {
   });
 
 });
+
+describe('namespaced tool calls', () => {
+  const NS_TOOL_STREAM = [
+    'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"mcp__butterbase__manage_app","arguments":"{\\"a\\":"}}]}}]}\n\n',
+    'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]}}]}\n\n',
+    'data: {"id":"1","choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n',
+    'data: [DONE]\n\n',
+  ].join('');
+
+  it('emits separate name + namespace in SSE items and in the persisted body', async () => {
+    let final: any = null;
+    const s = translateCcStreamToResponsesSse({
+      id: 'rsp_abcdefgh',
+      model: 'm',
+      createdAt: 1,
+      ccStream: streamOf(NS_TOOL_STREAM),
+      namespaceTools: new Map([
+        ['mcp__butterbase__manage_app', { namespace: 'mcp__butterbase', name: 'manage_app' }],
+      ]),
+      onClose: async (f) => { final = f; },
+    });
+    const raw = await collect(s);
+    const items = [...raw.matchAll(/^data: (.+)$/gm)]
+      .map((m) => JSON.parse(m[1]))
+      .filter((e) => e.item?.type === 'function_call')
+      .map((e) => e.item);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.name).toBe('manage_app');
+      expect(item.namespace).toBe('mcp__butterbase');
+    }
+    expect(final.output[0].name).toBe('manage_app');
+    expect(final.output[0].namespace).toBe('mcp__butterbase');
+    expect(final.output[0].arguments).toBe('{"a":1}');
+  });
+
+  it('leaves a non-namespaced tool call untouched', async () => {
+    let final: any = null;
+    const s = translateCcStreamToResponsesSse({
+      id: 'rsp_abcdefgh',
+      model: 'm',
+      createdAt: 1,
+      ccStream: streamOf(NS_TOOL_STREAM),
+      onClose: async (f) => { final = f; },
+    });
+    await collect(s);
+    expect(final.output[0].name).toBe('mcp__butterbase__manage_app');
+    expect(final.output[0].namespace).toBeUndefined();
+  });
+});

--- a/services/control-api/src/services/ai-router/responses-sse.ts
+++ b/services/control-api/src/services/ai-router/responses-sse.ts
@@ -1,4 +1,8 @@
-import type { ResponsesResponseBody } from './responses-translate.js';
+import {
+  namespacedFunctionCall,
+  type NamespaceToolMap,
+  type ResponsesResponseBody,
+} from './responses-translate.js';
 
 export function translateCcStreamToResponsesSse(args: {
   id: string;
@@ -6,6 +10,8 @@ export function translateCcStreamToResponsesSse(args: {
   createdAt: number;
   previousResponseId?: string | null;
   ccStream: ReadableStream<Uint8Array>;
+  /** Flattened -> namespaced tool mapping from the request translation, if any. */
+  namespaceTools?: NamespaceToolMap;
   onClose: (final: ResponsesResponseBody) => Promise<void>;
 }): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
@@ -142,11 +148,8 @@ export function translateCcStreamToResponsesSse(args: {
        */
       for (const call of toolCalls.values()) {
         const item = {
-          type: 'function_call' as const,
+          ...namespacedFunctionCall(call.call_id, call.name, call.arguments, args.namespaceTools),
           id: `fc_${args.id.slice(4, 12)}_${outputIndex}`,
-          call_id: call.call_id,
-          name: call.name,
-          arguments: call.arguments,
         };
         controller.enqueue(evt('response.output_item.added', { output_index: outputIndex, item }));
         controller.enqueue(

--- a/services/control-api/src/services/ai-router/responses-translate.test.ts
+++ b/services/control-api/src/services/ai-router/responses-translate.test.ts
@@ -56,3 +56,97 @@ describe('chatCompletionResponseToResponses', () => {
 it('BUILTIN_TOOL_TYPES enumerates the four deferred tools', () => {
   expect(BUILTIN_TOOL_TYPES).toEqual(['web_search_preview', 'file_search', 'code_interpreter', 'computer_use_preview']);
 });
+
+describe('namespace tools', () => {
+  const nsTool = {
+    type: 'namespace',
+    name: 'mcp__butterbase',
+    description: 'Tools in the mcp__butterbase namespace.',
+    tools: [
+      { type: 'function', name: 'manage_app', description: 'manage apps', parameters: { type: 'object' } },
+      { type: 'function', name: 'select_rows', description: 'read rows', parameters: { type: 'object' } },
+    ],
+  };
+
+  it('expands namespace tools into flattened chat-completions functions', () => {
+    const cc = responsesRequestToChatCompletion(
+      { model: 'm', input: 'x', tools: [nsTool, { type: 'function', name: 'now', parameters: {} }] } as any,
+      null, null, null);
+    expect((cc.tools as any[]).map((t) => t.function.name)).toEqual([
+      'mcp__butterbase__manage_app', 'mcp__butterbase__select_rows', 'now',
+    ]);
+    expect((cc.tools as any[])[0].function.description).toBe('manage apps');
+    expect((cc.tools as any[])[0].function.parameters).toEqual({ type: 'object' });
+  });
+
+  it('records the flattened -> {namespace, name} mapping in the supplied map', () => {
+    const map = new Map<string, { namespace: string; name: string }>();
+    responsesRequestToChatCompletion(
+      { model: 'm', input: 'x', tools: [nsTool, { type: 'function', name: 'now', parameters: {} }] } as any,
+      null, null, null, map);
+    expect(map.get('mcp__butterbase__manage_app')).toEqual({ namespace: 'mcp__butterbase', name: 'manage_app' });
+    expect(map.get('mcp__butterbase__select_rows')).toEqual({ namespace: 'mcp__butterbase', name: 'select_rows' });
+    expect(map.has('now')).toBe(false);
+  });
+
+  it('still drops built-in tools nested alongside a namespace tool', () => {
+    const cc = responsesRequestToChatCompletion(
+      { model: 'm', input: 'x', tools: [{ type: 'file_search' }, nsTool] } as any,
+      null, null, null);
+    expect((cc.tools as any[]).map((t) => t.function.name)).toEqual([
+      'mcp__butterbase__manage_app', 'mcp__butterbase__select_rows',
+    ]);
+  });
+
+  it('re-flattens a namespaced function_call arriving in input history', () => {
+    const map = new Map<string, { namespace: string; name: string }>();
+    const cc = responsesRequestToChatCompletion(
+      {
+        model: 'm',
+        tools: [nsTool],
+        input: [
+          { type: 'function_call', call_id: 'call_1', name: 'manage_app', namespace: 'mcp__butterbase', arguments: '{"a":1}' },
+          { type: 'function_call_output', call_id: 'call_1', output: 'ok' },
+          { type: 'message', role: 'user', content: 'and now?' },
+        ],
+      } as any,
+      null, null, null, map);
+    expect((cc.messages[0] as any).tool_calls[0].function.name).toBe('mcp__butterbase__manage_app');
+    expect((cc.messages[1] as any).tool_call_id).toBe('call_1');
+  });
+
+  it('re-flattens a namespaced call whose namespace field was stripped, via the map', () => {
+    const map = new Map<string, { namespace: string; name: string }>();
+    const cc = responsesRequestToChatCompletion(
+      {
+        model: 'm',
+        tools: [nsTool],
+        input: [{ type: 'function_call', call_id: 'call_1', name: 'manage_app', arguments: '{}' }],
+      } as any,
+      null, null, null, map);
+    expect((cc.messages[0] as any).tool_calls[0].function.name).toBe('mcp__butterbase__manage_app');
+  });
+
+  it('emits separate name + namespace on the non-streaming response path', () => {
+    const map = new Map([['mcp__butterbase__manage_app', { namespace: 'mcp__butterbase', name: 'manage_app' }]]);
+    const body = chatCompletionResponseToResponses({
+      id: 'rsp_abcdefgh', model: 'm', createdAt: 1, previousResponseId: null,
+      cc: {
+        id: 'cc1',
+        choices: [{ message: { role: 'assistant', content: null, tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'mcp__butterbase__manage_app', arguments: '{}' } },
+          { id: 'call_2', type: 'function', function: { name: 'plain', arguments: '{}' } },
+        ] }, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      } as any,
+      namespaceTools: map,
+    });
+    expect(body.output[0]).toEqual({
+      type: 'function_call', call_id: 'call_1', name: 'manage_app',
+      namespace: 'mcp__butterbase', arguments: '{}',
+    });
+    expect(body.output[1]).toEqual({
+      type: 'function_call', call_id: 'call_2', name: 'plain', arguments: '{}',
+    });
+  });
+});

--- a/services/control-api/src/services/ai-router/responses-translate.ts
+++ b/services/control-api/src/services/ai-router/responses-translate.ts
@@ -4,6 +4,21 @@ import { toReasoningEffort, type Reasoning } from './reasoning.js';
 
 export const BUILTIN_TOOL_TYPES = ['web_search_preview', 'file_search', 'code_interpreter', 'computer_use_preview'] as const;
 
+/**
+ * Chat Completions has no notion of a tool namespace, so `type: "namespace"`
+ * tools (what the Codex CLI sends for MCP servers) are flattened to
+ * `<namespace>__<tool>` on the way in. This map remembers the way back:
+ * flattened name -> the namespace plus the tool's own name. It must be threaded
+ * explicitly rather than re-derived by splitting on `__`, because namespace
+ * names themselves contain `__` (e.g. `mcp__butterbase`) and the split is
+ * therefore ambiguous.
+ */
+export type NamespaceToolMap = Map<string, { namespace: string; name: string }>;
+
+export function flattenNamespacedToolName(namespace: string, name: string): string {
+  return `${namespace}__${name}`;
+}
+
 type CCMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string | null;
@@ -11,7 +26,24 @@ type CCMessage = {
   tool_calls?: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }>;
 };
 
-function itemsToMessages(items: unknown[]): CCMessage[] {
+/**
+ * Map a Responses `function_call` item back to the flattened chat-completions
+ * tool name. Prefers the item's own `namespace` field (what we emit, and what
+ * clients echo back); falls back to a unique reverse lookup in the map for
+ * clients that drop the field.
+ */
+function flattenCallName(it: Record<string, unknown>, ns: NamespaceToolMap | undefined): string {
+  const name = String(it.name);
+  if (typeof it.namespace === 'string' && it.namespace.length > 0) {
+    return flattenNamespacedToolName(it.namespace, name);
+  }
+  if (!ns) return name;
+  if (ns.has(name)) return name;
+  const matches = [...ns.entries()].filter(([, v]) => v.name === name);
+  return matches.length === 1 ? matches[0][0] : name;
+}
+
+function itemsToMessages(items: unknown[], ns?: NamespaceToolMap): CCMessage[] {
   const out: CCMessage[] = [];
   for (const it of items as Array<Record<string, unknown>>) {
     // priorInput rows are stored as raw CC user messages (no `type` field); priorOutput rows are Responses items. Accept both.
@@ -27,7 +59,7 @@ function itemsToMessages(items: unknown[]): CCMessage[] {
       out.push({
         role: 'assistant', content: null,
         tool_calls: [{ id: String(it.call_id), type: 'function',
-                       function: { name: String(it.name), arguments: String(it.arguments) } }],
+                       function: { name: flattenCallName(it, ns), arguments: String(it.arguments) } }],
       });
     } else if (it.type === 'function_call_output') {
       out.push({ role: 'tool', tool_call_id: String(it.call_id), content: String(it.output) });
@@ -41,18 +73,48 @@ export function responsesRequestToChatCompletion(
   priorInput: unknown[] | null,
   priorOutput: unknown[] | null,
   reasoning: Reasoning | null,
+  /** Optional out-param: populated with the flattened -> namespaced tool mapping. */
+  namespaceTools?: NamespaceToolMap,
 ): ChatCompletionRequest {
+  // Tools are resolved first: the namespace mapping they produce is needed to
+  // re-flatten `function_call` items replayed in the conversation history.
+  const tools = req.tools?.flatMap((t) => {
+    if (t.type === 'function') {
+      return [{
+        type: 'function' as const,
+        function: { name: t.name!, description: t.description ?? '', parameters: t.parameters ?? {} },
+      }];
+    }
+    if (t.type === 'namespace') {
+      const nested = (t as { tools?: Array<Record<string, unknown>> }).tools ?? [];
+      const namespace = t.name ?? '';
+      return nested
+        .filter((n) => n.type === 'function' && typeof n.name === 'string')
+        .map((n) => {
+          const inner = String(n.name);
+          const flat = flattenNamespacedToolName(namespace, inner);
+          namespaceTools?.set(flat, { namespace, name: inner });
+          return {
+            type: 'function' as const,
+            function: {
+              name: flat,
+              description: typeof n.description === 'string' ? n.description : '',
+              parameters: (n.parameters as Record<string, unknown> | undefined) ?? {},
+            },
+          };
+        });
+    }
+    // Built-in tool types (and anything else unknown) are dropped; the caller
+    // is responsible for rejecting them up front.
+    return [];
+  });
+
   const messages: CCMessage[] = [];
   if (req.instructions) messages.push({ role: 'system', content: req.instructions });
-  if (priorInput) messages.push(...itemsToMessages(priorInput));
-  if (priorOutput) messages.push(...itemsToMessages(priorOutput));
+  if (priorInput) messages.push(...itemsToMessages(priorInput, namespaceTools));
+  if (priorOutput) messages.push(...itemsToMessages(priorOutput, namespaceTools));
   if (typeof req.input === 'string') messages.push({ role: 'user', content: req.input });
-  else messages.push(...itemsToMessages(req.input));
-
-  const tools = req.tools?.filter(t => t.type === 'function').map(t => ({
-    type: 'function' as const,
-    function: { name: t.name!, description: t.description ?? '', parameters: t.parameters ?? {} },
-  }));
+  else messages.push(...itemsToMessages(req.input, namespaceTools));
 
   const cc: Record<string, unknown> = {
     model: req.model, messages,
@@ -82,7 +144,10 @@ export interface ResponsesResponseBody {
     type: 'function_call';
     /** Item id. Optional: the non-streaming path does not mint one. */
     id?: string;
-    call_id: string; name: string; arguments: string;
+    call_id: string; name: string;
+    /** Present only for tools that arrived inside a `type: "namespace"` group. */
+    namespace?: string;
+    arguments: string;
   }>;
   usage: { input_tokens: number; output_tokens: number; total_tokens: number; reasoning_tokens?: number };
 }
@@ -106,6 +171,7 @@ type CCResponse = {
 
 export function chatCompletionResponseToResponses(args: {
   id: string; model: string; createdAt: number; previousResponseId: string | null; cc: CCResponse;
+  namespaceTools?: NamespaceToolMap;
 }): ResponsesResponseBody {
   const ch = args.cc.choices[0];
   const output: ResponsesResponseBody['output'] = [];
@@ -116,7 +182,7 @@ export function chatCompletionResponseToResponses(args: {
     });
   }
   for (const tc of ch.message.tool_calls ?? []) {
-    output.push({ type: 'function_call', call_id: tc.id, name: tc.function.name, arguments: tc.function.arguments });
+    output.push(namespacedFunctionCall(tc.id, tc.function.name, tc.function.arguments, args.namespaceTools));
   }
   const u = args.cc.usage;
   const usage: ResponsesResponseBody['usage'] = {
@@ -131,4 +197,22 @@ export function chatCompletionResponseToResponses(args: {
     model: args.model, previous_response_id: args.previousResponseId,
     output, usage,
   };
+}
+
+/**
+ * Build a Responses `function_call` item, splitting a flattened name back into
+ * separate `name` + `namespace` fields when it came from a namespace group.
+ * Codex rejects a flattened, bare, or dotted single name (`unsupported call`);
+ * only the two-field shape routes correctly.
+ */
+export function namespacedFunctionCall(
+  callId: string,
+  flatName: string,
+  argumentsJson: string,
+  ns?: NamespaceToolMap,
+): { type: 'function_call'; call_id: string; name: string; namespace?: string; arguments: string } {
+  const hit = ns?.get(flatName);
+  return hit
+    ? { type: 'function_call', call_id: callId, name: hit.name, namespace: hit.namespace, arguments: argumentsJson }
+    : { type: 'function_call', call_id: callId, name: flatName, arguments: argumentsJson };
 }

--- a/services/control-api/src/services/ai-router/responses.test.ts
+++ b/services/control-api/src/services/ai-router/responses.test.ts
@@ -70,6 +70,43 @@ describe('routeResponses', () => {
     expect((r.body as any).output[0].content[0].text).toBe('hi');
   });
 
+  it('threads the namespace map from request translation into the response', async () => {
+    vi.mocked(routeChatCompletion).mockResolvedValueOnce({
+      status: 200,
+      chosen: 'openrouter',
+      body: {
+        id: 'cc_x',
+        choices: [{
+          message: {
+            role: 'assistant', content: null,
+            tool_calls: [{ id: 'call_1', type: 'function',
+              function: { name: 'mcp__butterbase__manage_app', arguments: '{}' } }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      },
+    } as any);
+
+    const r = await routeResponses({ runtimePool: {} } as any, {
+      model: 'openai/gpt-4o',
+      input: 'hi',
+      tools: [{
+        type: 'namespace', name: 'mcp__butterbase',
+        tools: [{ type: 'function', name: 'manage_app', parameters: {} }],
+      }],
+    } as any);
+
+    // The model saw the flattened tool...
+    const sent = vi.mocked(routeChatCompletion).mock.calls.at(-1)![1] as any;
+    expect(sent.tools.map((t: any) => t.function.name)).toEqual(['mcp__butterbase__manage_app']);
+    // ...and the client gets it back split into name + namespace.
+    expect(r.status).toBe(200);
+    expect((r.body as any).output[0]).toMatchObject({
+      type: 'function_call', name: 'manage_app', namespace: 'mcp__butterbase',
+    });
+  });
+
   it('streaming branch: returns a stream and calls insertResponseRow after drain', async () => {
     const mockInsert = vi.mocked(insertResponseRow);
     mockInsert.mockClear();
@@ -92,5 +129,45 @@ describe('routeResponses', () => {
 
     await drainStream(r.stream!);
     expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('streaming branch: threads the namespace map into the SSE translator', async () => {
+    const ccLines = [
+      'data: {"id":"cc1","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"mcp__butterbase__manage_app","arguments":"{}"}}]}}]}\n\n',
+      'data: {"id":"cc1","choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n',
+      'data: [DONE]\n\n',
+    ].join('');
+    vi.mocked(routeChatCompletion).mockResolvedValueOnce({
+      status: 200,
+      chosen: 'openrouter',
+      stream: new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(ccLines));
+          c.close();
+        },
+      }),
+    } as any);
+
+    const r = await routeResponses({ runtimePool: {} } as any, {
+      model: 'openai/gpt-4o',
+      input: 'hi',
+      stream: true,
+      tools: [{
+        type: 'namespace', name: 'mcp__butterbase',
+        tools: [{ type: 'function', name: 'manage_app', parameters: {} }],
+      }],
+    } as any);
+
+    const reader = r.stream!.getReader();
+    const dec = new TextDecoder();
+    let raw = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      raw += dec.decode(value);
+    }
+    expect(raw).toContain('"namespace":"mcp__butterbase"');
+    expect(raw).toContain('"name":"manage_app"');
+    expect(raw).not.toContain('"name":"mcp__butterbase__manage_app"');
   });
 });

--- a/services/control-api/src/services/ai-router/responses.ts
+++ b/services/control-api/src/services/ai-router/responses.ts
@@ -5,6 +5,7 @@ import {
   responsesRequestToChatCompletion,
   chatCompletionResponseToResponses,
   BUILTIN_TOOL_TYPES,
+  type NamespaceToolMap,
   type ResponsesResponseBody,
 } from './responses-translate.js';
 import { parseReasoningFromBody } from './reasoning.js';
@@ -68,7 +69,15 @@ export async function routeResponses(
   }
 
   const reasoning = parseReasoningFromBody(req as unknown as Record<string, unknown>);
-  const ccReq = responsesRequestToChatCompletion(req, priorInput, priorOutput, reasoning);
+  /**
+   * Built here so both halves of the translation share one mapping: the request
+   * translation flattens `type: "namespace"` tools into it, and the response
+   * translation reads it back to split a called tool into `name` + `namespace`.
+   * Deriving it from the flattened string instead would be ambiguous —
+   * namespace names contain `__` themselves.
+   */
+  const namespaceTools: NamespaceToolMap = new Map();
+  const ccReq = responsesRequestToChatCompletion(req, priorInput, priorOutput, reasoning, namespaceTools);
   const id = generateResponseId();
   const createdAt = nowSeconds();
 
@@ -81,6 +90,7 @@ export async function routeResponses(
       createdAt,
       previousResponseId: req.previous_response_id ?? null,
       ccStream: cc.stream,
+      namespaceTools,
       onClose: async (finalBody) => {
         await insertResponseRow(ctx.runtimePool, {
           id,
@@ -111,6 +121,7 @@ export async function routeResponses(
     createdAt,
     previousResponseId: req.previous_response_id ?? null,
     cc: cc.body as any,
+    namespaceTools,
   });
   await insertResponseRow(ctx.runtimePool, {
     id,


### PR DESCRIPTION
## Problem

`responses-translate.ts` kept only `type: "function"` tools and silently discarded everything else:

```ts
req.tools?.filter(t => t.type === 'function')
```

Clients that group tools in a namespace lose them entirely — no error, no warning, the tools simply aren't there. OpenAI's Codex CLI does exactly this for MCP tools:

```json
{"type":"namespace","name":"mcp__butterbase",
 "tools":[{"type":"function","name":"manage_app", ...}]}
```

So the whole group was thrown away and the model never saw those tools. This is live on `/v1/responses` today.

## The fix, and why this exact shape

Determined empirically against real Codex CLI 0.149.1 — four return shapes tested, only the last works:

| Shape returned | Codex |
|---|---|
| flattened `mcp__butterbase__manage_app` | `unsupported call` |
| bare `manage_app` | `unsupported call` |
| dotted `mcp__butterbase.manage_app` | `unsupported call` |
| **separate `name` + `namespace` fields** | **routes correctly** |

This matches the Responses API contract: a namespaced call carries separate `name` and `namespace` fields rather than a flattened single name.

**Inbound:** expand `type:"namespace"` tools into their nested function tools (chat-completions has no namespace concept), recording a flattened-name → `{namespace, name}` map. `BUILTIN_TOOL_TYPES` are still dropped — the existing test asserting that still passes.

**Outbound:** emit the `function_call` item with `name` = inner name and `namespace` = namespace name, on **both** the non-streaming and streaming paths (including the persisted final body that `previous_response_id` replays).

**The map is threaded explicitly, never re-derived by splitting `__`** — namespace names contain `__` themselves (`mcp__butterbase`), so splitting is ambiguous. `routeResponses` owns the map; it's optional on every signature, so existing callers are unchanged.

History `function_call` items are mapped back to the flattened name on later turns, so multi-turn conversations don't break on turn two.

## Testing

- **345 passed** (up from 335); 10 new tests — 6 translate, 2 SSE, 2 end-to-end via `routeResponses` — each written RED first.
- Production build order compiles clean.
- **Verified end to end with real Codex** driving these exact modules:
  `MCP ROUTED -> server=butterbase tool=manage_app status=completed`, tool result returned, model answered from it. Before the fix the tool never reached the model at all.

## Known limitations (deliberate)

- A built-in tool nested *inside* a namespace is dropped rather than 400'd; `routeResponses`'s `unsupported_tool` check only inspects top-level tools. Codex doesn't nest built-ins today, and rejecting there would widen behaviour beyond this fix.
- History `function_call` items lacking a `namespace` field resolve by reverse lookup only when exactly one namespaced tool has that inner name; genuine collisions pass through unflattened rather than guess.