### PR TITLE
fix(clone): enforce replayed RLS instead of copying inert policies

### DIFF
--- a/services/control-api/src/__tests__/clone-replay-rls.test.ts
+++ b/services/control-api/src/__tests__/clone-replay-rls.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import type pg from 'pg';
+import { replayRls } from '../services/clone-replay.js';
+import { parsePgNameArray, mapPolicyCommand } from '../services/rls-introspector.js';
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+/**
+ * A fake pool that answers the introspection queries replayRls issues against
+ * the SOURCE, and records every statement issued against the DEST.
+ */
+function fakePools(opts: {
+  policies?: Record<string, unknown>[];
+  tableState?: Record<string, unknown>[];
+  failOn?: RegExp;
+}) {
+  const issued: string[] = [];
+  const source = {
+    query: async (sql: string) => {
+      if (/FROM pg_policies/i.test(sql)) return { rows: opts.policies ?? [] };
+      if (/pg_class/i.test(sql)) return { rows: opts.tableState ?? [] };
+      return { rows: [] };
+    },
+  } as unknown as pg.Pool;
+  const dest = {
+    query: async (sql: string) => {
+      issued.push(sql);
+      if (opts.failOn && opts.failOn.test(sql)) throw new Error('boom');
+      return { rows: [] };
+    },
+  } as unknown as pg.Pool;
+  return { source, dest, issued };
+}
+
+// pg_policies.roles is `name[]` (OID 1003). node-pg has no parser registered for
+// that OID, so it hands back the RAW STRING "{butterbase_user}" rather than an
+// array. The old code did `Array.isArray(r.roles) ? r.roles : []`, which took the
+// `[]` branch every single time — so every replayed policy came out `TO PUBLIC`.
+describe('parsePgNameArray', () => {
+  it('parses a real pg name[] literal that node-pg left as a string', () => {
+    expect(parsePgNameArray('{butterbase_user}')).toEqual(['butterbase_user']);
+    expect(parsePgNameArray('{a,b}')).toEqual(['a', 'b']);
+  });
+
+  it('parses an empty array literal', () => {
+    expect(parsePgNameArray('{}')).toEqual([]);
+  });
+
+  it('handles quoted role names containing commas or spaces', () => {
+    expect(parsePgNameArray('{"weird, role",plain}')).toEqual(['weird, role', 'plain']);
+  });
+
+  it('passes through a value node-pg already parsed into an array', () => {
+    expect(parsePgNameArray(['butterbase_user'])).toEqual(['butterbase_user']);
+  });
+
+  it('treats null/undefined as no roles', () => {
+    expect(parsePgNameArray(null)).toEqual([]);
+    expect(parsePgNameArray(undefined)).toEqual([]);
+  });
+});
+
+// pg_policies.cmd is TEXT — 'ALL' / 'SELECT' / 'INSERT' / 'UPDATE' / 'DELETE'.
+// The old CMD_MAP keyed on the pg_policy.polcmd CHARS ('r','a','w','d','*'), so
+// every lookup missed and fell back to 'ALL'. A SELECT-only policy was replayed
+// with write coverage it never had.
+describe('mapPolicyCommand', () => {
+  it('preserves a SELECT-only policy instead of widening it to ALL', () => {
+    expect(mapPolicyCommand('SELECT')).toBe('SELECT');
+  });
+
+  it('maps every pg_policies.cmd value', () => {
+    expect(mapPolicyCommand('ALL')).toBe('ALL');
+    expect(mapPolicyCommand('INSERT')).toBe('INSERT');
+    expect(mapPolicyCommand('UPDATE')).toBe('UPDATE');
+    expect(mapPolicyCommand('DELETE')).toBe('DELETE');
+  });
+
+  it('still accepts the raw polcmd chars, for callers reading pg_policy directly', () => {
+    expect(mapPolicyCommand('r')).toBe('SELECT');
+    expect(mapPolicyCommand('*')).toBe('ALL');
+  });
+
+  it('falls back to ALL for anything unrecognized', () => {
+    expect(mapPolicyCommand('nonsense')).toBe('ALL');
+  });
+});
+
+describe('replayRls', () => {
+  const policyRow = {
+    tablename: 'secret_notes',
+    policyname: 'owner_only',
+    cmd: 'SELECT',
+    permissive: 'PERMISSIVE',
+    roles: '{butterbase_user}',
+    qual: 'user_id = current_setting(\'app.user_id\', true)',
+    with_check: null,
+  };
+
+  it('grants the policy to the source roles, not PUBLIC', async () => {
+    const { source, dest, issued } = fakePools({ policies: [policyRow] });
+    await replayRls(source, dest, logger);
+    const create = issued.find((s) => /CREATE POLICY/i.test(s))!;
+    expect(create).toMatch(/TO "butterbase_user"/);
+    expect(create).not.toMatch(/TO PUBLIC/);
+  });
+
+  it('preserves FOR SELECT rather than widening to FOR ALL', async () => {
+    const { source, dest, issued } = fakePools({ policies: [policyRow] });
+    await replayRls(source, dest, logger);
+    expect(issued.find((s) => /CREATE POLICY/i.test(s))!).toMatch(/FOR SELECT/);
+  });
+
+  // The whole point. Postgres only ENFORCES policies once RLS is enabled on the
+  // table; a table with policies and relrowsecurity=false is wide open. The
+  // clone/update path created policies and never enabled anything, so every
+  // fork's "protected" tables were readable in full.
+  it('enables RLS on tables the source has it enabled on', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [policyRow],
+      tableState: [{ tablename: 'secret_notes', enabled: true, forced: false }],
+    });
+    await replayRls(source, dest, logger);
+    expect(issued.some((s) => /ALTER TABLE "secret_notes" ENABLE ROW LEVEL SECURITY/i.test(s))).toBe(true);
+  });
+
+  it('mirrors FORCE ROW LEVEL SECURITY when the source forces it', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [policyRow],
+      tableState: [{ tablename: 'secret_notes', enabled: true, forced: true }],
+    });
+    await replayRls(source, dest, logger);
+    expect(issued.some((s) => /FORCE ROW LEVEL SECURITY/i.test(s))).toBe(true);
+  });
+
+  it('does not force RLS when the source does not', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [policyRow],
+      tableState: [{ tablename: 'secret_notes', enabled: true, forced: false }],
+    });
+    await replayRls(source, dest, logger);
+    expect(issued.some((s) => /FORCE ROW LEVEL SECURITY/i.test(s))).toBe(false);
+  });
+
+  // A table can have RLS enabled with NO policies at all — that is a deliberate
+  // deny-all. Keying the enable off the policy list would silently drop it.
+  it('enables RLS on a protected table that has no policies', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [],
+      tableState: [{ tablename: 'locked_down', enabled: true, forced: false }],
+    });
+    await replayRls(source, dest, logger);
+    expect(issued.some((s) => /ALTER TABLE "locked_down" ENABLE ROW LEVEL SECURITY/i.test(s))).toBe(true);
+  });
+
+  // Update runs against a LIVE fork. Disabling RLS is the one direction that
+  // loosens security, so it must never be issued — even if the template has it
+  // off and the fork has it on.
+  it('never issues DISABLE or NO FORCE', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [policyRow],
+      tableState: [{ tablename: 'secret_notes', enabled: false, forced: false }],
+    });
+    await replayRls(source, dest, logger);
+    expect(issued.some((s) => /DISABLE ROW LEVEL SECURITY|NO FORCE/i.test(s))).toBe(false);
+  });
+
+  // Order matters on a live fork: flipping RLS on before the policies exist
+  // means a window where every non-owner read returns nothing.
+  it('creates policies before enabling RLS', async () => {
+    const { source, dest, issued } = fakePools({
+      policies: [policyRow],
+      tableState: [{ tablename: 'secret_notes', enabled: true, forced: false }],
+    });
+    await replayRls(source, dest, logger);
+    const createAt = issued.findIndex((s) => /CREATE POLICY/i.test(s));
+    const enableAt = issued.findIndex((s) => /ENABLE ROW LEVEL SECURITY/i.test(s));
+    expect(createAt).toBeGreaterThanOrEqual(0);
+    expect(enableAt).toBeGreaterThan(createAt);
+  });
+
+  // A failed ENABLE is a SECURITY failure, not a cosmetic one: the table stays
+  // readable. It must surface as a warning the job records, never be swallowed.
+  it('warns when enabling RLS fails', async () => {
+    const { source, dest } = fakePools({
+      policies: [],
+      tableState: [{ tablename: 'secret_notes', enabled: true, forced: false }],
+      failOn: /ENABLE ROW LEVEL SECURITY/i,
+    });
+    const res = await replayRls(source, dest, logger);
+    expect(res.warnings.join(' ')).toMatch(/secret_notes/);
+    expect(res.warnings.join(' ')).toMatch(/row level security|RLS/i);
+  });
+});
+
+// Enabling RLS on a table that carries a permissive `TO PUBLIC USING (true)`
+// policy enforces nothing — the policies OR together and that one is always
+// true. Forks cloned before the roles bug was fixed can carry exactly that,
+// because the old replay turned every `TO butterbase_service USING (true)`
+// bypass policy into a public one. Such a fork must not be left LOOKING
+// protected: the replay reports it.
+describe('replayRls neutered-policy detection', () => {
+  it('warns when an enabled table has a permissive TO PUBLIC USING (true) policy', async () => {
+    const issued: string[] = [];
+    const source = {
+      query: async (sql: string) => {
+        if (/FROM pg_policies/i.test(sql)) return { rows: [] };
+        if (/pg_class/i.test(sql)) return { rows: [{ tablename: 'notes', enabled: true, forced: false }] };
+        return { rows: [] };
+      },
+    } as unknown as pg.Pool;
+    const dest = {
+      query: async (sql: string) => {
+        issued.push(sql);
+        if (/pg_policies/i.test(sql)) {
+          return { rows: [{ policyname: 'svc_bypass', tablename: 'notes' }] };
+        }
+        return { rows: [] };
+      },
+    } as unknown as pg.Pool;
+
+    const res = await replayRls(source, dest, logger);
+    expect(res.warnings.join(' ')).toMatch(/notes/);
+    expect(res.warnings.join(' ')).toMatch(/svc_bypass/);
+    expect(res.warnings.join(' ')).toMatch(/not enforced|no effect|bypass/i);
+  });
+});

