### PR TITLE
fix(staging): compare the reset guard against the real database name

### DIFF
--- a/services/control-api/src/services/staging-reset.test.ts
+++ b/services/control-api/src/services/staging-reset.test.ts
@@ -89,7 +89,13 @@ const job = {
   id: 'job_r1', mode: 'staging_reset', source_app_id: 'app_prod', dest_app_id: 'app_staging',
 } as never;
 
-const STAGING_DB_NAME = 'db_staging';
+// The two names are DIFFERENT on purpose, and that difference is the whole
+// point. `apps.db_name` stores the unprefixed, app-id-shaped name; the physical
+// Neon database carries a `db_` prefix. A fixture that used one value for both
+// made Guard 3 compare a string to itself, so it passed in every test while
+// refusing every real reset in production.
+const STAGING_DB_NAME = 'app_staging';
+const STAGING_PHYSICAL_DB = 'db_app_staging';
 
 /**
  * Point the truncate's table set at `names`.
@@ -130,7 +136,7 @@ function setReconcile(destroyed: string[] = []): void {
  */
 function defaultStagingQueryResponse(sql: unknown) {
   if (typeof sql === 'string' && /current_database/.test(sql)) {
-    return { rows: [{ current_database: STAGING_DB_NAME }] };
+    return { rows: [{ current_database: STAGING_PHYSICAL_DB }] };
   }
   return { rows: [] };
 }
@@ -894,6 +900,45 @@ describe('executeStagingReset — schema reconcile', () => {
       return { rows: [] };
     });
     await expect(guard!()).rejects.toThrow(/refusing to alter schema.*db_someone_elses_app/s);
+  });
+
+  it('compares against the PREFIXED database name, not the raw apps.db_name', async () => {
+    // Regression: Guard 3 used to compare current_database() straight against
+    // apps.db_name. apps.db_name is unprefixed ('app_XXX'); the physical Neon
+    // database is 'db_app_XXX'. The two never matched, so the guard refused
+    // every reset in production while the test suite stayed green — the old
+    // fixture fed the same string to both sides.
+    //
+    // Both directions are pinned here. Accepting the raw apps.db_name would be
+    // just as wrong as rejecting the prefixed one: it would mean the guard had
+    // been loosened to match whatever it was handed.
+    let guard: (() => Promise<void>) | null = null;
+    mocks.reconcileStagingSchema.mockImplementation(async (args: never) => {
+      guard = (args as unknown as { assertStagingTarget: () => Promise<void> })
+        .assertStagingTarget;
+      return { applied: [], destroyed: [] };
+    });
+    await executeStagingReset(deps as never, job);
+
+    // The physical name is what a real connection reports — accepted.
+    stagingPool.query.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && /current_database/.test(sql)) {
+        return { rows: [{ current_database: STAGING_PHYSICAL_DB }] };
+      }
+      return { rows: [] };
+    });
+    await expect(guard!()).resolves.toBeUndefined();
+
+    // The unprefixed apps.db_name is NOT a database any connection reports.
+    stagingPool.query.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && /current_database/.test(sql)) {
+        return { rows: [{ current_database: STAGING_DB_NAME }] };
+      }
+      return { rows: [] };
+    });
+    await expect(guard!()).rejects.toThrow(
+      new RegExp(`expected "${STAGING_PHYSICAL_DB}"`),
+    );
   });
 
   it('never re-seeds, and fails the job, when the schema replay itself fails', async () => {

--- a/services/control-api/src/services/staging-reset.ts
+++ b/services/control-api/src/services/staging-reset.ts
@@ -14,6 +14,17 @@ import { getActivePromoteJob } from './promote-jobs.js';
 import { EXCLUDED_TABLES, introspectSchema } from './schema-introspector.js';
 
 /**
+ * Prefix Neon app databases are provisioned with. `apps.db_name` stores the
+ * name WITHOUT it (`app_XXX`), while the physical database is `db_app_XXX` —
+ * see `app-db-provision.ts` / `provisioner.ts`, which both build the database
+ * name as `db_${appId}`, and `neon-orphan-reconciler.ts`, which maps back by
+ * stripping this exact prefix. Anything comparing `apps.db_name` to
+ * `current_database()` must bridge the two.
+ */
+const APP_DB_NAME_PREFIX = 'db_';
+
+
+/**
  * The in-flight reset for this STAGING app, if any.
  *
  * Predicate must match idx_template_clone_jobs_one_reset (migration 120)
@@ -60,7 +71,9 @@ export interface ResetDeps {
   /** Per-app database of the STAGING app — the destination of the re-seed. */
   stagingPool: pg.Pool;
   /**
-   * The staging app's `apps.db_name`. Checked against `SELECT
+   * The staging app's `apps.db_name`, UNPREFIXED ('app_XXX'). Guard 3 prefixes
+   * it with `db_` before comparing, because that is what the physical Neon
+   * database is called. Checked against `SELECT
    * current_database()` on `stagingPool` immediately before the TRUNCATE —
    * see truncateStagingAppTables's Guard 3. Every other guard compares
    * values chosen upstream of the pool-resolution call (ids, object
@@ -313,10 +326,19 @@ async function assertStagingTarget(args: {
     'SELECT current_database()',
   );
   const connectedDb = dbCheck.rows[0]?.current_database;
-  if (connectedDb !== stagingDbName) {
+  // `apps.db_name` holds the UNPREFIXED, app-id-shaped name ('app_XXX'); the
+  // Neon database is provisioned as `db_${appId}` (app-db-provision.ts,
+  // provisioner.ts), and neon-orphan-reconciler maps back by stripping exactly
+  // this prefix. So current_database() returns the PREFIXED name and comparing
+  // it against a raw apps.db_name can never match — which made this guard
+  // refuse every reset that ever ran, rather than only the swapped-pool case it
+  // exists to catch. Verified against production: all 809 apps across both
+  // regions store db_name = id, none pre-prefixed.
+  const expectedDb = `${APP_DB_NAME_PREFIX}${stagingDbName}`;
+  if (connectedDb !== expectedDb) {
     throw new Error(
       `[staging-reset] refusing to ${action}: staging pool for app ${stagingAppId} is connected `
-        + `to database "${connectedDb}", expected "${stagingDbName}"`,
+        + `to database "${connectedDb}", expected "${expectedDb}"`,
     );
   }
 }


### PR DESCRIPTION
@-