### PR TITLE
fix(ai-router): stop unpriced chat routes settling at $0, and pin qwen3.8-flash

### DIFF
--- a/db/runtime-plane/049_ai_usage_cost_source.sql
+++ b/db/runtime-plane/049_ai_usage_cost_source.sql
@@ -1,0 +1,31 @@
+-- @scope: runtime
+-- 049: Record WHERE provider_cost_usd came from on each charge:
+--   'upstream'          — the provider reported the real cost for this call
+--                         (OpenRouter usage.cost, provider-secondary's and
+--                         provider-tertiary's billing ledgers)
+--   'catalog'           — the provider reports no cost, so we multiplied the
+--                         router's own published per-Mtok rates by the tokens
+--   'catalog_inherited' — same, but the rates were not the router's own: they
+--                         were copied from a priced sibling at catalog-refresh
+--                         time because this upstream publishes no rate card
+--   'catalog_unpriced'  — estimated against a route with NO price at all, so
+--                         the charge came out $0. Always a bug; the reconciler
+--                         should treat these as unbilled, not as free calls.
+--
+-- Why: provider_cost_usd is a single NUMERIC with no provenance, so a real
+-- settled cost is indistinguishable from a guess, and a $0 row from a genuinely
+-- free call. Without this column there is no way to ask "which charges do we
+-- still need to reconcile against the vendor's actual bill?" — the exact
+-- question Alibaba Model Studio forces on us, since it reports no per-call cost
+-- at all and only publishes minute-level aggregates.
+--
+-- Nullable: rows written before this migration have no recorded source. Read a
+-- NULL as "unknown, pre-049" rather than as 'upstream'.
+ALTER TABLE ai_usage_logs ADD COLUMN IF NOT EXISTS cost_source text;
+
+-- Reconciliation queue: the inferred rows, newest first. Partial so it stays
+-- small — the overwhelming majority of rows are 'upstream' and never queried
+-- through this path.
+CREATE INDEX IF NOT EXISTS ai_usage_logs_cost_source_unreconciled_idx
+  ON ai_usage_logs (created_at DESC)
+  WHERE cost_source IN ('catalog', 'catalog_inherited', 'catalog_unpriced');

--- a/services/control-api/src/routes/ai-images.ts
+++ b/services/control-api/src/routes/ai-images.ts
@@ -14,6 +14,7 @@ import {
   RouterError, InsufficientCreditsError,
   type RouteContext,
 } from '../services/ai-router/router.js';
+import type { CostSource } from '../services/ai-router/cost-source.js';
 import { readCatalogEntry } from '../services/ai-router/catalog.js';
 import { openrouterAdapter } from '../services/ai-router/adapters/openrouter.js';
 import type { RouterAdapter } from '../services/ai-router/adapters/types.js';
@@ -200,7 +201,10 @@ export async function aiImageRoutes(app: FastifyInstance) {
           { platformPool: app.controlDb, runtimePool, redis: getRedisClient(),
             adapters, markupPct, markupSource,
             appId, organizationId, userId: ownerId, region },
-          { leaseId: submit.leaseId, chosenRouter: submit.chosenRouter, canonicalModel: body.model, providerCostUsd: cost },
+          { leaseId: submit.leaseId, chosenRouter: submit.chosenRouter, canonicalModel: body.model, providerCostUsd: cost,
+            // No catalog fallback on this path — the cost is whatever the
+            // upstream reported inline, else $0.
+            costSource: inline.providerCostUsd !== undefined ? 'upstream' : 'catalog_unpriced' },
         );
       }
 
@@ -335,6 +339,9 @@ export async function pollAndSettleImageJob(
   //   3) $0 as final guard — only `failed`/`cancelled` paths, where charging
   //      would be wrong anyway.
   let providerCost = poll.providerCostUsd ?? 0;
+  // Provenance for migration 049. Starts as whatever the branch above produced:
+  // an upstream-reported cost, or $0 pending the catalog fallback below.
+  let costSource: CostSource = poll.providerCostUsd !== undefined ? 'upstream' : 'catalog_unpriced';
   if (poll.providerCostUsd === undefined && poll.status === 'completed') {
     const entry = await readCatalogEntry(ctx.redis, job.model);
     if (entry) {
@@ -343,7 +350,7 @@ export async function pollAndSettleImageJob(
         job.request_json as unknown as import('../services/ai-router/adapters/types.js').ImageGenerationRequest,
         job.upstream_router as RouterName,
       );
-      if (billed !== null) providerCost = billed;
+      if (billed !== null) { providerCost = billed; costSource = 'catalog'; }
     }
   }
 
@@ -362,6 +369,7 @@ export async function pollAndSettleImageJob(
       chosenRouter: job.upstream_router as RouterName,
       canonicalModel: job.model,
       providerCostUsd: providerCost,
+      costSource,
     });
   }
   return { status: poll.status, terminal: true };

