### PR TITLE
feat(control-api): register the app-copy overlay routes and worker

### DIFF
--- a/services/control-api/src/index.ts
+++ b/services/control-api/src/index.ts
@@ -696,6 +696,25 @@ try {
   // admin billing remediation console in production.
   console.warn('[control-api] admin-remediation overlay not registered:', err);
 }
+try {
+  // @ts-expect-error — overlay path resolved at runtime
+  const overlay = await import('../../../cloud-overlays/dist/cloud-overlays/app-copy/routes.js');
+  await app.register(overlay.default ?? overlay.appCopyRoutes);
+} catch (err) {
+  // OSS mode (overlay not built) is expected and must not throw — but a genuine
+  // registration error would otherwise silently 404 the app-copy console.
+  console.warn('[control-api] app-copy overlay not registered:', err);
+}
+try {
+  // @ts-expect-error — overlay path resolved at runtime
+  const worker = await import('../../../cloud-overlays/dist/cloud-overlays/app-copy/worker.js');
+  // @ts-expect-error — overlay path resolved at runtime
+  const deps = await import('../../../cloud-overlays/dist/cloud-overlays/app-copy/deps.js');
+  worker.startAppCopyWorker(app.controlDb, deps.makeExecuteDeps(app.controlDb));
+} catch (err) {
+  // OSS mode (overlay not built) is expected and must not throw.
+  console.warn('[control-api] app-copy worker not started:', err);
+}
 app.register(apiKeyRoutes);
 app.register(realtimeRoutes);
 app.register(ragRoutes);


### PR DESCRIPTION
Mounts the app-copy overlay. Without this, the overlay is built but nothing registers it: every `/admin/app-copy/*` call 404s and no copy job is ever claimed. This is the one OSS-side change the feature needs, and it blocks deploying it.

### What it does

- Registers `app-copy/routes.js` on the Fastify instance.
- Starts `startAppCopyWorker(app.controlDb, deps.makeExecuteDeps(app.controlDb))`.

### Why it looks like this

Both blocks copy the `admin-remediation` precedent directly above them: a dynamic import inside `try/catch`, so an OSS build with no overlay present degrades quietly, while a genuine registration failure is logged rather than swallowed. Nothing commercially sensitive crosses the boundary — only the import path and the graceful fallback.

Running the worker in every control-api instance is deliberate and safe: job claiming uses `FOR UPDATE SKIP LOCKED`, so instances compete for jobs rather than duplicating them.

### Notes for the reviewer

- The overlay itself lives in the private repo and is not part of this PR.
- Behaviour in an OSS build is unchanged: both imports fail, both warn, startup continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ydfdmR6Sf4fB9hAtSjabT
