### PR TITLE
feat(billing): configurable auto-refill threshold + warn the billed org

### DIFF
--- a/db/control-plane/115_auto_refill_threshold_and_org_credit_email_state.sql
+++ b/db/control-plane/115_auto_refill_threshold_and_org_credit_email_state.sql
@@ -1,0 +1,70 @@
+-- @scope: platform
+-- 115: Make the auto-refill trigger point user-configurable, and move the
+-- credits-email dedup markers from platform_users onto organizations.
+--
+-- Two related changes, one migration, because the email path reads both.
+--
+-- 1. organizations.auto_refill_threshold_usd
+--    Until now the trigger was a hardcoded constant in auto-refill-service.ts
+--    (`LOW_LEGACY_TOPUP_USD = 5`): with no monthly allowance left, refill fired
+--    once top-up credit fell below $5. That number was never surfaced in the
+--    UI, so "when does this actually charge me?" had no answer short of
+--    reading the source. This column is that constant, per-org.
+--
+--    NULL means "use the built-in default of 5", deliberately: every existing
+--    org keeps today's exact behaviour on deploy, and the column only starts
+--    mattering once someone edits it in the dashboard. A NOT NULL DEFAULT 5
+--    would look equivalent but is not — it erases the distinction between
+--    "never configured" and "deliberately set to 5", which is the thing an
+--    admin wants to know when debugging a refill that fired early.
+--
+--    It does NOT govern the second trigger. `crossedZero` (monthly + topup
+--    <= 0) stays unconditional in the service, so an org whose threshold is
+--    set to $1 and which takes a single $40 charge from $30 still refills
+--    instead of sailing past the trigger into the negative floor.
+--
+-- 2. organizations.credits_low_emailed_at / credits_exhausted_emailed_at
+--    Migration 071 put these on platform_users, before billing was per-org.
+--    Migration 093 moved the balances they debounce (monthly_allowance_usd,
+--    credits_usd) onto organizations and left these behind, so the low-credit
+--    email keyed its "already warned" state to the USER while reading the
+--    balance of that user's PERSONAL org. On a team org that is the wrong
+--    balance entirely: the org burning credits is not the org being checked,
+--    so team orgs were never warned, and a user in three orgs shared one
+--    debounce marker across all of them.
+--
+--    The markers belong next to the balance they debounce. The platform_users
+--    columns are intentionally NOT dropped here — same reasoning as migration
+--    096 gave for the stale auto_refill_* columns: drop them in a separate
+--    migration once a sweep confirms no reader remains. Leaving them costs two
+--    dead columns; dropping them early costs an outage if a reader was missed.
+
+BEGIN;
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS auto_refill_threshold_usd    NUMERIC(10,2),
+  ADD COLUMN IF NOT EXISTS credits_low_emailed_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS credits_exhausted_emailed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN organizations.auto_refill_threshold_usd IS
+  'Balance at or below which auto-refill charges the card, in USD. NULL means use the service default of 5. Does not govern the crossedZero trigger, which always fires at a combined balance of zero.';
+COMMENT ON COLUMN organizations.credits_low_emailed_at IS
+  'Debounce marker for the credits_low email. Cleared whenever the org balance is topped up or the monthly allowance resets.';
+COMMENT ON COLUMN organizations.credits_exhausted_emailed_at IS
+  'Debounce marker for the credits_exhausted email. Cleared whenever the org balance is topped up or the monthly allowance resets.';
+
+-- Carry the existing per-user markers over to each user's personal org, so
+-- deploying this does not re-send a warning to everyone who was already warned.
+-- Only personal orgs can be backfilled — team orgs have no prior state to
+-- inherit, and start un-warned, which is correct: they were never warned.
+UPDATE organizations o
+   SET credits_low_emailed_at       = pu.credits_low_emailed_at,
+       credits_exhausted_emailed_at = pu.credits_exhausted_emailed_at
+  FROM platform_users pu
+ WHERE pu.personal_organization_id = o.id
+   AND o.credits_low_emailed_at IS NULL
+   AND o.credits_exhausted_emailed_at IS NULL
+   AND (pu.credits_low_emailed_at IS NOT NULL
+     OR pu.credits_exhausted_emailed_at IS NOT NULL);
+
+COMMIT;

--- a/services/control-api/src/routes/auto-refill.ts
+++ b/services/control-api/src/routes/auto-refill.ts
@@ -3,10 +3,24 @@ import { z } from 'zod';
 import { requireUserId } from '../utils/require-auth.js';
 import { isHttpError } from '../services/error-handler.js';
 import { apiError } from '../utils/api-error.js';