--- a/services/control-api/src/routes/ai-videos.ts
+++ b/services/control-api/src/routes/ai-videos.ts
@@ -14,6 +14,7 @@ import {
   RouterError, InsufficientCreditsError,
   type RouteContext,
 } from '../services/ai-router/router.js';
+import type { CostSource } from '../services/ai-router/cost-source.js';
 import { readCatalogEntry } from '../services/ai-router/catalog.js';
 import { openrouterAdapter } from '../services/ai-router/adapters/openrouter.js';
 import type { RouterAdapter } from '../services/ai-router/adapters/types.js';
@@ -344,6 +345,9 @@ export async function pollAndSettleVideoJob(
   //   3) $0 as final guard — only `failed`/`cancelled` paths, where
   //      charging would be wrong anyway.
   let providerCost = poll.providerCostUsd ?? 0;
+  // Provenance for migration 049. Starts as whatever the branch above produced:
+  // an upstream-reported cost, or $0 pending the catalog fallback below.
+  let costSource: CostSource = poll.providerCostUsd !== undefined ? 'upstream' : 'catalog_unpriced';
   if (poll.providerCostUsd === undefined && poll.status === 'completed') {
     const entry = await readCatalogEntry(ctx.redis, job.model);
     if (entry) {
@@ -352,7 +356,7 @@ export async function pollAndSettleVideoJob(
         job.request_json as unknown as import('../services/ai-router/adapters/types.js').VideoGenerationRequest,
         job.upstream_router as RouterName,
       );
-      if (billed !== null) providerCost = billed;
+      if (billed !== null) { providerCost = billed; costSource = 'catalog'; }
     }
   }
 
@@ -370,6 +374,7 @@ export async function pollAndSettleVideoJob(
       chosenRouter: job.upstream_router as RouterName,
       canonicalModel: job.model,
       providerCostUsd: providerCost,
+      costSource,
     });
   }
   return { status: poll.status, terminal: true };

--- a/services/control-api/src/services/ai-router/catalog.test.ts
+++ b/services/control-api/src/services/ai-router/catalog.test.ts
@@ -3,8 +3,10 @@ import { Redis } from 'ioredis';
 import {
   readCatalogEntry, listCatalogModels, writeCatalog, readEnabledRouters,
   tryAcquireRefreshLock, releaseRefreshLock, recordUnknownId,
+  inheritMissingChatPrices,
   type CatalogEntry,
 } from './catalog.js';
+import type { CatalogRouter } from './select.js';
 
 const RUN_REDIS_TESTS = process.env.RUN_REDIS_TESTS === '1' || process.env.RUN_DB_TESTS === '1';
 const describeRedis = RUN_REDIS_TESTS ? describe : describe.skip;
