### PR TITLE
fix(schema): validate column DEFAULT and index opclass before interpolating

### DIFF
--- a/services/control-api/src/__tests__/schema-default-injection.test.ts
+++ b/services/control-api/src/__tests__/schema-default-injection.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeColumnDefault, isSafeOpclass, SchemaDSLSchema } from '../services/schema-validator.js';
+import { diffSchema } from '../services/schema-differ.js';
+
+// `default` and `opclass` were bare z.string() while type / table / column all
+// had patterns, and all four are interpolated straight into DDL. Statements run
+// via client.query(sql) with no params, which is Postgres's SIMPLE query
+// protocol — it happily executes `;`-chained statements. So a crafted default
+// ran arbitrary SQL inside the migration transaction.
+//
+// The template-update path made that cross-tenant: a template owner could ship
+// a payload that executes on every fork applying an update. filterAdditive only
+// rejects destructive DDL *kinds*, so a non-DROP payload (UPDATE, INSERT, COPY,
+// GRANT) sailed through it.
+describe('isSafeColumnDefault — accepts the real-world forms', () => {
+  const good = [
+    "gen_random_uuid()",
+    "now()",
+    "uuid_generate_v4()",
+    "CURRENT_TIMESTAMP",
+    "current_timestamp",
+    "CURRENT_DATE",
+    "LOCALTIMESTAMP",
+    "true",
+    "false",
+    "TRUE",
+    "null",
+    "0",
+    "-1",
+    "3.14",
+    "1e5",
+    "'pending'",
+    "''",
+    "'[]'",
+    "'[]'::jsonb",
+    "'{}'::jsonb",
+    "'{}'::text[]",
+    "'x''y'",              // doubled quote is the SQL escape, not a break-out
+    "nextval('my_seq')",
+    "now()::timestamptz",
+    "0::numeric(10,2)",
+    "  'padded'  ",        // surrounding whitespace is fine
+  ];
+  for (const d of good) {
+    it(`accepts ${JSON.stringify(d)}`, () => {
+      expect(isSafeColumnDefault(d)).toBe(true);
+    });
+  }
+});
+
+describe('isSafeColumnDefault — rejects injection', () => {
+  const bad: [string, string][] = [
+    ["'x'; DROP TABLE users; --", 'statement chaining'],
+    ["'x'; UPDATE members SET role='admin'; --", 'non-destructive payload filterAdditive would miss'],
+    ["'x'--", 'line comment'],
+    ["'x'/* c */", 'block comment'],
+    ["$$; DROP TABLE t; $$", 'dollar quoting'],
+    ["'unterminated", 'unbalanced quote'],
+    ["'a' || (SELECT password FROM secrets LIMIT 1)", 'subselect'],
+    ["(SELECT 1)", 'bare subselect'],
+    ["pg_read_file('/etc/passwd')", 'non-allowlisted function'],
+    ["gen_random_uuid(); DROP TABLE t", 'chaining after a legitimate call'],
+    ["1; COPY t FROM PROGRAM 'sh -c id'", 'COPY FROM PROGRAM'],
+  ];
+  for (const [d, why] of bad) {
+    it(`rejects ${why}: ${JSON.stringify(d)}`, () => {
+      expect(isSafeColumnDefault(d)).toBe(false);
+    });
+  }
+});
+
+describe('isSafeOpclass', () => {
+  it('accepts a plain operator class', () => {
+    expect(isSafeOpclass('vector_cosine_ops')).toBe(true);
+    expect(isSafeOpclass('gin_trgm_ops')).toBe(true);
+  });
+  it('rejects anything that is not a bare identifier', () => {
+    expect(isSafeOpclass('ops) ; DROP TABLE t; --')).toBe(false);
+    expect(isSafeOpclass('a b')).toBe(false);
+    expect(isSafeOpclass('"quoted"')).toBe(false);
+  });
+});
+
+// The validator is the gate the routes actually call, so the rejection has to
+// happen there — not only in the helper.
+describe('SchemaDSLSchema rejects an injected default', () => {
+  it('throws on a chained-statement default', () => {
+    expect(() => SchemaDSLSchema.parse({
+      tables: {
+        t: { columns: { c: { type: 'text', default: "'x'; DROP TABLE users; --" } } },
+      },
+    })).toThrow();
+  });
+
+  it('still accepts a legitimate schema', () => {
+    expect(() => SchemaDSLSchema.parse({
+      tables: {
+        t: {
+          columns: {
+            id: { type: 'uuid', primaryKey: true, default: 'gen_random_uuid()' },
+            status: { type: 'text', default: "'pending'" },
+            meta: { type: 'jsonb', default: "'{}'::jsonb" },
+          },
+        },
+      },
+    })).not.toThrow();
+  });
+
+  it('rejects an injected index opclass', () => {
+    expect(() => SchemaDSLSchema.parse({
+      tables: {
+        t: {
+          columns: { c: { type: 'text' } },
+          indexes: { i: { columns: ['c'], opclass: 'ops); DROP TABLE users; --' } },
+        },
+      },
+    })).toThrow();
+  });
+});
+
+// End-to-end: a validated schema must never produce DDL containing a statement
+// separator. This is the property that actually matters.
+describe('diffSchema never emits chained statements from a validated schema', () => {
+  it('emits one statement per DDL action, no embedded semicolons', () => {
+    const desired = SchemaDSLSchema.parse({
+      tables: {
+        t: {
+          columns: {
+            id: { type: 'uuid', primaryKey: true, default: 'gen_random_uuid()' },
+            status: { type: 'text', default: "'pending'" },
+          },
+        },
+      },
+    });
+    const stmts = diffSchema({ tables: {} }, desired as never);
+    for (const s of stmts) {
+      expect(s.sql.replace(/;\s*$/, '')).not.toContain(';');
+    }
+  });
+});
+
+// Every DEFAULT actually present on butterbase-crm (29 tables, 34 forks), read
+// out of `manage_schema get` on 2026-09-02. These are the introspected,
+// Postgres-canonicalised forms that round-trip through `manage_schema apply`,
+// so rejecting any of them breaks a live app. The first cut of this validator
+// was a regex and it rejected the interval expression below.
+describe('isSafeColumnDefault — real defaults from a live 29-table template', () => {
+  const live = [
+    "gen_random_uuid()",
+    "now()",
+    "true",
+    "false",
+    "0",
+    "25",
+    "180",
+    "'pending'::text",
+    "'copilot'::text",
+    "'active'::text",
+    "'member'::text",
+    "'draft'::text",
+    "'queued'::text",
+    "'gmail'::text",
+    "'people'::text",
+    "'manual'::text",
+    "'lead'::text",
+    "'Notetaker'::text",
+    "'{}'::jsonb",
+    "'[]'::jsonb",
+    "(now() + '24:00:00'::interval)",
+    "'[\"industry\", \"description\", \"linkedin_url\"]'::jsonb",
+    "'[\"title\", \"linkedin_url\"]'::jsonb",
+  ];
+  for (const d of live) {
+    it(`accepts live default ${JSON.stringify(d)}`, () => {
+      expect(isSafeColumnDefault(d)).toBe(true);
+    });
+  }
+});
+
+// The tokenizer is more permissive than the first regex (it has to be), so
+// re-assert the dangerous shapes against the shape it actually accepts.
+describe('isSafeColumnDefault — tokenizer still refuses execution', () => {
+  const bad = [
+    "(now() + '1 day'::interval); DROP TABLE t",
+    "now() || (SELECT 1)",
+    "(SELECT password FROM secrets)",
+    "COALESCE((SELECT 1), 2)",
+    "some_column",
+    "pg_sleep(10)",
+    "'a' -- x",
+    "(unbalanced",
+    "1 +",
+  ];
+  for (const d of bad) {
+    it(`rejects ${JSON.stringify(d)}`, () => {
+      expect(isSafeColumnDefault(d)).toBe(false);
+    });
+  }
+});
+
+// Distinct forms from butter-support (20 tables, 20 forks), same date.
+describe('isSafeColumnDefault — real defaults from the second live template', () => {
+  const live = [
+    "'draft_for_approval'::text",
+    "'med'::text",
+    "'warn'::text",
+    "'widget'::text",
+    "'open'::text",
+    "'idle'::text",
+    "'normal'::text",
+    "1",
+    "'{}'::text[]",
+  ];
+  for (const d of live) {
+    it(`accepts live default ${JSON.stringify(d)}`, () => {
+      expect(isSafeColumnDefault(d)).toBe(true);
+    });
+  }
+});

