### PR TITLE
fix(repo): pin release and in-flight-clone snapshots against retention

### DIFF
--- a/services/control-api/src/__tests__/repo-retention-pins.test.ts
+++ b/services/control-api/src/__tests__/repo-retention-pins.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type pg from 'pg';
+import { listActiveCloneSnapshotIdsForApp } from '../services/clone-jobs.js';
+import { listReleaseSnapshotIdsForApp } from '../services/template-releases.js';
+
+/** Captures the SQL + params a helper issues, and replays canned rows. */
+function fakeDb(rows: Record<string, unknown>[]) {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      return { rows, rowCount: rows.length };
+    },
+  } as unknown as pg.Pool;
+  return { pool, calls };
+}
+
+// A published release pins its snapshot forever. repo push runs planRetention
+// with REPO_RETAIN_SNAPSHOTS = 5, and the pinned set only ever held the newest
+// snapshot plus in-flight clones — so pushing five commits after publishing a
+// release deleted the snapshot that release points at, along with its orphan
+// blobs. The release row survived, pointing at bytes that no longer existed,
+// and every fork updating from it failed with "Source manifest not found".
+describe('listReleaseSnapshotIdsForApp', () => {
+  it('returns every published release snapshot for the app', async () => {
+    const { pool } = fakeDb([{ snapshot_id: 'snap_r1' }, { snapshot_id: 'snap_r2' }]);
+    const ids = await listReleaseSnapshotIdsForApp(pool, 'app_tmpl');
+    expect(ids).toEqual(new Set(['snap_r1', 'snap_r2']));
+  });
+
+  it('scopes the query to the app and reads template_releases', async () => {
+    const { pool, calls } = fakeDb([]);
+    await listReleaseSnapshotIdsForApp(pool, 'app_tmpl');
+    expect(calls[0].sql).toMatch(/FROM template_releases/i);
+    expect(calls[0].params).toEqual(['app_tmpl']);
+  });
+
+  it('returns an empty set for a template with no releases', async () => {
+    const { pool } = fakeDb([]);
+    expect(await listReleaseSnapshotIdsForApp(pool, 'app_tmpl')).toEqual(new Set());
+  });
+
+  // Two releases can be published from the same snapshot (publish twice with no
+  // push between). A Set already dedupes; this documents that it must.
+  it('dedupes releases that share a snapshot', async () => {
+    const { pool } = fakeDb([{ snapshot_id: 'snap_r1' }, { snapshot_id: 'snap_r1' }]);
+    expect(await listReleaseSnapshotIdsForApp(pool, 'app_tmpl')).toEqual(new Set(['snap_r1']));
+  });
+});
+
+// Same predicate bug that migration 111 fixed for the update mutex: a clone
+// passes through copying_repo / replaying_schema / replaying_rls /
+// replaying_functions / seeding_data / replaying_config /
+// replaying_durable_objects, but the pin only covered pending + processing. From
+// copying_repo onward the source snapshot was unpinned, so a repo push on the
+// template mid-clone could delete the very snapshot being copied.
+describe('listActiveCloneSnapshotIdsForApp', () => {
+  it('pins on every NON-TERMINAL status, not just pending/processing', async () => {
+    const { pool, calls } = fakeDb([]);
+    await listActiveCloneSnapshotIdsForApp(pool, 'app_tmpl');
+    const sql = calls[0].sql;
+    expect(sql).not.toMatch(/IN \(\s*'pending',\s*'processing'\s*\)/i);
+    expect(sql).toMatch(/NOT/i);
+    expect(calls[0].params).toEqual(['app_tmpl', ['completed', 'failed']]);
+  });
+
+  it('returns the snapshots in-flight clones are reading', async () => {
+    const { pool } = fakeDb([{ source_snapshot_id: 'snap_a' }, { source_snapshot_id: 'snap_b' }]);
+    expect(await listActiveCloneSnapshotIdsForApp(pool, 'app_tmpl'))
+      .toEqual(new Set(['snap_a', 'snap_b']));
+  });
+});

--- a/services/control-api/src/routes/repo.ts
+++ b/services/control-api/src/routes/repo.ts
@@ -24,6 +24,7 @@ import {
 } from '../services/repo-storage.js';
 import { presignBuildCacheGet, presignBuildCachePut } from '../services/r2.js';
 import { planRetention } from '../services/repo-retention.js';
+import { listReleaseSnapshotIdsForApp } from '../services/template-releases.js';
 import { listActiveCloneSnapshotIdsForApp } from '../services/clone-jobs.js';
 import { getRuntimeDbPool } from '../services/runtime-db.js';
 import { config } from '../config.js';
@@ -194,8 +195,16 @@ export async function repoRoutes(app: FastifyInstance) {
           blobs: new Set(m.files.map(f => f.sha256)),
         };
       }));