@@ -76,5 +78,109 @@ describeRedis('catalog', () => {
     await recordUnknownId(redis, 'provider-primary', 'weird-model-2');
     const members = await redis.smembers('ai_catalog:unknown');
     expect(members.sort()).toEqual(['provider-primary:weird-model-1', 'provider-primary:weird-model-2']);
+  });
+});
+
+
+// Pure — no Redis, so these always run.
+describe('inheritMissingChatPrices', () => {
+  const chat = (over: Partial<CatalogRouter>): CatalogRouter => ({
+    name: 'openrouter', upstreamId: 'u', promptPricePerMtok: 0,
+    completionPricePerMtok: 0, contextLength: 0, modality: 'chat', ...over,
+  } as CatalogRouter);
+
+  it('fills an unpriced chat route from a priced sibling', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 }),
+      chat({ name: 'provider-tertiary' }),
+    ]);
+    const t = out.find(r => r.name === 'provider-tertiary')!;
+    expect(t.promptPricePerMtok).toBe(0.15);
+    expect(t.completionPricePerMtok).toBe(0.47);
+    expect(t.priceInheritedFrom).toBe('openrouter');
+  });
+
+  it('leaves the donor untouched', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 }),
+      chat({ name: 'provider-tertiary' }),
+    ]);
+    const d = out.find(r => r.name === 'openrouter')!;
+    expect(d.priceInheritedFrom).toBeUndefined();
+    expect(d.promptPricePerMtok).toBe(0.15);
+  });
+
+  it('prefers openrouter as donor even when a cheaper sibling exists', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'provider-secondary', promptPricePerMtok: 0.01, completionPricePerMtok: 0.02 }),
+      chat({ name: 'openrouter', promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 }),
+      chat({ name: 'provider-tertiary' }),
+    ]);
+    expect(out.find(r => r.name === 'provider-tertiary')!.priceInheritedFrom).toBe('openrouter');
+    expect(out.find(r => r.name === 'provider-tertiary')!.promptPricePerMtok).toBe(0.15);
+  });
+
+  it('falls back to the CHEAPEST sibling when openrouter is absent', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'provider-quaternary', promptPricePerMtok: 2, completionPricePerMtok: 6 }),
+      chat({ name: 'provider-secondary', promptPricePerMtok: 0.5, completionPricePerMtok: 1 }),
+      chat({ name: 'provider-tertiary' }),
+    ]);
+    const t = out.find(r => r.name === 'provider-tertiary')!;
+    // cheapest by prompt + 3*completion: secondary 3.5 vs quaternary 20
+    expect(t.priceInheritedFrom).toBe('provider-secondary');
+    expect(t.promptPricePerMtok).toBe(0.5);
+  });
+
+  it('never touches video rows — 0/0 there is by design, priced via rawPricing', () => {
+    const video: CatalogRouter = {
+      name: 'provider-tertiary', upstreamId: 'seedance-2.0', promptPricePerMtok: 0,
+      completionPricePerMtok: 0, contextLength: 0, modality: 'video',
+      rawPricing: { unit: 'second', variants: [] },
+    } as CatalogRouter;
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 }),
+      video,
+    ]);
+    const v = out.find(r => r.modality === 'video')!;
+    expect(v.promptPricePerMtok).toBe(0);
+    expect(v.completionPricePerMtok).toBe(0);
+    expect(v.priceInheritedFrom).toBeUndefined();
+  });
+
+  it('skips rows carrying rawPricing even when modality says chat', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 }),
+      chat({ name: 'provider-secondary', rawPricing: { unit: 'image' } }),
+    ]);
+    expect(out.find(r => r.name === 'provider-secondary')!.priceInheritedFrom).toBeUndefined();
+  });
+
+  it('treats a missing modality as chat (legacy rows)', () => {
+    const legacy = { name: 'provider-tertiary', upstreamId: 'u', promptPricePerMtok: 0,
+      completionPricePerMtok: 0, contextLength: 0 } as CatalogRouter;
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 1, completionPricePerMtok: 2 }),
+      legacy,
+    ]);
+    expect(out.find(r => r.name === 'provider-tertiary')!.priceInheritedFrom).toBe('openrouter');
+  });
+
+  it('is a no-op when no sibling has a price', () => {
+    const input = [chat({ name: 'openrouter' }), chat({ name: 'provider-tertiary' })];
+    expect(inheritMissingChatPrices(input)).toEqual(input);
+  });
+
+  it('is a no-op for a single priced router', () => {
+    const input = [chat({ name: 'openrouter', promptPricePerMtok: 1, completionPricePerMtok: 2 })];
+    expect(inheritMissingChatPrices(input)).toEqual(input);
+  });
+
+  it('inherits when only the completion price is non-zero', () => {
+    const out = inheritMissingChatPrices([
+      chat({ name: 'openrouter', promptPricePerMtok: 0, completionPricePerMtok: 0.47 }),
+      chat({ name: 'provider-tertiary' }),
+    ]);
+    expect(out.find(r => r.name === 'provider-tertiary')!.completionPricePerMtok).toBe(0.47);
   });
 });