--- a/services/control-api/src/services/clone-replay.ts
+++ b/services/control-api/src/services/clone-replay.ts
@@ -13,7 +13,12 @@ import { introspectSchema } from './schema-introspector.js';
 import { diffSchema, type DDLStatement } from './schema-differ.js';
 import { applyMigration } from './schema-applier.js';
 import type { SchemaDSL } from './schema-validator.js';
-import { introspectRls } from './rls-introspector.js';
+import {
+  introspectRls,
+  introspectRlsTables,
+  mapPolicyCommand,
+  type RlsTableState,
+} from './rls-introspector.js';
 import AdmZip from 'adm-zip';
 import * as R2 from './r2.js';
 import * as DeploymentService from './deployment.service.js';
@@ -342,20 +347,34 @@ export async function replaySeedData(
 // replayRls helpers
 // ---------------------------------------------------------------------------
 
-const CMD_MAP: Record<string, string> = {
-  r: 'SELECT',
-  a: 'INSERT',
-  w: 'UPDATE',
-  d: 'DELETE',
-  '*': 'ALL',
-};
-
 /**
- * Replay RLS policies from the source app's database onto the dest app's database.
+ * Replay RLS from the source app's database onto the dest app's database.
  *
- * Soft-fails per-policy: if a policy fails to apply (e.g. due to a missing
- * column or function reference), the error is recorded as a warning and the
- * clone continues. The caller is responsible for persisting the warnings.
+ * Two halves, and BOTH are load-bearing:
+ *
+ *  1. the policies themselves, and
+ *  2. the per-table `relrowsecurity` / `relforcerowsecurity` toggles.
+ *
+ * Only (1) used to happen. Postgres does not enforce a policy until RLS is
+ * enabled on its table, so every clone and every template update produced a
+ * destination whose policies were decorative: a table the source protected
+ * came out fully readable, with `GRANT ... TO butterbase_anon` already applied
+ * by the schema applier. Replaying (2) is what makes the policies mean
+ * anything.
+ *
+ * Order is policies first, then enable. An update runs against a LIVE fork, and
+ * flipping RLS on before its policies exist opens a window where every
+ * non-owner read returns zero rows.
+ *
+ * Enabling is one-way: this never issues DISABLE or NO FORCE. A template that
+ * has RLS off must not be able to switch it off on a fork that turned it on —
+ * that is the only direction that loosens security, and update is additive by
+ * contract.
+ *
+ * Soft-fails per statement: a policy or toggle that fails is recorded as a
+ * warning and the replay continues. The caller persists the warnings. A failed
+ * ENABLE is reported in the same channel but is a security failure, not a
+ * cosmetic one — the table stays readable.
  *
  * @param sourceAppPool - Connected pool for the source app's per-app DB.
  * @param destAppPool   - Connected pool for the dest app's per-app DB.
@@ -373,7 +392,7 @@ export async function replayRls(
   let replayed = 0;
 
   for (const p of policies) {
-    const cmd = CMD_MAP[p.command] ?? 'ALL';
+    const cmd = mapPolicyCommand(p.command);
     const roles =
       p.roles.length === 0 || p.roles.includes('public')
         ? 'PUBLIC'
@@ -402,6 +421,70 @@ export async function replayRls(
         { table: p.table, policy: p.name, err },
         '[clone] RLS policy replay failed; continuing',
       );
+    }
+  }
+
+  // Toggles last — see the ordering note above.
+  let tableStates: RlsTableState[] = [];
+  try {
+    tableStates = await introspectRlsTables(sourceAppPool);
+  } catch (err) {
+    const msg = `RLS table state introspection failed: ${(err as Error).message}`;
+    warnings.push(msg);
+    logger.warn({ err }, '[clone] could not read source RLS table state; policies may be inert');
+  }
+
+  for (const t of tableStates) {
+    try {
+      await destAppPool.query(`ALTER TABLE "${t.table}" ENABLE ROW LEVEL SECURITY`);
+    } catch (err) {
+      const msg =
+        `RLS enable for ${t.table} failed: ${(err as Error).message} — ` +
+        `its policies will NOT be enforced on this app`;
+      warnings.push(msg);
+      logger.warn({ table: t.table, err }, '[clone] ENABLE ROW LEVEL SECURITY failed; table left unprotected');
+      continue;
+    }
+    if (t.forced) {
+      try {
+        await destAppPool.query(`ALTER TABLE "${t.table}" FORCE ROW LEVEL SECURITY`);
+      } catch (err) {
+        const msg = `RLS force for ${t.table} failed: ${(err as Error).message}`;
+        warnings.push(msg);
+        logger.warn({ table: t.table, err }, '[clone] FORCE ROW LEVEL SECURITY failed; continuing');
+      }
+    }
+
+    // Enabling RLS is not the same as being protected. Permissive policies OR
+    // together, so a single `TO PUBLIC USING (true)` policy makes the table
+    // readable by everyone no matter what else is on it. Forks cloned before
+    // the roles bug was fixed can carry exactly that: the old replay turned
+    // every `TO butterbase_service USING (true)` bypass policy public. Leaving
+    // such a table looking protected is worse than leaving it obviously open,
+    // so say so. Detection only -- dropping a policy the owner may have written
+    // deliberately is not this function's call to make.
+    try {
+      const neutered = await destAppPool.query<{ policyname: string }>(
+        `SELECT policyname FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = $1
+            AND permissive = 'PERMISSIVE'
+            AND (roles::text[] @> ARRAY['public'] OR roles::text = '{0}')
+            AND coalesce(btrim(qual), 'true') = 'true'`,
+        [t.table],
+      );
+      for (const row of neutered.rows) {
+        const msg =
+          `RLS is enabled on ${t.table} but policy "${row.policyname}" is PERMISSIVE ` +
+          `TO PUBLIC USING (true), so row filtering is NOT enforced on that table. ` +
+          `Review and scope or drop that policy.`;
+        warnings.push(msg);
+        logger.warn(
+          { table: t.table, policy: row.policyname },
+          '[clone] RLS enabled but a public allow-all policy neutralises it',
+        );
+      }
+    } catch (err) {
+      logger.warn({ table: t.table, err }, '[clone] could not audit policies for public allow-all');
     }
   }
 

--- a/services/control-api/src/services/neon-task-worker.ts
+++ b/services/control-api/src/services/neon-task-worker.ts
@@ -1695,11 +1695,16 @@ export async function executeUpdate(
       await setCloneJobStatus(controlDb, jobId, { status: 'replaying_schema' });
       await replaySchema(sourceAppPool, forkAppPool, forkAppId, logger, { filter: filterAdditive });
 
-      // -- 6. RLS. replayRls only issues CREATE POLICY and drops nothing, so it is
-      //       safe on a live fork — and necessary: a table the release adds is
-      //       created here with SELECT/INSERT/UPDATE/DELETE granted to
-      //       butterbase_anon by the schema applier, so skipping policy replay
+      // -- 6. RLS. replayRls only ADDS -- CREATE POLICY plus ENABLE/FORCE ROW
+      //       LEVEL SECURITY -- and never drops a policy or issues DISABLE/NO
+      //       FORCE, so it is safe on a live fork. It is also necessary: a table
+      //       the release adds is created here with SELECT/INSERT/UPDATE/DELETE
+      //       granted to butterbase_anon by the schema applier, so skipping this
       //       would publish that table wide open on every fork.
+      //
+      //       The ENABLE half is what makes the policies binding. Replaying
+      //       policies without it -- which is what this did until 2026-08-30 --
+      //       left every protected table readable in full.
       //
       //       Policies the fork already has make CREATE POLICY fail with
       //       "already exists"; replayRls catches per policy, so those are

--- a/services/control-api/src/services/rls-introspector.ts
+++ b/services/control-api/src/services/rls-introspector.ts
@@ -2,7 +2,9 @@
  * RLS introspector for clone jobs.
  *
  * Reads pg_policies from the source app's database so that the clone worker
- * can regenerate the same policies on the dest app's database.
+ * can regenerate the same policies on the dest app's database, plus the
+ * per-table RLS toggles from pg_class — WITHOUT which the regenerated policies
+ * are inert (see introspectRlsTables).
  */
 
 import type pg from 'pg';
@@ -10,14 +12,99 @@ import type pg from 'pg';
 export interface RlsPolicy {
   table: string;
   name: string;
-  command: 'r' | 'a' | 'w' | 'd' | '*';  // pg_policies.cmd: SELECT='r', INSERT='a', UPDATE='w', DELETE='d', ALL='*'
+  /**
+   * pg_policies.cmd, as Postgres actually returns it: 'ALL' | 'SELECT' |
+   * 'INSERT' | 'UPDATE' | 'DELETE'. The single-char forms ('r','a','w','d','*')
+   * belong to pg_policy.polcmd, a DIFFERENT relation — mapPolicyCommand accepts
+   * both so a caller reading either one is safe.
+   */
+  command: string;
   permissive: boolean;
   roles: string[];
   using: string | null;
   with_check: string | null;
 }
 
+/** Whether a table enforces RLS, and whether it does so even for its owner. */
+export interface RlsTableState {
+  table: string;
+  enabled: boolean;
+  forced: boolean;
+}
+
 const EXCLUDED_TABLES = new Set(['_ai_migrations', '_seed_tables']);
+
+/** Tables the app owns, as opposed to Butterbase's own bookkeeping. */
+function isAppTable(name: string): boolean {
+  return !EXCLUDED_TABLES.has(name) && !name.startsWith('app_') && !name.startsWith('_');
+}
+
+/**
+ * Parse a Postgres `name[]` / `text[]` literal that arrived as a raw string.
+ *
+ * `pg_policies.roles` has type `name[]` (OID 1003). node-pg ships parsers for
+ * `text[]` and friends but NOT for `name[]`, so it hands the value back as the
+ * literal string `"{butterbase_user}"`. The previous code tested
+ * `Array.isArray(...)` and fell back to `[]` on every single row, which made
+ * replayRls emit `TO PUBLIC` for every policy it replayed — widening the
+ * audience of each one, and in the case of a `butterbase_service` bypass policy
+ * (`USING (true)`) making the whole table readable by everyone once RLS was on.
+ *
+ * Accepts an already-parsed array too, so this keeps working if a future
+ * node-pg registers an OID 1003 parser or a caller casts to `text[]`.
+ */
+export function parsePgNameArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value !== 'string') return [];
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return [];
+  const inner = trimmed.slice(1, -1);
+  if (inner === '') return [];
+
+  const out: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (inQuotes) {
+      if (ch === '\\') { cur += inner[++i] ?? ''; continue; }
+      if (ch === '"') { inQuotes = false; continue; }
+      cur += ch;
+      continue;
+    }
+    if (ch === '"') { inQuotes = true; continue; }
+    if (ch === ',') { out.push(cur); cur = ''; continue; }
+    cur += ch;
+  }
+  out.push(cur);
+  return out.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+const POLCMD_CHARS: Record<string, string> = {
+  r: 'SELECT',
+  a: 'INSERT',
+  w: 'UPDATE',
+  d: 'DELETE',
+  '*': 'ALL',
+};
+
+const CMD_WORDS = new Set(['ALL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE']);
+
+/**
+ * Normalize a policy command to the keyword `CREATE POLICY ... FOR <cmd>` wants.
+ *
+ * The old CMD_MAP keyed ONLY on the single-char pg_policy.polcmd values, but the
+ * introspector reads pg_policies, whose `cmd` column is the full word. Every
+ * lookup therefore missed and fell through to 'ALL' — so a `FOR SELECT` policy
+ * was recreated with INSERT/UPDATE/DELETE coverage it never had. Both encodings
+ * are accepted here so neither reading is silently widened.
+ */
+export function mapPolicyCommand(cmd: string | null | undefined): string {
+  if (!cmd) return 'ALL';
+  const upper = cmd.toUpperCase();
+  if (CMD_WORDS.has(upper)) return upper;
+  return POLCMD_CHARS[cmd] ?? 'ALL';
+}
 
 export async function introspectRls(pool: pg.Pool): Promise<RlsPolicy[]> {
   const res = await pool.query(`
@@ -26,14 +113,46 @@ export async function introspectRls(pool: pg.Pool): Promise<RlsPolicy[]> {
     WHERE schemaname = 'public'
   `);
   return res.rows
-    .filter(r => !EXCLUDED_TABLES.has(r.tablename) && !r.tablename.startsWith('app_') && !r.tablename.startsWith('_'))
+    .filter(r => isAppTable(r.tablename))
     .map(r => ({
       table: r.tablename,
       name: r.policyname,
-      command: r.cmd as 'r' | 'a' | 'w' | 'd' | '*',
-      permissive: r.permissive === 'PERMISSIVE',
-      roles: Array.isArray(r.roles) ? r.roles : [],
+      command: r.cmd as string,
+      permissive: r.permissive === 'PERMISSIVE' || r.permissive === true,
+      roles: parsePgNameArray(r.roles),
       using: r.qual ?? null,
       with_check: r.with_check ?? null,
+    }));
+}
+
+/**
+ * Per-table RLS toggles.
+ *
+ * Postgres only ENFORCES policies when `relrowsecurity` is set on the table; a
+ * table carrying policies with RLS off is wide open. pg_policies says nothing
+ * about that flag, so replaying policies alone — which is all clone and update
+ * ever did — produced destination tables whose policies were decorative.
+ *
+ * Returns every app table with RLS enabled, INCLUDING ones with no policies at
+ * all: "enabled, no policies" is a deliberate deny-all, and keying off the
+ * policy list would silently discard it.
+ */
+export async function introspectRlsTables(pool: pg.Pool): Promise<RlsTableState[]> {
+  const res = await pool.query(`
+    SELECT c.relname AS tablename,
+           c.relrowsecurity AS enabled,
+           c.relforcerowsecurity AS forced
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relrowsecurity
+  `);
+  return res.rows
+    .filter(r => isAppTable(r.tablename))
+    .map(r => ({
+      table: r.tablename,
+      enabled: r.enabled === true,
+      forced: r.forced === true,
     }));
 }