-      const cloneActivePins = await listActiveCloneSnapshotIdsForApp(app.controlDb, ctx.appId);
-      const pinned = new Set<string>([manifest.snapshotId, ...cloneActivePins]);
+      // Pin: the snapshot just pushed, anything an in-flight clone is mid-copy on,
+      // and every snapshot a PUBLISHED RELEASE points at. Releases outlive the
+      // retention window by design — a fork may resolve one months later — so
+      // without this, publishing a release and then pushing REPO_RETAIN_SNAPSHOTS
+      // more commits silently deleted the bytes that release promised.
+      const [cloneActivePins, releasePins] = await Promise.all([
+        listActiveCloneSnapshotIdsForApp(app.controlDb, ctx.appId),
+        listReleaseSnapshotIdsForApp(app.controlDb, ctx.appId),
+      ]);
+      const pinned = new Set<string>([manifest.snapshotId, ...cloneActivePins, ...releasePins]);
       const plan = planRetention(summaries, pinned);
       for (const snap of plan.dropSnapshots) {
         await deleteSnapshot(ctx.appId, snap);

--- a/services/control-api/src/services/clone-jobs.ts
+++ b/services/control-api/src/services/clone-jobs.ts
@@ -336,15 +336,26 @@ export async function getActiveUpdateJob(
   return res.rows[0] ?? null;
 }
 
-/** Snapshot ids that an in-flight clone is reading from — caller adds them to planRetention's pinned set. */
+/**
+ * Snapshot ids that an in-flight clone is reading from — caller adds them to
+ * planRetention's pinned set.
+ *
+ * "In flight" is everything NOT terminal, not just pending/processing. A clone
+ * moves through copying_repo, replaying_schema, replaying_rls, seeding_data,
+ * replaying_functions, replaying_config and replaying_durable_objects, and the
+ * repo copy happens in the middle of that. Keying the pin on the two earliest
+ * statuses left the source snapshot unpinned for most of the clone's life, so a
+ * repo push on the template mid-clone could delete the very snapshot being
+ * copied. Same predicate mistake migration 111 fixed for the update mutex.
+ */
 export async function listActiveCloneSnapshotIdsForApp(
   controlDb: pg.Pool,
   sourceAppId: string,
 ): Promise<Set<string>> {
   const res = await controlDb.query<{ source_snapshot_id: string }>(
     `SELECT source_snapshot_id FROM template_clone_jobs
-     WHERE source_app_id = $1 AND status IN ('pending', 'processing')`,
-    [sourceAppId],
+      WHERE source_app_id = $1 AND NOT (status = ANY($2::text[]))`,
+    [sourceAppId, TERMINAL_CLONE_STATUSES],
   );
   return new Set(res.rows.map(r => r.source_snapshot_id));
 }

--- a/services/control-api/src/services/template-releases.ts
+++ b/services/control-api/src/services/template-releases.ts
@@ -149,3 +149,27 @@ export async function updateReleaseText(
   );
   return res.rows[0] ?? null;
 }
+
+/**
+ * Snapshot ids pinned by this app's published releases — the caller adds them to
+ * planRetention's pinned set.
+ *
+ * A release is a promise that a specific snapshot stays fetchable: forks resolve
+ * it at update time, potentially months later. Retention keeps only the newest
+ * REPO_RETAIN_SNAPSHOTS, and the pinned set previously held just the incoming
+ * snapshot plus in-flight clones — so publishing a release and then pushing five
+ * more commits deleted the snapshot that release pointed at, together with any
+ * blobs nothing else referenced. Nothing failed at push time. The release row
+ * survived, referencing bytes that no longer existed, and every fork updating
+ * from it died on "Source manifest not found".
+ */
+export async function listReleaseSnapshotIdsForApp(
+  controlDb: pg.Pool,
+  sourceAppId: string,
+): Promise<Set<string>> {
+  const res = await controlDb.query<{ snapshot_id: string }>(
+    `SELECT snapshot_id FROM template_releases WHERE source_app_id = $1`,
+    [sourceAppId],
+  );
+  return new Set(res.rows.map(r => r.snapshot_id));
+}


### PR DESCRIPTION
`repo push` runs `planRetention` with `REPO_RETAIN_SNAPSHOTS = 5`, and the pinned set held only the incoming snapshot plus clones in `pending`/`processing`. Two ways that deletes bytes something still depends on.

## 1. Published releases were never pinned

A release is a promise that a specific snapshot stays fetchable — a fork may resolve it months later. So publishing a release and then pushing five more commits deleted the snapshot that release points at, along with any blobs nothing else referenced.

**Nothing failed at push time.** The release row survived, referencing bytes that no longer existed, and every fork updating from it died on `Source manifest not found`.

This stopped being theoretical when real templates got releases: `butterbase-crm` `v1.0.0` pins `0f521de3…`, and that template is actively developed at 330 files. Five more pushes would have silently broken it.

## 2. In-flight clones were pinned for only 2 of 8 non-terminal statuses

A clone passes through `copying_repo`, `replaying_schema`, `replaying_rls`, `seeding_data`, `replaying_functions`, `replaying_config`, `replaying_durable_objects` — and **the repo copy happens in the middle of those**. Keying the pin on `pending`/`processing` left the source snapshot unpinned for most of the clone's life, so a push on the template mid-clone could delete the snapshot being copied.

Same predicate mistake migration `111` fixed for the update mutex. Now keyed on `NOT terminal`, using the existing `TERMINAL_CLONE_STATUSES`.

## Verification

New unit tests cover both helpers, including the dedupe case (two releases from one snapshot) and an assertion that the clone pin no longer keys on `IN ('pending','processing')`.

No regressions: failing-FILE sets diffed against a baseline taken on **this same commit** — 78 with the change, a strict subset of the baseline's 79. (Large pre-existing failure population, flaky run to run, no CI on this repo.)

Not covered by tests: the wiring in `routes/repo.ts` itself, since there is no route harness for it (S3 + quota + auth). Verifying behaviourally after deploy — publish a release on a throwaway template, push past the retention window, confirm the release snapshot survives and still clones.