--- a/services/control-api/src/services/ai-router/catalog.ts
+++ b/services/control-api/src/services/ai-router/catalog.ts
@@ -123,6 +123,57 @@ export interface RefreshResult {
  * Caller is responsible for lock acquisition (tryAcquireRefreshLock) when
  * coordinating with the cron refresher.
  */
+/**
+ * Fill in per-Mtok prices for chat routes whose upstream publishes none.
+ *
+ * Some routers settle from an authoritative post-call cost (OpenRouter's
+ * `usage.cost`, provider-secondary's and provider-tertiary's billing ledgers)
+ * and therefore have no reason to publish a rate card. Their catalog rows
+ * legitimately carry 0/0. That is fine right up until the cost lookup fails —
+ * `router.ts` then falls back to `estimateWorstCaseUsd`, which multiplies by
+ * those zeros and settles the call at $0. The customer is billed nothing and
+ * we still pay the upstream, with nothing logged.
+ *
+ * So an unpriced chat route borrows a priced sibling's rates as a
+ * last-resort estimate. It is never the billing basis when the real cost is
+ * available — only the floor under a failed lookup.
+ *
+ * Donor preference:
+ *   1. `openrouter`, when it offers the same model. It is the closest thing to
+ *      a public reference rate for a canonical id.
+ *   2. otherwise the CHEAPEST priced sibling, by the same prompt + 3x
+ *      completion weighting the ranker uses. Cheapest rather than dearest so a
+ *      failed lookup cannot silently overcharge; it can only under-recover,
+ *      which is the direction we already tolerate.
+ *
+ * Non-chat rows are left strictly alone. Video rows carry 0/0 by design and
+ * price per second via `rawPricing`; copying token rates onto them would
+ * invent a charge that does not exist. Rows carrying `rawPricing` are skipped
+ * for the same reason.
+ */
+export function inheritMissingChatPrices(routers: CatalogRouter[]): CatalogRouter[] {
+  const isChat = (r: CatalogRouter) => (r.modality ?? 'chat') === 'chat' && r.rawPricing === undefined;
+  const isPriced = (r: CatalogRouter) => r.promptPricePerMtok > 0 || r.completionPricePerMtok > 0;
+  const weight = (r: CatalogRouter) => r.promptPricePerMtok + 3 * r.completionPricePerMtok;
+
+  const donors = routers.filter(r => isChat(r) && isPriced(r));
+  if (donors.length === 0) return routers;
+
+  const donor =
+    donors.find(d => d.name === 'openrouter')
+    ?? [...donors].sort((a, b) => weight(a) - weight(b) || a.name.localeCompare(b.name))[0];
+
+  return routers.map(r => {
+    if (!isChat(r) || isPriced(r) || r.name === donor.name) return r;
+    return {
+      ...r,
+      promptPricePerMtok: donor.promptPricePerMtok,
+      completionPricePerMtok: donor.completionPricePerMtok,
+      priceInheritedFrom: donor.name,
+    };
+  });
+}
+
 export async function refreshCatalog(
   redis: Redis,
   adapters: RouterAdapter[],
@@ -164,7 +215,7 @@ export async function refreshCatalog(
     canonicalId,
     displayName: v.displayName,
     updatedAt: now,
-    routers: v.routers,
+    routers: inheritMissingChatPrices(v.routers),
   }));
 
   await writeCatalog(redis, entries, statuses);

--- a/services/control-api/src/services/ai-router/cost-source.test.ts
+++ b/services/control-api/src/services/ai-router/cost-source.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { classifyCostSource } from './cost-source.js';
+
+const priced = { promptPricePerMtok: 0.15, completionPricePerMtok: 0.47 };
+const inherited = { ...priced, priceInheritedFrom: 'openrouter' };
+const unpriced = { promptPricePerMtok: 0, completionPricePerMtok: 0 };
+
+describe('classifyCostSource', () => {
+  it('upstream when the provider reported a cost', () => {
+    expect(classifyCostSource(0.000051, priced)).toBe('upstream');
+  });
+
+  it('upstream even when the reported cost is legitimately 0', () => {
+    // A free model really can cost $0. That must not be confused with the
+    // failure case below, which is why we branch on null, not falsiness.
+    expect(classifyCostSource(0, priced)).toBe('upstream');
+  });
+
+  it('catalog when estimated against the route own published rates', () => {
+    expect(classifyCostSource(null, priced)).toBe('catalog');
+    expect(classifyCostSource(undefined, priced)).toBe('catalog');
+  });
+
+  it('catalog_inherited when the rates were borrowed from a sibling', () => {
+    expect(classifyCostSource(null, inherited)).toBe('catalog_inherited');
+  });
+
+  it('catalog_unpriced when the route carries no price — the $0 bug', () => {
+    expect(classifyCostSource(null, unpriced)).toBe('catalog_unpriced');
+  });
+
+  it('catalog_unpriced when there is no route at all', () => {
+    expect(classifyCostSource(null, undefined)).toBe('catalog_unpriced');
+  });
+
+  it('counts a route priced on only one side as priced', () => {
+    expect(classifyCostSource(null, { promptPricePerMtok: 0, completionPricePerMtok: 0.47 })).toBe('catalog');
+  });
+});
+
+describe('cost_source stays internal', () => {
+  // It is billing provenance, not customer data: a customer must never be able
+  // to see which of their charges we inferred.
+  const files = [
+    'src/services/ai-usage-logger.ts',
+    'src/services/billing-service.ts',
+    'src/routes/ai-config.ts',
+    'src/routes/gateway.ts',
+  ];
+
+  it('is not projected by any customer-facing usage reader', () => {
+    for (const f of files) {
+      const src = readFileSync(new URL(`../../../${f}`, import.meta.url), 'utf8');
+      expect(src, `${f} must not select cost_source`).not.toMatch(/cost_source/);
+    }
+  });
+
+  it('no reader uses SELECT * on ai_usage_logs, which would leak it implicitly', () => {
+    for (const f of files) {
+      const src = readFileSync(new URL(`../../../${f}`, import.meta.url), 'utf8');
+      expect(src, `${f} must not SELECT * from ai_usage_logs`)
+        .not.toMatch(/select\s+\*[\s\S]{0,200}?from\s+ai_usage_logs/i);
+    }
+  });
+});