### PR DESCRIPTION
Clone and template-update replayed `CREATE POLICY` but never enabled row level security on the destination table. Postgres does not enforce a policy until `relrowsecurity` is set, so every "protected" table arrived on a fork **fully readable** — with `SELECT/INSERT/UPDATE/DELETE` already granted to `butterbase_anon` by the schema applier.

## Reproduced, not theorised

A template table with RLS enabled, forced, and a per-user policy, cloned. On the fork, reading as `butterbase_user` with `app.user_id='alice'`:

| | before | after |
|---|---|---|
| rows returned | **alice's AND bob's** | alice's only |
| `relrowsecurity` / `relforcerowsecurity` | `f` / `f` | `t` / `t` |

## Enabling alone would have been dangerous

Two more defects in the same path silently widened every policy. Fixing only the enable would have produced forks that *look* protected and enforce nothing.

1. **Every policy was granted `TO PUBLIC`.** `pg_policies.roles` is `name[]` (OID 1003); node-pg registers no parser for that OID and returns the raw string `"{butterbase_user}"`. The code did `Array.isArray(r.roles) ? r.roles : []`, which took the empty branch on every row. Combined with a replayed `TO butterbase_service USING (true)` bypass policy, turning RLS on would enforce nothing — permissive policies OR together. Demonstrated against real Postgres.
2. **Every policy became `FOR ALL`.** `pg_policies.cmd` is the full word (`'SELECT'`), but `CMD_MAP` keyed on the `pg_policy.polcmd` chars (`'r'`) — a different relation. Every lookup missed and fell back to `'ALL'`, so a read-only policy silently gained write coverage.