--- a/services/control-api/src/services/schema-validator.ts
+++ b/services/control-api/src/services/schema-validator.ts
@@ -25,6 +25,165 @@ function isValidType(type: string): boolean {
   return false;
 }
 
+
+// ---------------------------------------------------------------------------
+// Column DEFAULT / index opclass safety
+// ---------------------------------------------------------------------------
+//
+// `default` and `opclass` are interpolated verbatim into DDL (schema-differ
+// emits `... SET DEFAULT ${col.default}`), and schema-applier runs each
+// statement through client.query(sql) with no bind params — Postgres's SIMPLE
+// query protocol, which executes `;`-chained statements. An unvalidated default
+// was therefore arbitrary SQL execution inside the migration transaction.
+//
+// Not merely self-inflicted: the template-update path replays a template's
+// schema onto every fork, so a payload authored once ran on other people's
+// databases. filterAdditive is no defence — it rejects destructive DDL *kinds*,
+// and `UPDATE members SET role='admin'` is not one.
+//
+// DDL defaults cannot be parameterized, so the control is an allowlist. This is
+// a tokenizer rather than one big regex for two reasons: the regex version
+// rejected `(now() + '24:00:00'::interval)`, a real default on a live template,
+// and a grammar this permissive is not something anyone can audit as a regex.
+
+/** Functions permitted in a default. `now()` is harmless, `pg_read_file()` is
+ *  not, and nothing distinguishes them automatically. Extend consciously. */
+const ALLOWED_DEFAULT_FUNCTIONS = new Set([
+  'now', 'current_timestamp', 'current_date', 'current_time',
+  'localtime', 'localtimestamp', 'statement_timestamp', 'transaction_timestamp',
+  'clock_timestamp', 'gen_random_uuid', 'uuid_generate_v4', 'nextval',
+  'date_trunc', 'to_timestamp', 'age', 'coalesce', 'array', 'jsonb_build_object',
+  'json_build_object', 'array_to_json',
+]);
+
+/** Barewords that may stand alone (no parentheses). */
+const ALLOWED_DEFAULT_KEYWORDS = new Set([
+  'true', 'false', 'null',
+  'current_date', 'current_timestamp', 'current_time',
+  'localtime', 'localtimestamp',
+]);
+
+/** Operators allowed between operands. */
+const ALLOWED_OPERATORS = new Set(['+', '-', '*', '/', '||']);
+
+/**
+ * True if `d` is a column DEFAULT expression we are willing to interpolate.
+ *
+ * Accepts: string/numeric literals, the standalone datetime keywords,
+ * allowlisted function calls, `::type` casts (including `numeric(10,2)` and
+ * `text[]`), parenthesised sub-expressions, and the operators above.
+ *
+ * Rejects rather than escapes — an arbitrary SQL *expression* cannot be escaped
+ * safely. A rejection must surface as a validation error naming the field, never
+ * be silently dropped: a dropped default changes the table's semantics.
+ */
+export function isSafeColumnDefault(d: string): boolean {
+  const src = d.trim();
+  if (src.length === 0 || src.length > 1000) return false;
+
+  let i = 0;
+  let depth = 0;
+  let afterCast = false;   // the next identifier is a TYPE name, not a function
+  let prevSignificant = ''; // last token emitted, for operator/operand sanity
+
+  while (i < src.length) {
+    const c = src[i];
+
+    // Whitespace
+    if (/\s/.test(c)) { i++; continue; }
+
+    // String literal — content is inert, but the quoting must close.
+    if (c === "'") {
+      i++;
+      for (;;) {
+        if (i >= src.length) return false;              // unterminated
+        if (src[i] === "'") {
+          if (src[i + 1] === "'") { i += 2; continue; } // '' escape
+          i++; break;
+        }
+        i++;
+      }
+      prevSignificant = 'operand';
+      afterCast = false;
+      continue;
+    }
+
+    // Comment introducers and statement separators are never legitimate here.
+    if (c === ';' || c === '$' || c === '"' || c === '\\' || c === '@' || c === '#') return false;
+    if (c === '-' && src[i + 1] === '-') return false;
+    if (c === '/' && src[i + 1] === '*') return false;
+
+    // Cast
+    if (c === ':' && src[i + 1] === ':') { i += 2; afterCast = true; continue; }
+
+    // Parens
+    if (c === '(') { depth++; i++; prevSignificant = 'open'; continue; }
+    if (c === ')') { depth--; if (depth < 0) return false; i++; prevSignificant = 'operand'; continue; }
+
+    // Array-type brackets, only meaningful right after a cast type
+    if (c === '[' || c === ']') { i++; continue; }
+
+    // Argument separator
+    if (c === ',') { i++; prevSignificant = 'op'; continue; }
+
+    // Operators
+    if (c === '|' && src[i + 1] === '|') { i += 2; prevSignificant = 'op'; continue; }
+    if (ALLOWED_OPERATORS.has(c)) {
+      // A leading +/- is a sign on a number, which is fine either way.
+      i++; prevSignificant = 'op'; continue;
+    }
+
+    // Numeric literal
+    if (/[0-9]/.test(c)) {
+      while (i < src.length && /[0-9.]/.test(src[i])) i++;
+      if (i < src.length && /[eE]/.test(src[i]) && /[0-9+-]/.test(src[i + 1] ?? '')) {
+        i += 2;
+        while (i < src.length && /[0-9]/.test(src[i])) i++;
+      }
+      prevSignificant = 'operand';
+      afterCast = false;
+      continue;
+    }
+
+    // Identifier: function name, type name, or standalone keyword
+    if (/[A-Za-z_]/.test(c)) {
+      const startI = i;
+      while (i < src.length && /[A-Za-z0-9_]/.test(src[i])) i++;
+      const word = src.slice(startI, i).toLowerCase();
+
+      // A type name after `::` — any identifier is fine; it is not executable.
+      if (afterCast) { afterCast = false; prevSignificant = 'operand'; continue; }
+
+      // Look ahead past whitespace for a '(' to decide function vs keyword.
+      let j = i;
+      while (j < src.length && /\s/.test(src[j])) j++;
+      const isCall = src[j] === '(';
+
+      if (isCall) {
+        if (!ALLOWED_DEFAULT_FUNCTIONS.has(word)) return false;
+      } else if (!ALLOWED_DEFAULT_KEYWORDS.has(word)) {
+        // A bare identifier that is not a keyword would be a column or
+        // function reference — refuse it.
+        return false;
+      }
+      prevSignificant = 'operand';
+      continue;
+    }
+
+    // Anything else is unrecognised, so refuse.
+    return false;
+  }
+
+  if (depth !== 0) return false;
+  if (prevSignificant === 'op' || prevSignificant === 'open') return false;
+  return true;
+}
+
+/** Index operator classes are bare identifiers (vector_cosine_ops, gin_trgm_ops). */
+export function isSafeOpclass(o: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(o);
+}
+
 const referentialActionEnum = z.enum([
   'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION',
 ]);