+import {
+  DEFAULT_AUTO_REFILL_THRESHOLD_USD,
+  MIN_AUTO_REFILL_THRESHOLD_USD,
+  MAX_AUTO_REFILL_THRESHOLD_USD,
+} from '../services/auto-refill-service.js';
 
 const putSchema = z.object({
   enabled: z.boolean(),
   amount_usd: z.number().min(5).max(500).nullable().optional(),
+  // Omitted -> leave the stored threshold alone. Explicit null -> clear it and
+  // fall back to the service default. The two are distinct on purpose: a
+  // client that only toggles `enabled` must not silently reset the trigger.
+  threshold_usd: z
+    .number()
+    .min(MIN_AUTO_REFILL_THRESHOLD_USD)
+    .max(MAX_AUTO_REFILL_THRESHOLD_USD)
+    .nullable()
+    .optional(),
 });
 
 export async function autoRefillRoutes(app: FastifyInstance) {
@@ -16,10 +30,12 @@ export async function autoRefillRoutes(app: FastifyInstance) {
       const r = await app.controlDb.query<{
         auto_refill_enabled: boolean;
         auto_refill_amount_usd: string | null;
+        auto_refill_threshold_usd: string | null;
         auto_refill_last_attempt_at: Date | null;
         auto_refill_last_failure_reason: string | null;
       }>(
         `SELECT o.auto_refill_enabled, o.auto_refill_amount_usd,
+                o.auto_refill_threshold_usd,
                 o.auto_refill_last_attempt_at, o.auto_refill_last_failure_reason
          FROM organizations o
          JOIN platform_users u ON u.personal_organization_id = o.id
@@ -30,9 +46,21 @@ export async function autoRefillRoutes(app: FastifyInstance) {
         return reply.code(404).send({ error: 'user_not_found' });
       }
       const row = r.rows[0];
+      const configured = row.auto_refill_threshold_usd != null
+        ? parseFloat(row.auto_refill_threshold_usd)
+        : null;
       return {
         enabled: row.auto_refill_enabled,
         amount_usd: row.auto_refill_amount_usd != null ? parseFloat(row.auto_refill_amount_usd) : null,
+        // `threshold_usd` is what the org actually set (null = never set);
+        // `effective_threshold_usd` is the number the service will compare
+        // against, so a client can render "we charge below $X" without having
+        // to know the default. Both, because collapsing them would hide
+        // whether the value was chosen or inherited.
+        threshold_usd: configured,
+        effective_threshold_usd: configured ?? DEFAULT_AUTO_REFILL_THRESHOLD_USD,
+        threshold_min_usd: MIN_AUTO_REFILL_THRESHOLD_USD,
+        threshold_max_usd: MAX_AUTO_REFILL_THRESHOLD_USD,
         last_attempt_at: row.auto_refill_last_attempt_at,
         last_failure_reason: row.auto_refill_last_failure_reason,
       };
@@ -68,13 +96,20 @@ export async function autoRefillRoutes(app: FastifyInstance) {
         }
       }
 
+      // `threshold_usd` absent from the body leaves the column untouched —
+      // hence the COALESCE against a sentinel rather than a plain assignment.
+      const thresholdProvided = Object.prototype.hasOwnProperty.call(
+        request.body as object,
+        'threshold_usd',
+      );
       await app.controlDb.query(
         `UPDATE organizations SET
            auto_refill_enabled = $1,
            auto_refill_amount_usd = $2,
+           auto_refill_threshold_usd = CASE WHEN $4 THEN $5 ELSE auto_refill_threshold_usd END,
            auto_refill_last_failure_reason = CASE WHEN $1 THEN NULL ELSE auto_refill_last_failure_reason END
          WHERE id = (SELECT personal_organization_id FROM platform_users WHERE id = $3)`,
-        [body.enabled, body.amount_usd ?? null, userId]
+        [body.enabled, body.amount_usd ?? null, userId, thresholdProvided, body.threshold_usd ?? null]
       );
 
       // Audit events deferred — see auto-refill-service.ts header comment.

--- a/services/control-api/src/services/__tests__/credits-email.test.ts
+++ b/services/control-api/src/services/__tests__/credits-email.test.ts
@@ -3,111 +3,156 @@ import { maybeSendCreditsEmail, resetCreditsEmailState } from '../credits-email.
 
 type FakeRow = Record<string, unknown>;
 
-// Minimal Pool-like mock that captures queries.
-function mockDb(selectRows: FakeRow[] = []) {
+/**
+ * Minimal Pool-like mock that dispatches by SQL shape:
+ *   - the org SELECT returns `orgRow`
+ *   - the organization_members owner-email SELECT returns `ownerEmails`
+ *   - the marker-claiming UPDATE reports `claimRowCount` rows affected, so a
+ *     test can simulate losing the race to a concurrent settle
+ */
+function mockDb(orgRow: FakeRow | null, ownerEmails: string[] = ['a@b.com'], claimRowCount = 1) {
   const queries: { text: string; values: unknown[] }[] = [];
   return {
     queries,
     query: vi.fn(async (text: string, values: unknown[] = []) => {
       queries.push({ text, values });
-      // Return the next row for SELECTs; empty for UPDATEs.
-      if (/^\s*SELECT/i.test(text)) {
-        const row = selectRows.shift();
-        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+      if (/FROM organization_members/i.test(text)) {
+        return { rows: ownerEmails.map((email) => ({ email })), rowCount: ownerEmails.length };
       }
-      return { rows: [], rowCount: 0 };
+      if (/^\s*SELECT/i.test(text)) {
+        return { rows: orgRow ? [orgRow] : [], rowCount: orgRow ? 1 : 0 };
+      }
+      return { rows: [], rowCount: claimRowCount };
     }),
+  };
+}
+
+function orgRow(over: FakeRow = {}): FakeRow {
+  return {
+    auto_refill_enabled: false,
+    auto_refill_last_failure_reason: null,
+    auto_refill_threshold_usd: null,
+    credits_low_emailed_at: null,
+    credits_exhausted_emailed_at: null,
+    monthly_allowance_usd: '0.00',
+    credits_usd: '0.00',
+    ...over,
   };
 }
 
 // Production signature: sendBillingEmail(to, template, data)
 const sendBillingEmail = vi.fn(async (_to: string, _template: string, _data: Record<string, string>) => undefined);
 
+const ORG = 'org-1';
+
 describe('maybeSendCreditsEmail', () => {
   beforeEach(() => { sendBillingEmail.mockClear(); });
 
   it('skips when auto-refill is on and healthy', async () => {
-    const db = mockDb([{
-      email: 'a@b.com',
-      auto_refill_enabled: true,
-      auto_refill_last_failure_reason: null,
-      credits_low_emailed_at: null,
-      credits_exhausted_emailed_at: null,
-      monthly_allowance_usd: '0.00',
-      credits_usd: '0.00',
-    }]);
-    await maybeSendCreditsEmail({ db: db as never, userId: 'u1', postBalance: 0, sendBillingEmail });
+    const db = mockDb(orgRow({ auto_refill_enabled: true }));
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
     expect(sendBillingEmail).not.toHaveBeenCalled();
   });
 
   it('sends credits_exhausted when balance is 0 and not yet emailed', async () => {
-    const db = mockDb([{
-      email: 'a@b.com',
-      auto_refill_enabled: false,
-      auto_refill_last_failure_reason: null,
-      credits_low_emailed_at: null,
-      credits_exhausted_emailed_at: null,
-      monthly_allowance_usd: '0.00',
-      credits_usd: '0.00',
-    }]);
-    await maybeSendCreditsEmail({ db: db as never, userId: 'u1', postBalance: 0, sendBillingEmail });
+    const db = mockDb(orgRow());
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
     expect(sendBillingEmail).toHaveBeenCalledTimes(1);
-    // Second positional arg is the template name
-    const template = sendBillingEmail.mock.calls[0][1] as string;
-    expect(template).toBe('credits_exhausted');
+    expect(sendBillingEmail.mock.calls[0][1]).toBe('credits_exhausted');
   });
 
   it('does not double-send credits_exhausted', async () => {
-    const db = mockDb([{
-      email: 'a@b.com',
-      auto_refill_enabled: false,
-      auto_refill_last_failure_reason: null,
-      credits_low_emailed_at: null,
-      credits_exhausted_emailed_at: new Date().toISOString(),
-      monthly_allowance_usd: '0.00',
-      credits_usd: '0.00',
-    }]);
-    await maybeSendCreditsEmail({ db: db as never, userId: 'u1', postBalance: 0, sendBillingEmail });
+    const db = mockDb(orgRow({ credits_exhausted_emailed_at: new Date().toISOString() }));
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
     expect(sendBillingEmail).not.toHaveBeenCalled();
   });
 
   it('sends credits_low when below threshold and not yet emailed', async () => {
-    const db = mockDb([{
-      email: 'a@b.com',
-      auto_refill_enabled: false,
-      auto_refill_last_failure_reason: null,
-      credits_low_emailed_at: null,
-      credits_exhausted_emailed_at: null,
-      monthly_allowance_usd: '0.50',
-      credits_usd: '0.00',
-    }]);
-    await maybeSendCreditsEmail({ db: db as never, userId: 'u1', postBalance: 0.5, sendBillingEmail });
+    const db = mockDb(orgRow({ monthly_allowance_usd: '0.50' }));
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0.5, sendBillingEmail });
     expect(sendBillingEmail).toHaveBeenCalledTimes(1);
-    const template = sendBillingEmail.mock.calls[0][1] as string;
-    expect(template).toBe('credits_low');
+    expect(sendBillingEmail.mock.calls[0][1]).toBe('credits_low');
   });
 
   it('sends credits_low even when auto-refill is on but currently failing', async () => {
-    const db = mockDb([{
-      email: 'a@b.com',
+    const db = mockDb(orgRow({
       auto_refill_enabled: true,
       auto_refill_last_failure_reason: 'card_declined',
-      credits_low_emailed_at: null,
-      credits_exhausted_emailed_at: null,
       monthly_allowance_usd: '0.50',
-      credits_usd: '0.00',
-    }]);
-    await maybeSendCreditsEmail({ db: db as never, userId: 'u1', postBalance: 0.5, sendBillingEmail });
+    }));
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0.5, sendBillingEmail });
     expect(sendBillingEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns at the org's configured threshold, not the deployment default", async () => {
+    // $8 is far above the $1 default but below this org's $20.
+    const db = mockDb(orgRow({ auto_refill_threshold_usd: '20.00', credits_usd: '8.00' }));
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 8, sendBillingEmail });
+    expect(sendBillingEmail).toHaveBeenCalledTimes(1);
+    expect(sendBillingEmail.mock.calls[0][1]).toBe('credits_low');
+    expect((sendBillingEmail.mock.calls[0][2] as Record<string, string>).threshold_usd).toBe('20.00');
+  });
+
+  it('reads the org that was billed, not any user', async () => {
+    const db = mockDb(orgRow());
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
+    const select = db.queries[0];
+    expect(select.text).toMatch(/FROM organizations o/i);
+    expect(select.text).not.toMatch(/personal_organization_id/i);
+    expect(select.values).toEqual([ORG]);
+  });
+
+  it('emails every owner of a team org', async () => {
+    const db = mockDb(orgRow(), ['one@x.com', 'two@x.com']);
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
+    expect(sendBillingEmail).toHaveBeenCalledTimes(2);
+    expect(sendBillingEmail.mock.calls.map((c) => c[0]).sort()).toEqual(['one@x.com', 'two@x.com']);
+  });
+
+  it('sends nothing when the org has no owner with an email', async () => {
+    const db = mockDb(orgRow(), []);
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
+    expect(sendBillingEmail).not.toHaveBeenCalled();
+  });
+
+  it('stamps the dedup marker before sending', async () => {
+    const db = mockDb(orgRow());
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
+    const update = db.queries.find((q) => /^\s*UPDATE organizations/i.test(q.text));
+    expect(update).toBeDefined();
+    expect(update!.text).toMatch(/credits_exhausted_emailed_at = now\(\)/i);
+    expect(update!.text).toMatch(/credits_exhausted_emailed_at IS NULL/i);
+  });
+
+  it('sends nothing when a concurrent settle already claimed the marker', async () => {
+    const db = mockDb(orgRow(), ['a@b.com'], 0);
+    await maybeSendCreditsEmail({ db: db as never, organizationId: ORG, postBalance: 0, sendBillingEmail });
+    expect(sendBillingEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not let one failing recipient suppress the others', async () => {
+    const db = mockDb(orgRow(), ['bad@x.com', 'good@x.com']);
+    const flaky = vi.fn(async (to: string) => {
+      if (to === 'bad@x.com') throw new Error('bounce');
+    });
+    await maybeSendCreditsEmail({
+      db: db as never,
+      organizationId: ORG,
+      postBalance: 0,
+      sendBillingEmail: flaky as never,
+    });
+    expect(flaky).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('resetCreditsEmailState', () => {
-  it('nulls both timestamps', async () => {
-    const db = mockDb();
-    await resetCreditsEmailState(db as never, 'u1');
+  it('nulls both timestamps on the org', async () => {
+    const db = mockDb(null);
+    await resetCreditsEmailState(db as never, ORG);
     const text = db.queries[0].text;
+    expect(text).toMatch(/UPDATE organizations/i);
     expect(text).toMatch(/credits_low_emailed_at\s*=\s*NULL/i);
     expect(text).toMatch(/credits_exhausted_emailed_at\s*=\s*NULL/i);
+    expect(db.queries[0].values).toEqual([ORG]);
   });
 });

--- a/services/control-api/src/services/ai-router/messages.ts
+++ b/services/control-api/src/services/ai-router/messages.ts
@@ -76,7 +76,7 @@ function wrapNativeAnthropicStreamForSettlement(
       await settleAfterCall(ctx.platformPool, lease, chargedCredits);
       maybeTriggerAutoRefill({ pool: ctx.platformPool, redis: ctx.redis }, ctx.organizationId)
         .catch(err => console.warn('[messages] auto-refill failed:', err));
-      maybeFireCreditsEmail(ctx.platformPool, ctx.userId)
+      maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId)
         .catch(err => console.warn('[messages] credits-email failed:', err));
       const reasoningTokens = thinkingText.length > 0
         ? estimatePromptTokens([{ role: 'assistant', content: thinkingText }], canonicalId)
@@ -240,7 +240,7 @@ export async function routeMessages(
     await settleAfterCall(ctx.platformPool, lease, chargedCredits);
     maybeTriggerAutoRefill({ pool: ctx.platformPool, redis: ctx.redis }, ctx.organizationId)
       .catch(err => console.error('[messages] auto-refill failed:', err));
-    maybeFireCreditsEmail(ctx.platformPool, ctx.userId)
+    maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId)
       .catch(err => console.error('[messages] credits-email failed:', err));
     writeAiUsageRow(ctx.runtimePool, {
       appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: stripped,

--- a/services/control-api/src/services/ai-router/router.ts
+++ b/services/control-api/src/services/ai-router/router.ts
@@ -57,12 +57,6 @@ function pickRanker() {
 }
 
 /**
- * Non-fatal post-settle hook: reads the user's current credits balance
- * (monthly allowance + topup) and lets credits-email decide whether to
- * fire credits_low / credits_exhausted. Dedup-guarded inside
- * maybeSendCreditsEmail via columns on platform_users.
- */
-/**
  * Wraps acquireForEstimatedCost so that an InsufficientCreditsError also
  * emits a billing/denied audit event. The audit_events.app_id column is
  * NOT NULL, so we only record when the router was invoked from an app
@@ -114,21 +108,31 @@ export async function acquireWithAudit(
   }
 }
 
-export async function maybeFireCreditsEmail(pool: pg.Pool, userId: string): Promise<void> {
+/**
+ * Non-fatal post-settle hook: reads the org's current credits balance
+ * (monthly allowance + topup) and lets credits-email decide whether to
+ * fire credits_low / credits_exhausted. Dedup-guarded inside
+ * maybeSendCreditsEmail via columns on organizations (migration 113).
+ *
+ * Takes the org that was billed, not the calling user. The balance read here
+ * must be the one the settle just drew down, and under per-org billing that is
+ * `ctx.organizationId` — for a team-org request the caller's personal org has
+ * a completely unrelated balance.
+ */
+export async function maybeFireCreditsEmail(pool: pg.Pool, organizationId: string): Promise<void> {
   try {
     const r = await pool.query<{ monthly_allowance_usd: string; credits_usd: string }>(
       `SELECT o.monthly_allowance_usd::text, o.credits_usd::text
-         FROM platform_users pu
-         JOIN organizations o ON o.id = pu.personal_organization_id
-        WHERE pu.id = $1`,
-      [userId],
+         FROM organizations o
+        WHERE o.id = $1`,
+      [organizationId],
     );
     if (r.rows.length === 0) return;
     const postBalance = parseFloat(r.rows[0].monthly_allowance_usd ?? '0')
       + parseFloat(r.rows[0].credits_usd ?? '0');
     await maybeSendCreditsEmail({
       db: pool,
-      userId,
+      organizationId,
       postBalance,
       sendBillingEmail: (to, template, data) =>
         sendBillingEmail(to, template as any, data),
@@ -300,7 +304,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
         { pool: ctx.platformPool, redis: ctx.redis },
         ctx.organizationId,
       ).catch((err) => console.error('[router] auto-refill check failed:', err));
-      maybeFireCreditsEmail(ctx.platformPool, ctx.userId).catch((err) => console.error('[router] credits-email failed:', err));
+      maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId).catch((err) => console.error('[router] credits-email failed:', err));
       writeAiUsageRow(ctx.runtimePool, {
         appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: canonicalId, router: chosenRouter!,
         promptTokens: usage.promptTokens, completionTokens: usage.completionTokens,
@@ -343,7 +347,7 @@ export async function routeChatCompletion(ctx: RouteContext, req: ChatCompletion
     { pool: ctx.platformPool, redis: ctx.redis },
     ctx.organizationId,
   ).catch((err) => console.error('[router] auto-refill check failed:', err));
-  maybeFireCreditsEmail(ctx.platformPool, ctx.userId).catch((err) => console.error('[router] credits-email failed:', err));
+  maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId).catch((err) => console.error('[router] credits-email failed:', err));
   writeAiUsageRow(ctx.runtimePool, {
     appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: canonicalId, router: chosenRouter,
     promptTokens: usage.promptTokens, completionTokens: usage.completionTokens,
@@ -520,7 +524,7 @@ export async function routeEmbedding(ctx: RouteContext, req: EmbeddingRequest): 
     { pool: ctx.platformPool, redis: ctx.redis },
     ctx.organizationId,
   ).catch((err) => console.error('[router] auto-refill check failed:', err));
-  maybeFireCreditsEmail(ctx.platformPool, ctx.userId).catch((err) => console.error('[router] credits-email failed:', err));
+  maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId).catch((err) => console.error('[router] credits-email failed:', err));
   writeAiUsageRow(ctx.runtimePool, {
     appId: ctx.appId, organizationId: ctx.organizationId, userId: ctx.userId, model: canonicalId, router: chosenRouter,
     promptTokens: usage.promptTokens, completionTokens: 0,
@@ -1054,7 +1058,7 @@ export async function settleVideoJob(
     { pool: ctx.platformPool, redis: ctx.redis },
     ctx.organizationId,
   ).catch((err) => console.error('[router] auto-refill check failed:', err));
-  maybeFireCreditsEmail(ctx.platformPool, ctx.userId).catch(
+  maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId).catch(
     (err) => console.error('[router] credits-email failed:', err),
   );
   writeAiUsageRow(ctx.runtimePool, {
@@ -1239,7 +1243,7 @@ export async function settleImageJob(
     { pool: ctx.platformPool, redis: ctx.redis },
     ctx.organizationId,
   ).catch((err) => console.error('[router] auto-refill check failed:', err));
-  maybeFireCreditsEmail(ctx.platformPool, ctx.userId).catch(
+  maybeFireCreditsEmail(ctx.platformPool, ctx.organizationId).catch(
     (err) => console.error('[router] credits-email failed:', err),
   );
   writeAiUsageRow(ctx.runtimePool, {

--- a/services/control-api/src/services/auto-refill-service.test.ts
+++ b/services/control-api/src/services/auto-refill-service.test.ts
@@ -98,6 +98,74 @@ describe('maybeTriggerAutoRefill — gating', () => {
     expect(r.reason).toBe('disabled');
   });
 
+  it('uses the org threshold instead of the default when one is configured', async () => {
+    // $12 sits above the $5 default but below this org's configured $20, so
+    // the configured value is what decides.
+    const deps = makeDeps({
+      pool: { query: makePoolQuery({
+        monthly_allowance_usd: '0',
+        credits_usd: '12', auto_refill_enabled: true,
+        auto_refill_amount_usd: '20',
+        auto_refill_threshold_usd: '20.00',
+      }) },
+      stripeCharge: vi.fn(async () => ({ status: 'succeeded', paymentIntentId: 'pi_t' })),
+      grantAutoRefill: vi.fn(async () => ({ granted: 20 })),
+    });
+    const r = await maybeTriggerAutoRefill(deps as any, ORG);
+    expect(r.attempted).toBe(true);
+    expect(r.status).toBe('succeeded');
+  });
+
+  it('holds off above a configured threshold that is lower than the default', async () => {
+    // $3 would trip the $5 default, but this org asked to wait until $2.
+    const deps = makeDeps({
+      pool: { query: makePoolQuery({
+        monthly_allowance_usd: '0',
+        credits_usd: '3', auto_refill_enabled: true,
+        auto_refill_amount_usd: '20',
+        auto_refill_threshold_usd: '2.00',
+      }) },
+    });
+    const r = await maybeTriggerAutoRefill(deps as any, ORG);
+    expect(r.attempted).toBe(false);
+    expect(r.reason).toBe('not_low');
+    expect(deps.stripeCharge).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default when the threshold column is NULL', async () => {
+    const deps = makeDeps({
+      pool: { query: makePoolQuery({
+        monthly_allowance_usd: '0',
+        credits_usd: '4', auto_refill_enabled: true,
+        auto_refill_amount_usd: '20',
+        auto_refill_threshold_usd: null,
+      }) },
+      stripeCharge: vi.fn(async () => ({ status: 'succeeded', paymentIntentId: 'pi_d' })),
+      grantAutoRefill: vi.fn(async () => ({ granted: 20 })),
+    });
+    const r = await maybeTriggerAutoRefill(deps as any, ORG);
+    expect(r.attempted).toBe(true);
+    expect(r.status).toBe('succeeded');
+  });
+
+  it('still refills at a zero balance that jumped past a low threshold', async () => {
+    // The crossedZero backstop: threshold is $1, but the balance went straight
+    // to -$10 without ever being observed inside the $0-$1 band.
+    const deps = makeDeps({
+      pool: { query: makePoolQuery({
+        monthly_allowance_usd: '0',
+        credits_usd: '-10', auto_refill_enabled: true,
+        auto_refill_amount_usd: '20',
+        auto_refill_threshold_usd: '1.00',
+      }) },
+      stripeCharge: vi.fn(async () => ({ status: 'succeeded', paymentIntentId: 'pi_z' })),
+      grantAutoRefill: vi.fn(async () => ({ granted: 20 })),
+    });
+    const r = await maybeTriggerAutoRefill(deps as any, ORG);
+    expect(r.attempted).toBe(true);
+    expect(r.status).toBe('succeeded');
+  });
+
   it('no-op when Redis lock is already held', async () => {
     const deps = makeDeps({
       pool: { query: makePoolQuery({

--- a/services/control-api/src/services/auto-refill-service.ts
+++ b/services/control-api/src/services/auto-refill-service.ts
@@ -18,6 +18,18 @@ import { sendBillingEmail } from './auth/email-service.js';
 const LOCK_KEY_PREFIX = 'auto_refill:lock:';
 const LOCK_TTL_SEC = 60;
 
+/**
+ * Trigger point used when `organizations.auto_refill_threshold_usd` is NULL,
+ * i.e. the org has never configured one. This is the value the rule was
+ * hardcoded to before it became configurable, so an unconfigured org behaves
+ * exactly as it did.
+ */
+export const DEFAULT_AUTO_REFILL_THRESHOLD_USD = 5;
+
+/** Bounds enforced by the API routes; exported so they cannot drift apart. */
+export const MIN_AUTO_REFILL_THRESHOLD_USD = 1;
+export const MAX_AUTO_REFILL_THRESHOLD_USD = 100;
+
 export interface MaybeTriggerResult {
   attempted: boolean;
   status?: 'succeeded' | 'failed';
@@ -66,11 +78,13 @@ export async function maybeTriggerAutoRefill(deps: Deps, organizationId: string)
     credits_usd: string;
     auto_refill_enabled: boolean;
     auto_refill_amount_usd: string | null;
+    auto_refill_threshold_usd: string | null;
   }>(
     `SELECT o.monthly_allowance_usd::text AS monthly_allowance_usd,
             o.credits_usd,
             o.auto_refill_enabled,
-            o.auto_refill_amount_usd
+            o.auto_refill_amount_usd,
+            o.auto_refill_threshold_usd
        FROM organizations o
       WHERE o.id = $1`,
     [organizationId]
@@ -81,22 +95,36 @@ export async function maybeTriggerAutoRefill(deps: Deps, organizationId: string)
   const monthly = parseFloat(u.monthly_allowance_usd);
   const topup = parseFloat(u.credits_usd);
   const amount = u.auto_refill_amount_usd ? parseFloat(u.auto_refill_amount_usd) : 0;
+  // NULL column -> the default. Parsed defensively: a NaN here would make the
+  // `topup < threshold` comparison false for every balance and silently
+  // disable refill for that org, which is the failure mode hardest to notice.
+  const parsedThreshold = u.auto_refill_threshold_usd != null
+    ? parseFloat(u.auto_refill_threshold_usd)
+    : NaN;
+  const threshold = Number.isFinite(parsedThreshold) && parsedThreshold > 0
+    ? parsedThreshold
+    : DEFAULT_AUTO_REFILL_THRESHOLD_USD;
 
   // Two independent triggers, neither subsumes the other:
-  //   - lowLegacy: the original proactive-buffer rule. Requests still succeed
-  //     in the $0-$5 band, so this is the only path that can ever invoke
-  //     maybeTriggerAutoRefill for it (it's fire-and-forget from post-settle
-  //     hooks — if the org gets 402'd before a lease ever settles, e.g. by
-  //     falling straight to ~$0 with no floor to extend credit, refill is
-  //     never reached again). Keep firing early here or legacy-path orgs can
-  //     wedge into a permanent 402 despite auto-refill being enabled.
+  //   - lowBalance: the proactive-buffer rule, and the one the org configures.
+  //     Requests still succeed in the $0-threshold band, so this is the only
+  //     path that can ever invoke maybeTriggerAutoRefill for it (it's
+  //     fire-and-forget from post-settle hooks — if the org gets 402'd before
+  //     a lease ever settles, e.g. by falling straight to ~$0 with no floor to
+  //     extend credit, refill is never reached again). Keep firing early here
+  //     or an org can wedge into a permanent 402 despite auto-refill being on.
   //   - crossedZero: fire before the negative floor (credit_floor_usd) is
   //     consumed, so a positive monthly_allowance_usd can no longer mask a
   //     deeply negative credits_usd and block refill entirely.
-  const LOW_LEGACY_TOPUP_USD = 5;
-  const lowLegacy = monthly <= 0 && topup < LOW_LEGACY_TOPUP_USD;
+  //
+  // crossedZero is deliberately NOT configurable. It is the backstop for the
+  // case the threshold cannot catch: a single charge large enough to jump the
+  // whole band in one settle (threshold $1, balance $30, one $40 call) never
+  // observes a balance inside $0-threshold, so without this it would never
+  // refill at all.
+  const lowBalance = monthly <= 0 && topup < threshold;
   const crossedZero = monthly + topup <= 0;
-  if (!(lowLegacy || crossedZero)) return { attempted: false, reason: 'not_low' };
+  if (!(lowBalance || crossedZero)) return { attempted: false, reason: 'not_low' };
   if (!u.auto_refill_enabled || amount <= 0) return { attempted: false, reason: 'disabled' };
 
   const lockKey = LOCK_KEY_PREFIX + organizationId;

--- a/services/control-api/src/services/credit-grants-service.ts
+++ b/services/control-api/src/services/credit-grants-service.ts
@@ -1,5 +1,5 @@
 import type pg from 'pg';
-import { resetCreditsEmailState } from './credits-email.js';
+import { resetCreditsEmailState, resetCreditsEmailStateForUserPersonalOrg } from './credits-email.js';
 import { NotFoundError } from './api-errors.js';
 
 export interface SignupGrantArgs {
@@ -67,7 +67,9 @@ export async function grantSignupCredits(
     );
 
     await client.query('COMMIT');
-    await resetCreditsEmailState(pool, args.userId);
+    // Debounce markers live on the org that was credited (migration 113), and
+    // signup credit always lands on the user's personal org.
+    await resetCreditsEmailStateForUserPersonalOrg(pool, args.userId);
     return { granted: amount };
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -131,14 +133,16 @@ export async function grantAutoRefillCredits(
       await client.query('COMMIT');
       return { granted: 0 };
     }
-    const ownerId = ins.rows[0].owner_id as string;
     await client.query(
       `UPDATE organizations SET credits_usd = credits_usd + $1 WHERE id = $2`,
       [args.amountUsd, args.organizationId]
     );
     await client.query('COMMIT');
-    // Reset the credits-email debounce for the org owner (who was charged).
-    await resetCreditsEmailState(pool, ownerId);
+    // Reset the credits-email debounce on the org that was credited, so the
+    // next time this org runs low its owners get warned again. Previously this
+    // reset the OWNER's personal-org marker, which for a team org cleared a
+    // marker belonging to a different balance entirely.
+    await resetCreditsEmailState(pool, args.organizationId);
     return { granted: args.amountUsd };
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});

--- a/services/control-api/src/services/credits-email.ts
+++ b/services/control-api/src/services/credits-email.ts
@@ -1,11 +1,16 @@
 import type { Pool } from 'pg';
 
-const LOW_THRESHOLD = parseFloat(process.env.CREDITS_LOW_THRESHOLD_USD ?? '1.00');
+/**
+ * Fallback trigger point for the low-balance warning, used when the org has
+ * not configured `auto_refill_threshold_usd`. Kept as an env var because it
+ * predates the per-org column and some deployments set it.
+ */
+const DEFAULT_LOW_THRESHOLD = parseFloat(process.env.CREDITS_LOW_THRESHOLD_USD ?? '1.00');
 
-interface UserState {
-  email: string;
+interface OrgState {
   auto_refill_enabled: boolean;
   auto_refill_last_failure_reason: string | null;
+  auto_refill_threshold_usd: string | null;
   credits_low_emailed_at: Date | string | null;
   credits_exhausted_emailed_at: Date | string | null;
   monthly_allowance_usd: string;
@@ -14,7 +19,13 @@ interface UserState {
 
 export interface MaybeSendArgs {
   db: Pool;
-  userId: string;
+  /**
+   * The org whose balance was drawn — NOT the caller's personal org. Under
+   * per-org billing these differ for every team-org request, and keying this
+   * to the user was why team orgs were never warned: the query read the
+   * caller's personal balance, which the request had not touched.
+   */
+  organizationId: string;
   postBalance: number;
   /**
    * Injected for testability. Production callers pass the real
@@ -27,66 +38,127 @@ export interface MaybeSendArgs {
 }
 
 export async function maybeSendCreditsEmail(args: MaybeSendArgs): Promise<void> {
-  const { db, userId, postBalance, sendBillingEmail } = args;
+  const { db, organizationId, postBalance, sendBillingEmail } = args;
   const dashboardUrl = args.dashboardUrl ?? process.env.DASHBOARD_URL ?? '';
 
-  // auto_refill_* / credits_usd / monthly_allowance_usd moved to `organizations`
-  // in the per-org billing split (migration 093). Join through the user's
-  // personal_organization_id — same pattern router.ts uses when computing
-  // postBalance. credits_*_emailed_at (dedup markers) stayed on platform_users.
-  const result = await db.query<UserState>(
-    `SELECT pu.email,
-            o.auto_refill_enabled,
+  // Balance, auto-refill config and the dedup markers all live on
+  // `organizations` as of migration 113 — one row, no join through
+  // platform_users. Recipients are resolved separately, below.
+  const result = await db.query<OrgState>(
+    `SELECT o.auto_refill_enabled,
             o.auto_refill_last_failure_reason,
-            pu.credits_low_emailed_at,
-            pu.credits_exhausted_emailed_at,
+            o.auto_refill_threshold_usd::text AS auto_refill_threshold_usd,
+            o.credits_low_emailed_at,
+            o.credits_exhausted_emailed_at,
             o.monthly_allowance_usd::text AS monthly_allowance_usd,
             o.credits_usd::text            AS credits_usd
-       FROM platform_users pu
-       JOIN organizations o ON o.id = pu.personal_organization_id
-      WHERE pu.id = $1`,
-    [userId],
+       FROM organizations o
+      WHERE o.id = $1`,
+    [organizationId],
   );
 
   if (result.rows.length === 0) return;
-  const u = result.rows[0];
+  const o = result.rows[0];
 
-  // Skip if auto-refill is on and not currently failing.
-  if (u.auto_refill_enabled && u.auto_refill_last_failure_reason == null) return;
+  // Skip if auto-refill is on and not currently failing — a working auto-refill
+  // means the balance is about to be topped up, so there is nothing to warn
+  // about. A failing one is exactly when the warning matters most.
+  if (o.auto_refill_enabled && o.auto_refill_last_failure_reason == null) return;
+
+  // Warn at the org's own trigger point when it has set one, so "tell me when
+  // I drop below $X" holds whether or not the card charge succeeds. Orgs that
+  // never configured a threshold keep the deployment-wide default.
+  const parsedThreshold = o.auto_refill_threshold_usd != null
+    ? parseFloat(o.auto_refill_threshold_usd)
+    : NaN;
+  const threshold = Number.isFinite(parsedThreshold) && parsedThreshold > 0
+    ? parsedThreshold
+    : DEFAULT_LOW_THRESHOLD;
+
+  const wantsExhausted = postBalance === 0 && o.credits_exhausted_emailed_at == null;
+  const wantsLow = postBalance > 0 && postBalance < threshold && o.credits_low_emailed_at == null;
+  if (!wantsExhausted && !wantsLow) return;
+
+  const recipients = await orgOwnerEmails(db, organizationId);
+  if (recipients.length === 0) return;
 
   const data: Record<string, string> = {
     total_usd: postBalance.toFixed(2),
-    monthly_allowance_usd: parseFloat(u.monthly_allowance_usd ?? '0').toFixed(2),
-    topup_usd: parseFloat(u.credits_usd ?? '0').toFixed(2),
+    monthly_allowance_usd: parseFloat(o.monthly_allowance_usd ?? '0').toFixed(2),
+    topup_usd: parseFloat(o.credits_usd ?? '0').toFixed(2),
+    threshold_usd: threshold.toFixed(2),
     reset_date: args.resetDate ?? '',
     dashboard_url: dashboardUrl,
   };
 
-  if (postBalance === 0 && u.credits_exhausted_emailed_at == null) {
-    await sendBillingEmail(u.email, 'credits_exhausted', data);
-    await db.query(
-      `UPDATE platform_users SET credits_exhausted_emailed_at = now() WHERE id = $1`,
-      [userId],
-    );
-    return;
-  }
+  const template = wantsExhausted ? 'credits_exhausted' : 'credits_low';
+  const marker = wantsExhausted ? 'credits_exhausted_emailed_at' : 'credits_low_emailed_at';
 
-  if (postBalance > 0 && postBalance < LOW_THRESHOLD && u.credits_low_emailed_at == null) {
-    await sendBillingEmail(u.email, 'credits_low', data);
-    await db.query(
-      `UPDATE platform_users SET credits_low_emailed_at = now() WHERE id = $1`,
-      [userId],
-    );
-  }
+  // Stamp the marker BEFORE sending. A duplicate warning to every owner of an
+  // org is worse than a missed one, and settles are concurrent: two calls
+  // finishing together would both read a NULL marker and both send. Stamping
+  // first means the loser of that race sees the mark and drops out.
+  const claimed = await db.query(
+    `UPDATE organizations SET ${marker} = now()
+      WHERE id = $1 AND ${marker} IS NULL`,
+    [organizationId],
+  );
+  if (claimed.rowCount === 0) return;
+
+  // Send to every owner, the same recipient set auto-refill failures use.
+  // Failures are per-recipient: one bad address must not suppress the rest,
+  // and the marker stays stamped either way — a warning email is not worth
+  // re-attempting on the next settle.
+  await Promise.all(
+    recipients.map((to) =>
+      Promise.resolve()
+        .then(() => sendBillingEmail(to, template, data))
+        .catch((err) => console.error(`[credits-email] ${template} to ${to} failed:`, err)),
+    ),
+  );
 }
 
-export async function resetCreditsEmailState(db: Pool, userId: string): Promise<void> {
+/**
+ * Every owner of the org. For a personal org that is the single account
+ * holder; for a team org it is each member with role='owner'.
+ */
+async function orgOwnerEmails(db: Pool, organizationId: string): Promise<string[]> {
+  const { rows } = await db.query<{ email: string }>(
+    `SELECT DISTINCT pu.email
+       FROM organization_members om
+       JOIN platform_users pu ON pu.id = om.user_id
+      WHERE om.organization_id = $1 AND om.role = 'owner' AND pu.email IS NOT NULL`,
+    [organizationId],
+  );
+  return rows.map((r) => r.email);
+}
+
+/**
+ * Convenience wrapper for callers that only hold a user id and are crediting
+ * that user's personal org (signup grants). Team-org callers must pass the org
+ * id to `resetCreditsEmailState` directly — there is no user-to-org shortcut
+ * that is correct for them.
+ */
+export async function resetCreditsEmailStateForUserPersonalOrg(db: Pool, userId: string): Promise<void> {
   await db.query(
-    `UPDATE platform_users
+    `UPDATE organizations o
+        SET credits_low_emailed_at = NULL,
+            credits_exhausted_emailed_at = NULL
+       FROM platform_users pu
+      WHERE pu.id = $1
+        AND o.id = pu.personal_organization_id
+        AND (o.credits_low_emailed_at IS NOT NULL OR o.credits_exhausted_emailed_at IS NOT NULL)`,
+    [userId],
+  );
+}
+
+export async function resetCreditsEmailState(db: Pool, organizationId: string): Promise<void> {
+  await db.query(
+    `UPDATE organizations
        SET credits_low_emailed_at = NULL,
            credits_exhausted_emailed_at = NULL
      WHERE id = $1
        AND (credits_low_emailed_at IS NOT NULL OR credits_exhausted_emailed_at IS NOT NULL)`,
-    [userId],
+    [organizationId],
   );
 }

--- a/services/control-api/src/services/monthly-resets-service.ts
+++ b/services/control-api/src/services/monthly-resets-service.ts
@@ -85,14 +85,15 @@ export async function resetMonthlyAllowanceWithClient(
 
   // Balance was just bumped — clear the credits-email dedup state so the next
   // time the balance drops we re-warn. Inline (not via resetCreditsEmailState)
-  // to stay inside the caller-owned transaction.
+  // to stay inside the caller-owned transaction. Keyed to the org whose
+  // allowance was just reset, matching where the markers live (migration 113).
   await client.query(
-    `UPDATE platform_users
+    `UPDATE organizations
         SET credits_low_emailed_at = NULL,
             credits_exhausted_emailed_at = NULL
       WHERE id = $1
         AND (credits_low_emailed_at IS NOT NULL OR credits_exhausted_emailed_at IS NOT NULL)`,
-    [args.userId]
+    [organizationId]
   );
 
   return { newAmount: grantAmount, previousUnspent };


### PR DESCRIPTION
## What

Two related changes to the credit-billing path.

**1. The auto-refill trigger point is now configurable.** It fired at a hardcoded `LOW_LEGACY_TOPUP_USD = 5` that was never surfaced in any UI, so "when does this actually charge me?" had no answer short of reading the source. That constant becomes `organizations.auto_refill_threshold_usd`.

`NULL` means "use the built-in default of 5" — deliberately, so every existing org keeps today's exact behaviour on deploy, and an admin can still tell "never configured" apart from "deliberately set to 5".

The `crossedZero` trigger (`monthly + topup <= 0`) stays **unconditional**. It is the backstop for the case a threshold can never catch: a single charge large enough to jump the whole band in one settle (threshold $1, balance $30, one $40 call) never observes a balance inside the band, so without it that org would never refill at all.

**2. The low-credit email was reading the wrong org.** `maybeFireCreditsEmail` was keyed on `userId` and joined through `platform_users.personal_organization_id`. Under per-org billing that is the wrong balance for every team-org request — the org burning credits was not the org being checked. Team orgs were effectively **never warned**, and a user in three orgs shared one debounce marker across all of them.

All seven post-settle call sites now pass `ctx.organizationId`; the mail goes to every `role='owner'` member (the same recipient set auto-refill failures already use); and the dedup markers move onto `organizations` to sit beside the balance they debounce.

## Notable details

- **Two fixes the type checker could not catch.** Org ids and user ids are both `string`, so passing one where the other is expected compiles cleanly and silently does nothing. The Stripe top-up path and the signup-grant path were both handing a *user id* to `resetCreditsEmailState`; both now use an explicit personal-org helper.
- **The dedup marker is stamped before sending**, via `UPDATE ... WHERE marker IS NULL`. Settles are concurrent — two finishing together would otherwise both read a NULL marker and both mail every owner.
- **`parseFloat(NULL)` guard.** The new column is NULL for every existing org, and `x < NaN` is `false` for all x — a silently-passing guard. Reads go through `Number.isFinite(...) && > 0` and fall back to the default.

## Migration

`115_auto_refill_threshold_and_org_credit_email_state.sql` — **pre-deploy safe**. Three nullable columns, no default, no drop, no rename, no `NOT NULL`; the backfill writes only to columns the current image never reads, and `platform_users.credits_low_emailed_at` is deliberately left in place for a later sweep. The current prod image survives the post-migration shape.

Numbered 115 because `113`/`114` were taken in the internal stream — both streams share one `_migrations` table keyed on filename.

## Testing

31 unit tests pass (13 rewritten credits-email, 18 auto-refill incl. 4 new threshold cases).

Smoke-tested live over HTTP against a local stack, driving real AI calls through the gateway to fire the actual post-settle hooks:

- Same org, same $4.98 balance — threshold $1 does **not** fire; threshold $100 **does** (charge attempted, `no_stripe_customer`, auto-refill flipped off, failure email sent). Isolates the threshold as the cause.
- Team org at $3.00 vs personal org at $50.00, called with a team-scoped key: team org's marker stamped and the email body reads `Available: $3.00`; personal org untouched. Under the old code this path found the healthy $50 and sent nothing.
- Dedup verified: a second settle with the marker set sends zero mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134wxnuD1ENPnHg81tTg9tc