### PR TITLE
fix(db): renumber the cost_source migration 049 -> 051

### DIFF
--- a/db/runtime-plane/051_ai_usage_cost_source.sql
+++ b/db/runtime-plane/051_ai_usage_cost_source.sql
@@ -1,5 +1,5 @@
 -- @scope: runtime
--- 049: Record WHERE provider_cost_usd came from on each charge:
+-- 051: Record WHERE provider_cost_usd came from on each charge:
 --   'upstream'          — the provider reported the real cost for this call
 --                         (OpenRouter usage.cost, provider-secondary's and
 --                         provider-tertiary's billing ledgers)

--- a/services/control-api/src/routes/ai-images.ts
+++ b/services/control-api/src/routes/ai-images.ts
@@ -339,7 +339,7 @@ export async function pollAndSettleImageJob(
   //   3) $0 as final guard — only `failed`/`cancelled` paths, where charging
   //      would be wrong anyway.
   let providerCost = poll.providerCostUsd ?? 0;
-  // Provenance for migration 049. Starts as whatever the branch above produced:
+  // Provenance for migration 051. Starts as whatever the branch above produced:
   // an upstream-reported cost, or $0 pending the catalog fallback below.
   let costSource: CostSource = poll.providerCostUsd !== undefined ? 'upstream' : 'catalog_unpriced';
   if (poll.providerCostUsd === undefined && poll.status === 'completed') {

--- a/services/control-api/src/routes/ai-videos.ts
+++ b/services/control-api/src/routes/ai-videos.ts
@@ -345,7 +345,7 @@ export async function pollAndSettleVideoJob(
   //   3) $0 as final guard — only `failed`/`cancelled` paths, where
   //      charging would be wrong anyway.
   let providerCost = poll.providerCostUsd ?? 0;
-  // Provenance for migration 049. Starts as whatever the branch above produced:
+  // Provenance for migration 051. Starts as whatever the branch above produced:
   // an upstream-reported cost, or $0 pending the catalog fallback below.
   let costSource: CostSource = poll.providerCostUsd !== undefined ? 'upstream' : 'catalog_unpriced';
   if (poll.providerCostUsd === undefined && poll.status === 'completed') {

--- a/services/control-api/src/services/ai-router/cost-source.ts
+++ b/services/control-api/src/services/ai-router/cost-source.ts
@@ -7,7 +7,7 @@
  * parked there would vanish behind the mock.
  */
 /**
- * Where a row's `provider_cost_usd` came from. Mirrors migration 049.
+ * Where a row's `provider_cost_usd` came from. Mirrors migration 051.
  *
  *   upstream          the provider reported the real cost for this call
  *   catalog           estimated from the chosen router's own published rates

--- a/services/control-api/src/services/ai-router/usage-log.ts
+++ b/services/control-api/src/services/ai-router/usage-log.ts
@@ -21,7 +21,7 @@ export interface AiUsageRow {
   /**
    * Provenance of providerCostUsd. Required, not optional: a wrong value here
    * is invisible, so every writer must state which case it is in rather than
-   * inheriting a default. See migration 049 for the vocabulary.
+   * inheriting a default. See migration 051 for the vocabulary.
    */
   costSource: CostSource;
   fallbackChain: string[];   // router_name:reason entries from upstream fallbacks


### PR DESCRIPTION
`049` was already taken — `049_apps_latest_release_number.sql` landed with the template-releases merge while #136 was in flight.

Prod's `_runtime_migrations` shows the runtime plane is already at **050**:

```
050_app_do_env_vars_value_nullable.sql
049_apps_latest_release_number.sql
049_app_do_env_var_defaults_on_clone.sql
048_markup_source.sql
048_env_var_defaults_on_clone.sql
```

Not fatal on its own — the ledger keys on **filename**, not number, so a third `049` would still have applied. But it leaves ordering between same-numbered files decided by an alphabetical tiebreak, and a number that no longer means anything. **051** is the next free slot. Caught by preflight before the migration was applied anywhere.

Also worth flagging: three migrations applied in prod are **absent from this repo** (`048_env_var_defaults_on_clone`, `049_app_do_env_var_defaults_on_clone`, `050_app_do_env_vars_value_nullable`) — the runtime plane in production is ahead of main. Pick the next number by querying `_runtime_migrations`, not by listing the directory.

`tsc --noEmit` clean; `364 passed | 26 skipped` in `src/services/ai-router/`.