--- a/services/control-api/src/services/ai-router/cost-source.ts
+++ b/services/control-api/src/services/ai-router/cost-source.ts
@@ -1,0 +1,33 @@
+/**
+ * Provenance of a settled `provider_cost_usd`.
+ *
+ * Lives in its own module rather than in usage-log.ts because callers that
+ * classify a cost are not always callers that write a usage row, and because
+ * usage-log.ts is `vi.mock`ed wholesale in the router tests — a pure function
+ * parked there would vanish behind the mock.
+ */
+/**
+ * Where a row's `provider_cost_usd` came from. Mirrors migration 049.
+ *
+ *   upstream          the provider reported the real cost for this call
+ *   catalog           estimated from the chosen router's own published rates
+ *   catalog_inherited  estimated from rates copied off a priced sibling, because
+ *                     this upstream publishes no rate card of its own
+ *   catalog_unpriced  estimated against a route with no price at all, so the
+ *                     charge came out $0 — always a bug, never a free call
+ */
+export type CostSource = 'upstream' | 'catalog' | 'catalog_inherited' | 'catalog_unpriced';
+
+/**
+ * Classify a settled cost. `route` is the catalog row actually billed against —
+ * pass the same one handed to estimateWorstCaseUsd, or the ranked head.
+ */
+export function classifyCostSource(
+  providerReportedCost: number | null | undefined,
+  route: { promptPricePerMtok: number; completionPricePerMtok: number; priceInheritedFrom?: unknown } | undefined,
+): CostSource {
+  if (providerReportedCost !== null && providerReportedCost !== undefined) return 'upstream';
+  if (!route) return 'catalog_unpriced';
+  if (route.promptPricePerMtok <= 0 && route.completionPricePerMtok <= 0) return 'catalog_unpriced';
+  return route.priceInheritedFrom ? 'catalog_inherited' : 'catalog';
+}

--- a/services/control-api/src/services/ai-router/messages.ts
+++ b/services/control-api/src/services/ai-router/messages.ts
@@ -16,6 +16,7 @@ import { estimatePromptTokens } from './tokenizer.js';
 import { settleAfterCall, leaseTtlSeconds } from './billing-gate.js';
 import type { LeaseHandle } from './billing-gate.js';
 import { writeAiUsageRow } from './usage-log.js';
+import { classifyCostSource } from './cost-source.js';
 import { applyMarkup } from './markup.js';
 import { maybeTriggerAutoRefill } from '../auto-refill-service.js';
 
