### PR TITLE
fix(auto-api): JSON-encode values bound for json/jsonb columns

### DIFF
--- a/services/control-api/src/routes/auto-api.ts
+++ b/services/control-api/src/routes/auto-api.ts
@@ -4,6 +4,7 @@ import type { Pool, PoolClient } from 'pg';
 import { getAppPoolForApp } from '../services/app-pool.js';
 import { introspectSchema } from '../services/schema-introspector.js';
 import { buildSelectQuery } from '../services/query-builder.js';
+import { encodeValuesForColumns } from '../services/pg-json-values.js';
 import { AppResolver, AppNotFoundError, AppAuthRequiredError, AppPausedError, assertAppNotPaused } from '../services/app-resolver.js';
 import { verifyEndUserJwt } from '../services/end-user-auth.js';
 import { ApiKeyService } from '../services/api-key-service.js';
@@ -1024,7 +1025,7 @@ export async function autoApiRoutes(app: FastifyInstance) {
 
       const columns = entries.map(([k]) => `"${k}"`).join(', ');
       const placeholders = entries.map((_, i) => `$${i + 1}`).join(', ');
-      const values = entries.map(([, v]) => v);
+      const values = encodeValuesForColumns(entries, tableDef.columns);
 
       const result = await executeWithRole(pool, role, userId, async (client) => {
         return client.query(
@@ -1140,7 +1141,7 @@ export async function autoApiRoutes(app: FastifyInstance) {
       }
 
       const setClauses = entries.map(([k], i) => `"${k}" = $${i + 1}`).join(', ');
-      const values = [...entries.map(([, v]) => v), id];
+      const values = [...encodeValuesForColumns(entries, tableDef.columns), id];
 
       const result = await executeWithRole(pool, role, userId, async (client) => {
         return client.query(

--- a/services/control-api/src/services/__tests__/pg-json-values.test.ts
+++ b/services/control-api/src/services/__tests__/pg-json-values.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { encodeValuesForColumns } from '../pg-json-values.js';
+
+/**
+ * node-pg serialises a JS array as a Postgres ARRAY literal ("{}", "{\"a\",\"b\"}")
+ * whatever the target column is. Bound to a json/jsonb column, Postgres then parses
+ * that literal as JSON — so ["a","b"] became {"a","b"} and failed with
+ * `Expected ":", but found ","`, while [] became {} and was stored, silently, as an
+ * empty OBJECT instead of an empty array.
+ *
+ * Values for json/jsonb columns must therefore be JSON-encoded text before binding.
+ */
+const columns = {
+  id: { type: 'uuid' },
+  title: { type: 'text' },
+  filters: { type: 'jsonb' },
+  legacy_doc: { type: 'json' },
+  tags: { type: 'text[]' },
+  count: { type: 'integer' },
+};
+
+const encode = (row: Record<string, unknown>) =>
+  Object.fromEntries(
+    encodeValuesForColumns(Object.entries(row), columns).map((v, i) => [Object.keys(row)[i], v])
+  );
+
+describe('encodeValuesForColumns', () => {
+  it('JSON-encodes a non-empty array bound for a jsonb column', () => {
+    expect(encode({ filters: ['a', 'b'] }).filters).toBe('["a","b"]');
+  });
+
+  it('JSON-encodes an EMPTY array so it stays an array, not an object', () => {
+    // The silent-corruption case: [] bound raw became {} in the database.
+    expect(encode({ filters: [] }).filters).toBe('[]');
+  });
+
+  it('JSON-encodes arrays of objects and of numbers', () => {
+    expect(encode({ filters: [{ k: 1 }] }).filters).toBe('[{"k":1}]');
+    expect(encode({ filters: [1, 2] }).filters).toBe('[1,2]');
+  });
+
+  it('encodes json columns the same way as jsonb', () => {
+    expect(encode({ legacy_doc: ['x'] }).legacy_doc).toBe('["x"]');
+  });
+
+  it('JSON-encodes objects for jsonb columns too, rather than relying on the driver', () => {
+    expect(encode({ filters: { a: 1 } }).filters).toBe('{"a":1}');
+  });
+
+  it('leaves text[] arrays alone — the array literal is correct for that type', () => {
+    expect(encode({ tags: ['a', 'b'] }).tags).toEqual(['a', 'b']);
+  });
+
+  it('leaves scalars and null untouched', () => {
+    expect(encode({ title: 'hello' }).title).toBe('hello');
+    expect(encode({ count: 3 }).count).toBe(3);
+    expect(encode({ filters: null }).filters).toBeNull();
+  });
+
+  it('passes a string through unchanged, so a client that already encoded still works', () => {
+    expect(encode({ filters: '["a"]' }).filters).toBe('["a"]');
+  });
+
+  it('ignores columns it knows nothing about', () => {
+    expect(encodeValuesForColumns([['mystery', ['a']]], columns)).toEqual([['a']]);
+  });
+
+  it('preserves order and arity of the entries it is given', () => {
+    const entries: [string, unknown][] = [['title', 't'], ['filters', ['a']], ['count', 1]];
+    expect(encodeValuesForColumns(entries, columns)).toEqual(['t', '["a"]', 1]);
+  });
+});

--- a/services/control-api/src/services/pg-json-values.ts
+++ b/services/control-api/src/services/pg-json-values.ts
@@ -1,0 +1,49 @@
+/**
+ * Encoding of request values before they are bound as query parameters.
+ *
+ * node-pg serialises a JavaScript array into a Postgres ARRAY literal — `{}` for an
+ * empty one, `{"a","b"}` otherwise — regardless of the column it is bound to. That is
+ * correct for `text[]` and wrong for `json` / `jsonb`, where Postgres then tries to
+ * read the array literal as JSON:
+ *
+ *   ["a","b"]  ->  {"a","b"}  ->  22P02: Expected ":", but found ","   (rejected, 400)
+ *   []         ->  {}         ->  a valid, EMPTY JSON OBJECT           (accepted, wrong)
+ *
+ * The second case is the dangerous one: an empty list was stored as an empty object
+ * with no error. Plain objects were unaffected because node-pg JSON-encodes those.
+ *
+ * So values headed for a JSON column are encoded here rather than left to the driver.
+ */
+
+const JSON_COLUMN_TYPES = new Set(['json', 'jsonb']);
+
+export interface ColumnTypeInfo {
+  type: string;
+}
+
+/** True when this column stores JSON and needs an encoded string rather than a raw value. */
+export function isJsonColumn(column: ColumnTypeInfo | undefined): boolean {
+  if (!column) return false;
+  return JSON_COLUMN_TYPES.has(String(column.type).trim().toLowerCase());
+}
+
+/**
+ * Map `[column, value]` pairs to the values to bind, JSON-encoding anything bound for
+ * a json/jsonb column. Order and arity are preserved so the result lines up with the
+ * `$1, $2, …` placeholders built from the same entries.
+ *
+ * Values are left untouched when the column is unknown, the column is not JSON, the
+ * value is null/undefined, or the caller already passed encoded text.
+ */
+export function encodeValuesForColumns(
+  entries: Array<[string, unknown]>,
+  columns: Record<string, ColumnTypeInfo>
+): unknown[] {
+  return entries.map(([key, value]) => {
+    if (!isJsonColumn(columns[key])) return value;
+    if (value === null || value === undefined) return value;
+    // A string is taken as already-encoded JSON; re-encoding would double-quote it.
+    if (typeof value === 'string') return value;
+    return JSON.stringify(value);
+  });
+}


### PR DESCRIPTION
## The bug

A row the data API returns cannot be written back to it. `GET` hands you a JSON array; `POST` refuses it:

```
400 VALIDATION_INVALID_INPUT — Invalid input: Expected ":", but found ","
```

## Root cause

`routes/auto-api.ts` bound request values straight to node-pg. node-pg serialises a JS array as a Postgres ARRAY literal regardless of the target column — correct for `text[]`, wrong for `json`/`jsonb`, where Postgres then parses that literal as JSON:

```
["a","b"]  ->  {"a","b"}  ->  22P02: Expected ":", but found ","   (rejected, 400)
[]         ->  {}         ->  a valid, EMPTY JSON OBJECT           (accepted, WRONG)
```

**The empty-array case is the more serious half:** `[]` was accepted and silently stored as `{}` — a list became an object, with no error. Confirmed via `jsonb_typeof` on an affected row.

Objects were unaffected (node-pg JSON-encodes them); `text[]` was unaffected (the literal is right for that type).

## Blast radius

Any read-edit-write client, whenever a row carries a populated `jsonb` array. In the CRM template that is `enrichment_settings.target_columns_*` on every workspace, plus any populated `saved_views.filters`, `agent_messages.tool_calls`, `comment_campaign_items.target_post_meta` and `social_posts.media`.

The error's own remediation text also had it backwards — it told callers not to send the stringified form that was in fact the only one that worked.

## Fix

New `services/pg-json-values.ts` exports `encodeValuesForColumns`, which JSON-encodes values bound for `json`/`jsonb` columns and leaves everything else alone. Wired into both write paths — `POST /v1/:app_id/:table` and `PATCH /v1/:app_id/:table/:id` — the only two sites binding caller-supplied column values.

It is a separate pure module rather than inline because the auto-api integration tests need live Postgres and are excluded from the default vitest run; the seam gives the fix ten tests that actually execute by default.

## Verification

- 10 unit tests on the encoder, written before the fix (confirmed failing), now green in the default suite.
- 13 behavioural checks against a rebuilt container: non-empty arrays accepted and stored as arrays; **empty arrays stay arrays**; objects unchanged; already-encoded strings not double-encoded; `text[]` untouched; PATCH fixed; and a row the API emitted can be written straight back.
- Real MCP client → server → DB via `insert_row` / `select_rows`: value stored as a genuine jsonb array.
- Full control-api suite against a **same-commit baseline**: 65 failing files before, 66 after. The one extra, `deployment.wfp.test.ts`, passes 11/11 in isolation, is load/timing sensitive, and sits in code this change never touches.

## Not included

`clone-replay.ts` (~line 327) binds seed-data rows the same way and has the same defect, but a different failure mode — the insert is soft-failed and logged as a job warning, so the symptom is silently missing seed rows during clone / template-update. Deserves its own change and its own test.

No migrations. No new env vars. control-api only.