@@ -42,7 +201,12 @@ const ColumnDefSchema = z.object({
   }),
   primaryKey: z.boolean().optional(),
   nullable: z.boolean().optional(),
-  default: z.string().optional(),
+  default: z.string().refine(isSafeColumnDefault, {
+    message:
+      'Unsupported DEFAULT expression. Allowed: literals, TRUE/FALSE/NULL, the ' +
+      'CURRENT_* datetime keywords, and simple calls such as now() or ' +
+      'gen_random_uuid(), each with an optional ::type cast.',
+  }).optional(),
   unique: z.boolean().optional(),
   references: z.union([
     z.string().regex(/^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/, 'Must be "table.column"'),
@@ -54,7 +218,9 @@ const IndexDefSchema = z.object({
   columns: z.array(z.string().regex(identifierPattern)),
   unique: z.boolean().optional(),
   method: z.enum(['btree', 'hash', 'gist', 'gin', 'hnsw', 'ivfflat']).optional(),
-  opclass: z.string().optional(),
+  opclass: z.string().refine(isSafeOpclass, {
+    message: 'Operator class must be a bare identifier, e.g. vector_cosine_ops.',
+  }).optional(),
 });
 
 const TableDefSchema = z.object({


### PR DESCRIPTION
`default` and `opclass` were bare `z.string()` while `type`, table and column names all had patterns — and all of them are interpolated verbatim into DDL by `schema-differ` (3 sites for `default`, 1 for `opclass`). `schema-applier` then runs each statement through `client.query(sql)` with no bind params, which is Postgres's **simple query protocol**: it executes `;`-chained statements.

A crafted default was therefore arbitrary SQL inside the migration transaction.

## Why it wasn't only self-inflicted

The template-update path replays a template's schema onto **every fork**, so a payload authored once ran on other people's databases.

`filterAdditive` is no defence there — it rejects destructive DDL *kinds*, and `UPDATE members SET role='admin'` is not one. Nor is a subselect that exfiltrates into a default value.

## Implemented as a tokenizer, not a regex — for a concrete reason

The first cut was a regex. Before shipping it I read the actual schemas of both live templates and found this on `agent_proposals.expires_at`, present in **both** `butterbase-crm` (34 forks) and `butter-support` (20 forks):

```
"default": "(now() + '24:00:00'::interval)"
```

**The regex rejected it.** Postgres returns that canonicalized form from introspection, so it round-trips through `manage_schema apply` — shipping the regex would have broken schema changes on both templates and every fork of them.

A grammar permissive enough to accept that is also not auditable as a regex, and this is security code.

**Accepts:** string/numeric literals, standalone datetime keywords, allowlisted function calls, `::type` casts (incl. `numeric(10,2)`, `text[]`), parenthesised sub-expressions, arithmetic.
**Refuses:** bare identifiers (column/function references), non-allowlisted calls, comments, dollar quotes, unbalanced quotes, statement separators.

## Verification

Unit: 84 tests, including **every DEFAULT actually present on both live templates**, read out of `manage_schema get` — so the regression this nearly shipped is permanently guarded.

Real HTTP against a locally rebuilt stack:

| payload | path | result |
|---|---|---|
| `'x'; CREATE TABLE pwned_marker(id int); --` | CREATE TABLE | 400 |
| `'x'; UPDATE memberships SET role='admin'; --` | ALTER SET DEFAULT | 400 |
| `'a' \|\| (SELECT secret FROM widget_secrets LIMIT 1)` | ALTER SET DEFAULT | 400 |
| `'x' -- comment` / `$$; DROP TABLE contacts; $$` / `pg_sleep(5)` | ALTER SET DEFAULT | 400 |
| `ops); CREATE TABLE pwned_idx(id int); --` | index opclass | 400 |
| full set of real production defaults | CREATE TABLE | **200** |

Nothing executed: `pwned_marker` / `pwned_idx` absent, existing tables untouched, zero `level:50`. The applied defaults are functional, not merely stored — a `DEFAULT VALUES` insert computed `expires_at` 24h out.

No regressions: failing-FILE sets diffed against a baseline on this same commit.