## Safety properties

- **Enabling is one-way.** `DISABLE` / `NO FORCE` are never issued. Update runs against live forks, and loosening security is the one direction that must not be automatic.
- **Policies are created before the enable**, so a live fork never has a window of enabled-with-no-policies where every non-owner read returns nothing.
- **Tables with RLS enabled and no policies are still replayed** — that is a deliberate deny-all, and keying the enable off the policy list would silently drop it.
- **A failed `ENABLE` is surfaced as a warning naming the table**, because it is a security failure, not a cosmetic one.

## Detection for forks cloned before this fix

`replayRls` never drops policies, so a fork carrying an already-mis-replayed public allow-all stays open. After enabling, such a table is now reported: *"RLS is enabled on X but policy Y is PERMISSIVE TO PUBLIC USING (true), so row filtering is NOT enforced."* Detection only — dropping a policy the owner may have written deliberately is not this path's call.

## Verification

- New clone: protected, roles preserved, `FOR SELECT` preserved.
- An **already-exposed fork was healed by running a template update** (`f|f` → `t|t`, alice sees one row).
- The neutered-policy warning surfaces in a real job's `warnings` array.
- 19 new tests. Full control-api suite diffed against baseline by failing-FILE set: no new failures.

## Rollout note

This changes runtime behaviour on clone/update: forks whose apps currently work *because* RLS was accidentally off will begin filtering rows on their next clone or update. Existing forks stay exposed until each one updates — closing that fully needs a separate backfill decision.

`divergence.rls` will flip for existing forks, since old release manifests hashed the misparsed roles/cmd. Display only — `decideEligibility` gates on `repo` and `functions`, so no fork's update eligibility changes.