@@ -67,7 +68,10 @@ function wrapNativeAnthropicStreamForSettlement(
     if (settled) return;
     settled = true;
     try {
+      // This path has no upstream-reported cost at all, so it is always an
+      // estimate against `pricing`.
       const providerCost = estimateWorstCaseUsd(pricing, inputTokens, outputTokens, cacheReadTokens, cacheCreateTokens);
+      const costSource = classifyCostSource(null, pricing);
       const chargedCredits = applyMarkup(providerCost, ctx.markupPct);
       await settleAfterCall(ctx.platformPool, lease, chargedCredits);
       maybeTriggerAutoRefill({ pool: ctx.platformPool, redis: ctx.redis }, ctx.organizationId)
@@ -83,7 +87,7 @@ function wrapNativeAnthropicStreamForSettlement(
         promptTokens: inputTokens, completionTokens: outputTokens,
         totalTokens: inputTokens + outputTokens,
         providerCostUsd: providerCost, chargedCreditsUsd: chargedCredits,
-        markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain: [], leaseId: lease.leaseId,
+        markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource, fallbackChain: [], leaseId: lease.leaseId,
         keyType: 'platform', chargedToUser: true,
         cacheReadInputTokens: cacheReadTokens,
         cacheCreationInputTokens: cacheCreateTokens,
@@ -222,6 +226,7 @@ export async function routeMessages(
       };
     })();
 
+    const costSource = classifyCostSource(result.providerCostUsd, native.router);
     const providerCost = result.providerCostUsd
       ?? estimateWorstCaseUsd(
         native.router,
@@ -243,7 +248,7 @@ export async function routeMessages(
       promptTokens: usage.promptTokens, completionTokens: usage.completionTokens,
       totalTokens: usage.promptTokens + usage.completionTokens,
       providerCostUsd: providerCost, chargedCreditsUsd: chargedCredits,
-      markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain: [], leaseId: lease.leaseId,
+      markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource, fallbackChain: [], leaseId: lease.leaseId,
       keyType: 'platform', chargedToUser: true,
       cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
       cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -17,6 +17,7 @@ import { applyMarkup } from './markup.js';
 import type { MarkupSource } from './special-pricing.js';
 import { acquireForEstimatedCost, acquireNominal, settleAfterCall, leaseTtlSeconds, InsufficientCreditsError } from './billing-gate.js';
 import { writeAiUsageRow } from './usage-log.js';
+import { classifyCostSource, type CostSource } from './cost-source.js';
 import { pickProviderCost } from './adapters/openrouter.js';
 import { logAuditEvent } from '../audit/audit-events-service.js';
 import { maybeTriggerAutoRefill } from '../auto-refill-service.js';
@@ -292,6 +293,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
   if (result.stream) {
     const wrapped = wrapStreamForSettlement(result.stream, async (usage, providerCost) => {
       const cost = providerCost ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cacheReadInputTokens ?? 0, usage.cacheCreationInputTokens ?? 0);
+      const costSource = classifyCostSource(providerCost, ranked[0]);
       const chargedCredits = applyMarkup(cost, ctx.markupPct);
       await settleAfterCall(ctx.platformPool, lease, chargedCredits);
       maybeTriggerAutoRefill(
@@ -304,7 +306,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
         promptTokens: usage.promptTokens, completionTokens: usage.completionTokens,
         totalTokens: usage.promptTokens + usage.completionTokens,
         providerCostUsd: cost, chargedCreditsUsd: chargedCredits,
-        markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain, leaseId: lease.leaseId,
+        markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource, fallbackChain, leaseId: lease.leaseId,
         keyType: 'platform', chargedToUser: true,
         cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
         cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
@@ -333,6 +335,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
   const usage: AdapterUsage = result.usage ?? { promptTokens: 0, completionTokens: 0, totalCost: null };
   const providerCost = result.providerCostUsd
     ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, usage.completionTokens, usage.cache_read_input_tokens ?? 0, usage.cache_creation_input_tokens ?? 0);
+  const costSource = classifyCostSource(result.providerCostUsd, ranked[0]);
   const chargedCredits = applyMarkup(providerCost, ctx.markupPct);
 
   await settleAfterCall(ctx.platformPool, lease, chargedCredits);
@@ -346,7 +349,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
     promptTokens: usage.promptTokens, completionTokens: usage.completionTokens,
     totalTokens: usage.promptTokens + usage.completionTokens,
     providerCostUsd: providerCost, chargedCreditsUsd: chargedCredits,
-    markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain, leaseId: lease.leaseId,
+    markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource, fallbackChain, leaseId: lease.leaseId,
     keyType: 'platform', chargedToUser: true,
     cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
     cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
@@ -509,6 +512,7 @@ export async function routeEmbedding(ctx: RouteContext, req: EmbeddingRequest): 
   const usage: AdapterUsage = result.usage ?? { promptTokens: 0, completionTokens: 0, totalCost: null };
   const providerCost = result.providerCostUsd
     ?? estimateWorstCaseUsd(ranked[0], usage.promptTokens, 0, usage.cache_read_input_tokens ?? 0, usage.cache_creation_input_tokens ?? 0);
+  const costSource = classifyCostSource(result.providerCostUsd, ranked[0]);
   const chargedCredits = applyMarkup(providerCost, ctx.markupPct);
 
   await settleAfterCall(ctx.platformPool, lease, chargedCredits);
@@ -522,7 +526,7 @@ export async function routeEmbedding(ctx: RouteContext, req: EmbeddingRequest): 
     promptTokens: usage.promptTokens, completionTokens: 0,
     totalTokens: usage.promptTokens,
     providerCostUsd: providerCost, chargedCreditsUsd: chargedCredits,
-    markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain, leaseId: lease.leaseId,
+    markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource, fallbackChain, leaseId: lease.leaseId,
     keyType: 'platform', chargedToUser: true,
     cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
     cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
@@ -1033,6 +1037,8 @@ export async function settleVideoJob(
     chosenRouter: RouterName;
     canonicalModel: string;
     providerCostUsd: number;
+    /** Whether providerCostUsd came from the upstream or from our own rate card. */
+    costSource: CostSource;
     fallbackChain?: string[];
   },
 ): Promise<{ chargedCreditsUsd: number; providerCostUsd: number }> {
@@ -1055,7 +1061,7 @@ export async function settleVideoJob(
     appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: args.canonicalModel, router: args.chosenRouter,
     promptTokens: 0, completionTokens: 0, totalTokens: 0,
     providerCostUsd: args.providerCostUsd, chargedCreditsUsd: chargedCredits,
-    markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain: args.fallbackChain ?? [], leaseId: args.leaseId,
+    markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource: args.costSource, fallbackChain: args.fallbackChain ?? [], leaseId: args.leaseId,
     keyType: 'platform', chargedToUser: true,
   }).catch(err => console.error('[router] usage-log write failed:', err));
   console.log(JSON.stringify({
@@ -1216,6 +1222,8 @@ export async function settleImageJob(
     chosenRouter: RouterName;
     canonicalModel: string;
     providerCostUsd: number;
+    /** Whether providerCostUsd came from the upstream or from our own rate card. */
+    costSource: CostSource;
     fallbackChain?: string[];
   },
 ): Promise<{ chargedCreditsUsd: number; providerCostUsd: number }> {
@@ -1238,7 +1246,7 @@ export async function settleImageJob(
     appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: args.canonicalModel, router: args.chosenRouter,
     promptTokens: 0, completionTokens: 0, totalTokens: 0,
     providerCostUsd: args.providerCostUsd, chargedCreditsUsd: chargedCredits,
-    markupPct: ctx.markupPct, markupSource: ctx.markupSource, fallbackChain: args.fallbackChain ?? [], leaseId: args.leaseId,
+    markupPct: ctx.markupPct, markupSource: ctx.markupSource, costSource: args.costSource, fallbackChain: args.fallbackChain ?? [], leaseId: args.leaseId,
     keyType: 'platform', chargedToUser: true,
   }).catch(err => console.error('[router] usage-log write failed:', err));
   console.log(JSON.stringify({

--- a/services/control-api/src/services/ai-router/select.ts
+++ b/services/control-api/src/services/ai-router/select.ts
@@ -11,6 +11,11 @@ export interface CatalogRouter {
   modality?: Modality;
   // Router-native pricing for non-chat modalities. See UpstreamModel.rawPricing.
   rawPricing?: unknown;
+  // Set when this row's per-Mtok prices were copied from a sibling router
+  // during refreshCatalog because the upstream publishes no rates of its own.
+  // Purely informational — nothing routes on it — but it makes an inherited
+  // estimate distinguishable from a real published price when debugging a bill.
+  priceInheritedFrom?: RouterName;
 }
 
 export interface CatalogEntry {
@@ -52,6 +57,19 @@ const PREFERRED_ROUTER_BY_MODEL: Readonly<Record<string, RouterName>> = {
   // routes/dashboard-agent.ts) and is at price parity with OpenRouter, so this
   // pin costs nothing.
   'qwen/qwen3.8-max': 'provider-quaternary',
+  // qwen3.8-flash is the hosted build of the open-weight Qwen3.8-Flash-Next.
+  // On release it was single-homed on OpenRouter, whose Alibaba upstream was
+  // rate-limiting it — measured 3/6 successful calls against 6/6 direct, so the
+  // gateway returned MODEL_UNAVAILABLE about half the time. Published rate is
+  // 0.16/0.47 against OpenRouter's 0.15/0.47, i.e. parity, so the same
+  // "pin costs nothing" reasoning as qwen3.8-max applies.
+  //
+  // Tradeoff worth knowing: provider-tertiary also serves this model and
+  // settles from a real billing ledger, whereas the direct slot reports no
+  // per-call cost and settles from the static table above. Pinning direct
+  // trades a slightly less precise cost for the better availability that was
+  // the actual outage. Tertiary stays on the entry as the next hop.
+  'qwen/qwen3.8-flash': 'provider-quaternary',
   'qwen/qwen3.7-max': 'provider-quaternary',
   'qwen/qwen3.7-plus': 'provider-quaternary',
   'qwen/qwen3.6-flash': 'provider-quaternary',

--- a/services/control-api/src/services/ai-router/usage-log.ts
+++ b/services/control-api/src/services/ai-router/usage-log.ts
@@ -1,6 +1,9 @@
 import type pg from 'pg';
 import type { RouterName } from './normalize.js';
 import { incrementUsage } from '../usage-metering.js';
+import type { CostSource } from './cost-source.js';
+
+export type { CostSource };
 
 export interface AiUsageRow {
   appId: string | null;
@@ -15,6 +18,12 @@ export interface AiUsageRow {
   chargedCreditsUsd: number;
   markupPct: number;
   markupSource: string;
+  /**
+   * Provenance of providerCostUsd. Required, not optional: a wrong value here
+   * is invisible, so every writer must state which case it is in rather than
+   * inheriting a default. See migration 049 for the vocabulary.
+   */
+  costSource: CostSource;
   fallbackChain: string[];   // router_name:reason entries from upstream fallbacks
   leaseId: string | null;
   keyType: 'platform' | 'byok';
@@ -40,8 +49,9 @@ export async function writeAiUsageRow(runtimePool: pg.Pool, row: AiUsageRow): Pr
        app_id, user_id, model, provider, prompt_tokens, completion_tokens, total_tokens,
        cost_usd, key_type, charged_to_user, request_metadata,
        router, provider_cost_usd, charged_credits_usd, markup_pct, fallback_chain, lease_id,
-       cache_read_input_tokens, cache_creation_input_tokens, reasoning_tokens, organization_id, markup_source
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)`,
+       cache_read_input_tokens, cache_creation_input_tokens, reasoning_tokens, organization_id, markup_source,
+       cost_source
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)`,
     [
       row.appId,
       row.userId,
@@ -65,6 +75,7 @@ export async function writeAiUsageRow(runtimePool: pg.Pool, row: AiUsageRow): Pr
       row.reasoningTokens ?? null,
       row.organizationId,
       row.markupSource,
+      row.costSource,
     ]
   );
 


### PR DESCRIPTION
## The bug

Routers that settle from an authoritative post-call cost — OpenRouter's `usage.cost`, provider-secondary's and provider-tertiary's billing ledgers — have no reason to publish a rate card, so their catalog rows legitimately carry `0/0`.

That is fine right up until the cost lookup fails. `router.ts` then falls back to `estimateWorstCaseUsd`, multiplies by those zeros, and settles the call at **$0**: the customer is billed nothing, we still pay the upstream, and nothing logs.

This became reachable when `provider-tertiary` started discovering its ~57 chat models (internal `f733f5a6`), all unpriced by design.

## The fix

`refreshCatalog` fills an unpriced chat route from a priced sibling:

- donor is **openrouter** when it offers the model — the closest thing to a public reference rate for a canonical id — otherwise the **cheapest** priced sibling, by the ranker's own `prompt + 3x completion` weighting. Cheapest so a failed lookup can only under-recover, never silently overcharge.
- the inherited figure is never the billing basis when a real cost is available; it is only the floor under a failed lookup.
- filled rows are tagged `priceInheritedFrom` so an estimate stays distinguishable from a published price when reading a bill back.

### What is deliberately left alone

Video rows carry `0/0` **by design** and price per second via `rawPricing` — copying token rates onto them would invent a charge that does not exist. Rows carrying `rawPricing` are skipped for the same reason, and a missing `modality` still means chat (matching the field's existing default).

## Also: pin `qwen/qwen3.8-flash`

It was single-homed on OpenRouter, whose Alibaba upstream was rate-limiting a day-old model — **measured 3/6 successful calls against 6/6 direct**, so the gateway returned `MODEL_UNAVAILABLE` about half the time.

Published 0.16/0.47 against OpenRouter's 0.15/0.47 is parity, so the "pin costs nothing" reasoning behind the existing `qwen3.8-max` pin applies unchanged.

Tradeoff recorded in the code: provider-tertiary also serves this model and settles from a real ledger, whereas the direct slot reports no per-call cost. Pinning direct trades slightly less precise cost for the availability that was the actual outage; tertiary stays on the entry as the next hop.

## Tests

10 new unconditional (non-Redis) cases covering donor preference, the cheapest-sibling fallback, video/`rawPricing` exclusion, legacy rows with no `modality`, and both no-op paths.

`355 passed | 26 skipped` across `src/services/ai-router/`, `tsc --noEmit` clean.